### PR TITLE
Fix Unrecognized Hadoop major version number exception

### DIFF
--- a/shims/common/src/main/java/org/apache/hadoop/hive/shims/ShimLoader.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/shims/ShimLoader.java
@@ -169,6 +169,7 @@ public abstract class ShimLoader {
     case 1:
       return HADOOP20SVERSIONNAME;
     case 2:
+    case 3:
       return HADOOP23VERSIONNAME;
     default:
       throw new IllegalArgumentException("Unrecognized Hadoop major version number: " + vers);


### PR DESCRIPTION
This PR aims for fixing Hadoop3 issue when running with Spark. The related JIRA is [SPARK-18673](https://issues.apache.org/jira/browse/SPARK-18673). In the PR it mentions that [HIVE-15016](https://issues.apache.org/jira/browse/HIVE-15016) and [HIVE-18550](https://issues.apache.org/jira/browse/HIVE-18550) is enough to support Hadoop3. Actually most of the changes in this two JIRA is related to HBase, which is not required for us, a necessary fix is only just one line. 

So here propose to fix Hadoop 3 compatible issue for 1.2.1-spark2 branch, if we still plan to use this branch as a built-in hive support for Spark.

If we plan to upgrade built-in hive support to latest Hive, then this fix is not necessary.

