### PR TITLE
add threadpool, optimize hive copy or rename tmp path file to dest path

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,11 @@ import java.net.URISyntaxException;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
 import java.util.BitSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.*;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -51,712 +54,742 @@ import org.apache.hadoop.util.Shell;
  * Collection of file manipulation utilities common across Hive.
  */
 public final class FileUtils {
-  private static final Log LOG = LogFactory.getLog(FileUtils.class.getName());
+    private static final Log LOG = LogFactory.getLog(FileUtils.class.getName());
 
-  public static final PathFilter HIDDEN_FILES_PATH_FILTER = new PathFilter() {
-    public boolean accept(Path p) {
-      String name = p.getName();
-      return !name.startsWith("_") && !name.startsWith(".");
-    }
-  };
-
-  public static final PathFilter STAGING_DIR_PATH_FILTER = new PathFilter() {
-    public boolean accept(Path p) {
-      String name = p.getName();
-      return !name.startsWith(".");
-    }
-  };
-
-  /**
-   * Variant of Path.makeQualified that qualifies the input path against the default file system
-   * indicated by the configuration
-   *
-   * This does not require a FileSystem handle in most cases - only requires the Filesystem URI.
-   * This saves the cost of opening the Filesystem - which can involve RPCs - as well as cause
-   * errors
-   *
-   * @param path
-   *          path to be fully qualified
-   * @param conf
-   *          Configuration file
-   * @return path qualified relative to default file system
-   */
-  public static Path makeQualified(Path path, Configuration conf) throws IOException {
-
-    if (!path.isAbsolute()) {
-      // in this case we need to get the working directory
-      // and this requires a FileSystem handle. So revert to
-      // original method.
-      return path.makeQualified(FileSystem.get(conf));
-    }
-
-    URI fsUri = FileSystem.getDefaultUri(conf);
-    URI pathUri = path.toUri();
-
-    String scheme = pathUri.getScheme();
-    String authority = pathUri.getAuthority();
-
-    // validate/fill-in scheme and authority. this follows logic
-    // identical to FileSystem.get(URI, conf) - but doesn't actually
-    // obtain a file system handle
-
-    if (scheme == null) {
-      // no scheme - use default file system uri
-      scheme = fsUri.getScheme();
-      authority = fsUri.getAuthority();
-      if (authority == null) {
-        authority = "";
-      }
-    } else {
-      if (authority == null) {
-        // no authority - use default one if it applies
-        if (scheme.equals(fsUri.getScheme()) && fsUri.getAuthority() != null) {
-          authority = fsUri.getAuthority();
-        } else {
-          authority = "";
+    public static final PathFilter HIDDEN_FILES_PATH_FILTER = new PathFilter() {
+        public boolean accept(Path p) {
+            String name = p.getName();
+            return !name.startsWith("_") && !name.startsWith(".");
         }
-      }
+    };
+
+    public static final PathFilter STAGING_DIR_PATH_FILTER = new PathFilter() {
+        public boolean accept(Path p) {
+            String name = p.getName();
+            return !name.startsWith(".");
+        }
+    };
+
+    /**
+     * Variant of Path.makeQualified that qualifies the input path against the default file system
+     * indicated by the configuration
+     * <p>
+     * This does not require a FileSystem handle in most cases - only requires the Filesystem URI.
+     * This saves the cost of opening the Filesystem - which can involve RPCs - as well as cause
+     * errors
+     *
+     * @param path path to be fully qualified
+     * @param conf Configuration file
+     * @return path qualified relative to default file system
+     */
+    public static Path makeQualified(Path path, Configuration conf) throws IOException {
+
+        if (!path.isAbsolute()) {
+            // in this case we need to get the working directory
+            // and this requires a FileSystem handle. So revert to
+            // original method.
+            return path.makeQualified(FileSystem.get(conf));
+        }
+
+        URI fsUri = FileSystem.getDefaultUri(conf);
+        URI pathUri = path.toUri();
+
+        String scheme = pathUri.getScheme();
+        String authority = pathUri.getAuthority();
+
+        // validate/fill-in scheme and authority. this follows logic
+        // identical to FileSystem.get(URI, conf) - but doesn't actually
+        // obtain a file system handle
+
+        if (scheme == null) {
+            // no scheme - use default file system uri
+            scheme = fsUri.getScheme();
+            authority = fsUri.getAuthority();
+            if (authority == null) {
+                authority = "";
+            }
+        } else {
+            if (authority == null) {
+                // no authority - use default one if it applies
+                if (scheme.equals(fsUri.getScheme()) && fsUri.getAuthority() != null) {
+                    authority = fsUri.getAuthority();
+                } else {
+                    authority = "";
+                }
+            }
+        }
+
+        return new Path(scheme, authority, pathUri.getPath());
     }
 
-    return new Path(scheme, authority, pathUri.getPath());
-  }
-
-  private FileUtils() {
-    // prevent instantiation
-  }
-
-
-  public static String makePartName(List<String> partCols, List<String> vals) {
-    return makePartName(partCols, vals, null);
-  }
-
-  /**
-   * Makes a valid partition name.
-   * @param partCols The partition keys' names
-   * @param vals The partition values
-   * @param defaultStr
-   *         The default name given to a partition value if the respective value is empty or null.
-   * @return An escaped, valid partition name.
-   */
-  public static String makePartName(List<String> partCols, List<String> vals,
-      String defaultStr) {
-    StringBuilder name = new StringBuilder();
-    for (int i = 0; i < partCols.size(); i++) {
-      if (i > 0) {
-        name.append(Path.SEPARATOR);
-      }
-      name.append(escapePathName((partCols.get(i)).toLowerCase(), defaultStr));
-      name.append('=');
-      name.append(escapePathName(vals.get(i), defaultStr));
+    private FileUtils() {
+        // prevent instantiation
     }
-    return name.toString();
-  }
 
-  /**
-   * default directory will have the same depth as number of skewed columns
-   * this will make future operation easy like DML merge, concatenate merge
-   * @param skewedCols
-   * @param name
-   * @return
-   */
-  public static String makeDefaultListBucketingDirName(List<String> skewedCols,
-      String name) {
-    String lbDirName;
-    String defaultDir = FileUtils.escapePathName(name);
-    StringBuilder defaultDirPath = new StringBuilder();
-    for (int i = 0; i < skewedCols.size(); i++) {
-      if (i > 0) {
-        defaultDirPath.append(Path.SEPARATOR);
-      }
-      defaultDirPath.append(defaultDir);
-    }
-    lbDirName = defaultDirPath.toString();
-    return lbDirName;
-  }
 
-  /**
-   * Makes a valid list bucketing directory name.
-   * @param lbCols The skewed keys' names
-   * @param vals The skewed values
-   * @return An escaped, valid list bucketing directory name.
-   */
-  public static String makeListBucketingDirName(List<String> lbCols, List<String> vals) {
-    StringBuilder name = new StringBuilder();
-    for (int i = 0; i < lbCols.size(); i++) {
-      if (i > 0) {
-        name.append(Path.SEPARATOR);
-      }
-      name.append(escapePathName((lbCols.get(i)).toLowerCase()));
-      name.append('=');
-      name.append(escapePathName(vals.get(i)));
-    }
-    return name.toString();
-  }
-
-  // NOTE: This is for generating the internal path name for partitions. Users
-  // should always use the MetaStore API to get the path name for a partition.
-  // Users should not directly take partition values and turn it into a path
-  // name by themselves, because the logic below may change in the future.
-  //
-  // In the future, it's OK to add new chars to the escape list, and old data
-  // won't be corrupt, because the full path name in metastore is stored.
-  // In that case, Hive will continue to read the old data, but when it creates
-  // new partitions, it will use new names.
-  // edit : There are some use cases for which adding new chars does not seem
-  // to be backward compatible - Eg. if partition was created with name having
-  // a special char that you want to start escaping, and then you try dropping
-  // the partition with a hive version that now escapes the special char using
-  // the list below, then the drop partition fails to work.
-
-  static BitSet charToEscape = new BitSet(128);
-  static {
-    for (char c = 0; c < ' '; c++) {
-      charToEscape.set(c);
+    public static String makePartName(List<String> partCols, List<String> vals) {
+        return makePartName(partCols, vals, null);
     }
 
     /**
-     * ASCII 01-1F are HTTP control characters that need to be escaped.
-     * \u000A and \u000D are \n and \r, respectively.
+     * Makes a valid partition name.
+     *
+     * @param partCols   The partition keys' names
+     * @param vals       The partition values
+     * @param defaultStr The default name given to a partition value if the respective value is empty or null.
+     * @return An escaped, valid partition name.
      */
-    char[] clist = new char[] {'\u0001', '\u0002', '\u0003', '\u0004',
-        '\u0005', '\u0006', '\u0007', '\u0008', '\u0009', '\n', '\u000B',
-        '\u000C', '\r', '\u000E', '\u000F', '\u0010', '\u0011', '\u0012',
-        '\u0013', '\u0014', '\u0015', '\u0016', '\u0017', '\u0018', '\u0019',
-        '\u001A', '\u001B', '\u001C', '\u001D', '\u001E', '\u001F',
-        '"', '#', '%', '\'', '*', '/', ':', '=', '?', '\\', '\u007F', '{',
-        '[', ']', '^'};
-
-    for (char c : clist) {
-      charToEscape.set(c);
-    }
-
-    if(Shell.WINDOWS){
-      //On windows, following chars need to be escaped as well
-      char [] winClist = {' ', '<','>','|'};
-      for (char c : winClist) {
-        charToEscape.set(c);
-      }
-    }
-
-  }
-
-  static boolean needsEscaping(char c) {
-    return c >= 0 && c < charToEscape.size() && charToEscape.get(c);
-  }
-
-  public static String escapePathName(String path) {
-    return escapePathName(path, null);
-  }
-
-  /**
-   * Escapes a path name.
-   * @param path The path to escape.
-   * @param defaultPath
-   *          The default name for the path, if the given path is empty or null.
-   * @return An escaped path name.
-   */
-  public static String escapePathName(String path, String defaultPath) {
-
-    // __HIVE_DEFAULT_NULL__ is the system default value for null and empty string.
-    // TODO: we should allow user to specify default partition or HDFS file location.
-    if (path == null || path.length() == 0) {
-      if (defaultPath == null) {
-        //previously, when path is empty or null and no default path is specified,
-        // __HIVE_DEFAULT_PARTITION__ was the return value for escapePathName
-        return "__HIVE_DEFAULT_PARTITION__";
-      } else {
-        return defaultPath;
-      }
-    }
-
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < path.length(); i++) {
-      char c = path.charAt(i);
-      if (needsEscaping(c)) {
-        sb.append('%');
-        sb.append(String.format("%1$02X", (int) c));
-      } else {
-        sb.append(c);
-      }
-    }
-    return sb.toString();
-  }
-
-  public static String unescapePathName(String path) {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < path.length(); i++) {
-      char c = path.charAt(i);
-      if (c == '%' && i + 2 < path.length()) {
-        int code = -1;
-        try {
-          code = Integer.valueOf(path.substring(i + 1, i + 3), 16);
-        } catch (Exception e) {
-          code = -1;
+    public static String makePartName(List<String> partCols, List<String> vals,
+                                      String defaultStr) {
+        StringBuilder name = new StringBuilder();
+        for (int i = 0; i < partCols.size(); i++) {
+            if (i > 0) {
+                name.append(Path.SEPARATOR);
+            }
+            name.append(escapePathName((partCols.get(i)).toLowerCase(), defaultStr));
+            name.append('=');
+            name.append(escapePathName(vals.get(i), defaultStr));
         }
-        if (code >= 0) {
-          sb.append((char) code);
-          i += 2;
-          continue;
+        return name.toString();
+    }
+
+    /**
+     * default directory will have the same depth as number of skewed columns
+     * this will make future operation easy like DML merge, concatenate merge
+     *
+     * @param skewedCols
+     * @param name
+     * @return
+     */
+    public static String makeDefaultListBucketingDirName(List<String> skewedCols,
+                                                         String name) {
+        String lbDirName;
+        String defaultDir = FileUtils.escapePathName(name);
+        StringBuilder defaultDirPath = new StringBuilder();
+        for (int i = 0; i < skewedCols.size(); i++) {
+            if (i > 0) {
+                defaultDirPath.append(Path.SEPARATOR);
+            }
+            defaultDirPath.append(defaultDir);
         }
-      }
-      sb.append(c);
-    }
-    return sb.toString();
-  }
-
-  /**
-   * Recursively lists status for all files starting from a particular directory (or individual file
-   * as base case).
-   *
-   * @param fs
-   *          file system
-   *
-   * @param fileStatus
-   *          starting point in file system
-   *
-   * @param results
-   *          receives enumeration of all files found
-   */
-  public static void listStatusRecursively(FileSystem fs, FileStatus fileStatus,
-      List<FileStatus> results) throws IOException {
-
-    if (fileStatus.isDir()) {
-      for (FileStatus stat : fs.listStatus(fileStatus.getPath(), HIDDEN_FILES_PATH_FILTER)) {
-        listStatusRecursively(fs, stat, results);
-      }
-    } else {
-      results.add(fileStatus);
-    }
-  }
-
-  /**
-   * Find the parent of path that exists, if path does not exist
-   *
-   * @param fs
-   *          file system
-   * @param path
-   * @return FileStatus for argument path if it exists or the first ancestor in the path that exists
-   * @throws IOException
-   */
-  public static FileStatus getPathOrParentThatExists(FileSystem fs, Path path) throws IOException {
-    FileStatus stat = FileUtils.getFileStatusOrNull(fs, path);
-    if (stat != null) {
-      return stat;
-    }
-    Path parentPath = path.getParent();
-    return getPathOrParentThatExists(fs, parentPath);
-  }
-
-  /**
-   * Perform a check to determine if the user is able to access the file passed in.
-   * If the user name passed in is different from the current user, this method will
-   * attempt to do impersonate the user to do the check; the current user should be
-   * able to create proxy users in this case.
-   * @param fs   FileSystem of the path to check
-   * @param stat FileStatus representing the file
-   * @param action FsAction that will be checked
-   * @param user User name of the user that will be checked for access.  If the user name
-   *             is null or the same as the current user, no user impersonation will be done
-   *             and the check will be done as the current user. Otherwise the file access
-   *             check will be performed within a doAs() block to use the access privileges
-   *             of this user. In this case the user must be configured to impersonate other
-   *             users, otherwise this check will fail with error.
-   * @throws IOException
-   * @throws AccessControlException
-   * @throws InterruptedException
-   * @throws Exception
-   */
-  public static void checkFileAccessWithImpersonation(final FileSystem fs,
-      final FileStatus stat, final FsAction action, final String user)
-          throws IOException, AccessControlException, InterruptedException, Exception {
-    UserGroupInformation ugi = Utils.getUGI();
-    String currentUser = ugi.getShortUserName();
-
-    if (user == null || currentUser.equals(user)) {
-      // No need to impersonate user, do the checks as the currently configured user.
-      ShimLoader.getHadoopShims().checkFileAccess(fs, stat, action);
-      return;
+        lbDirName = defaultDirPath.toString();
+        return lbDirName;
     }
 
-    // Otherwise, try user impersonation. Current user must be configured to do user impersonation.
-    UserGroupInformation proxyUser = UserGroupInformation.createProxyUser(
-        user, UserGroupInformation.getLoginUser());
-    proxyUser.doAs(new PrivilegedExceptionAction<Object>() {
-      @Override
-      public Object run() throws Exception {
-        FileSystem fsAsUser = FileSystem.get(fs.getUri(), fs.getConf());
-        ShimLoader.getHadoopShims().checkFileAccess(fsAsUser, stat, action);
-        return null;
-      }
-    });
-  }
-
-  /**
-   * Check if user userName has permissions to perform the given FsAction action
-   * on all files under the file whose FileStatus fileStatus is provided
-   *
-   * @param fs
-   * @param fileStatus
-   * @param userName
-   * @param action
-   * @return
-   * @throws IOException
-   */
-  public static boolean isActionPermittedForFileHierarchy(FileSystem fs, FileStatus fileStatus,
-      String userName, FsAction action) throws Exception {
-    boolean isDir = fileStatus.isDir();
-
-    FsAction dirActionNeeded = action;
-    if (isDir) {
-      // for dirs user needs execute privileges as well
-      dirActionNeeded.and(FsAction.EXECUTE);
+    /**
+     * Makes a valid list bucketing directory name.
+     *
+     * @param lbCols The skewed keys' names
+     * @param vals   The skewed values
+     * @return An escaped, valid list bucketing directory name.
+     */
+    public static String makeListBucketingDirName(List<String> lbCols, List<String> vals) {
+        StringBuilder name = new StringBuilder();
+        for (int i = 0; i < lbCols.size(); i++) {
+            if (i > 0) {
+                name.append(Path.SEPARATOR);
+            }
+            name.append(escapePathName((lbCols.get(i)).toLowerCase()));
+            name.append('=');
+            name.append(escapePathName(vals.get(i)));
+        }
+        return name.toString();
     }
 
-    try {
-      checkFileAccessWithImpersonation(fs, fileStatus, action, userName);
-    } catch (AccessControlException err) {
-      // Action not permitted for user
-      return false;
+    // NOTE: This is for generating the internal path name for partitions. Users
+    // should always use the MetaStore API to get the path name for a partition.
+    // Users should not directly take partition values and turn it into a path
+    // name by themselves, because the logic below may change in the future.
+    //
+    // In the future, it's OK to add new chars to the escape list, and old data
+    // won't be corrupt, because the full path name in metastore is stored.
+    // In that case, Hive will continue to read the old data, but when it creates
+    // new partitions, it will use new names.
+    // edit : There are some use cases for which adding new chars does not seem
+    // to be backward compatible - Eg. if partition was created with name having
+    // a special char that you want to start escaping, and then you try dropping
+    // the partition with a hive version that now escapes the special char using
+    // the list below, then the drop partition fails to work.
+
+    static BitSet charToEscape = new BitSet(128);
+
+    static {
+        for (char c = 0; c < ' '; c++) {
+            charToEscape.set(c);
+        }
+
+        /**
+         * ASCII 01-1F are HTTP control characters that need to be escaped.
+         * \u000A and \u000D are \n and \r, respectively.
+         */
+        char[] clist = new char[]{'\u0001', '\u0002', '\u0003', '\u0004',
+                '\u0005', '\u0006', '\u0007', '\u0008', '\u0009', '\n', '\u000B',
+                '\u000C', '\r', '\u000E', '\u000F', '\u0010', '\u0011', '\u0012',
+                '\u0013', '\u0014', '\u0015', '\u0016', '\u0017', '\u0018', '\u0019',
+                '\u001A', '\u001B', '\u001C', '\u001D', '\u001E', '\u001F',
+                '"', '#', '%', '\'', '*', '/', ':', '=', '?', '\\', '\u007F', '{',
+                '[', ']', '^'};
+
+        for (char c : clist) {
+            charToEscape.set(c);
+        }
+
+        if (Shell.WINDOWS) {
+            //On windows, following chars need to be escaped as well
+            char[] winClist = {' ', '<', '>', '|'};
+            for (char c : winClist) {
+                charToEscape.set(c);
+            }
+        }
+
     }
 
-    if (!isDir) {
-      // no sub dirs to be checked
-      return true;
-    }
-    // check all children
-    FileStatus[] childStatuses = fs.listStatus(fileStatus.getPath());
-    for (FileStatus childStatus : childStatuses) {
-      // check children recursively
-      if (!isActionPermittedForFileHierarchy(fs, childStatus, userName, action)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * A best effort attempt to determine if if the file is a local file
-   * @param conf
-   * @param fileName
-   * @return true if it was successfully able to determine that it is a local file
-   */
-  public static boolean isLocalFile(HiveConf conf, String fileName) {
-    try {
-      // do best effort to determine if this is a local file
-      return isLocalFile(conf, new URI(fileName));
-    } catch (URISyntaxException e) {
-      LOG.warn("Unable to create URI from " + fileName, e);
-    }
-    return false;
-  }
-
-  /**
-   * A best effort attempt to determine if if the file is a local file
-   * @param conf
-   * @param fileUri
-   * @return true if it was successfully able to determine that it is a local file
-   */
-  public static boolean isLocalFile(HiveConf conf, URI fileUri) {
-    try {
-      // do best effort to determine if this is a local file
-      FileSystem fsForFile = FileSystem.get(fileUri, conf);
-      return LocalFileSystem.class.isInstance(fsForFile);
-    } catch (IOException e) {
-      LOG.warn("Unable to get FileSystem for " + fileUri, e);
-    }
-    return false;
-  }
-
-  public static boolean isOwnerOfFileHierarchy(FileSystem fs, FileStatus fileStatus, String userName)
-      throws IOException {
-    if (!fileStatus.getOwner().equals(userName)) {
-      return false;
+    static boolean needsEscaping(char c) {
+        return c >= 0 && c < charToEscape.size() && charToEscape.get(c);
     }
 
-    if (!fileStatus.isDir()) {
-      // no sub dirs to be checked
-      return true;
+    public static String escapePathName(String path) {
+        return escapePathName(path, null);
     }
-    // check all children
-    FileStatus[] childStatuses = fs.listStatus(fileStatus.getPath());
-    for (FileStatus childStatus : childStatuses) {
-      // check children recursively
-      if (!isOwnerOfFileHierarchy(fs, childStatus, userName)) {
-        return false;
-      }
-    }
-    return true;
-  }
 
-  /**
-   * Creates the directory and all necessary parent directories.
-   * @param fs FileSystem to use
-   * @param f path to create.
-   * @param inheritPerms whether directory inherits the permission of the last-existing parent path
-   * @param conf Hive configuration
-   * @return true if directory created successfully.  False otherwise, including if it exists.
-   * @throws IOException exception in creating the directory
-   */
-  public static boolean mkdir(FileSystem fs, Path f, boolean inheritPerms, Configuration conf) throws IOException {
-    LOG.info("Creating directory if it doesn't exist: " + f);
-    if (!inheritPerms) {
-      //just create the directory
-      return fs.mkdirs(f);
-    } else {
-      //Check if the directory already exists. We want to change the permission
-      //to that of the parent directory only for newly created directories.
-      try {
-        return fs.getFileStatus(f).isDir();
-      } catch (FileNotFoundException ignore) {
-      }
-      //inherit perms: need to find last existing parent path, and apply its permission on entire subtree.
-      Path lastExistingParent = f;
-      Path firstNonExistentParent = null;
-      while (!fs.exists(lastExistingParent)) {
-        firstNonExistentParent = lastExistingParent;
-        lastExistingParent = lastExistingParent.getParent();
-      }
-      boolean success = fs.mkdirs(f);
-      if (!success) {
-        return false;
-      } else {
-        HadoopShims shim = ShimLoader.getHadoopShims();
-        HdfsFileStatus fullFileStatus = shim.getFullFileStatus(conf, fs, lastExistingParent);
+    /**
+     * Escapes a path name.
+     *
+     * @param path        The path to escape.
+     * @param defaultPath The default name for the path, if the given path is empty or null.
+     * @return An escaped path name.
+     */
+    public static String escapePathName(String path, String defaultPath) {
+
+        // __HIVE_DEFAULT_NULL__ is the system default value for null and empty string.
+        // TODO: we should allow user to specify default partition or HDFS file location.
+        if (path == null || path.length() == 0) {
+            if (defaultPath == null) {
+                //previously, when path is empty or null and no default path is specified,
+                // __HIVE_DEFAULT_PARTITION__ was the return value for escapePathName
+                return "__HIVE_DEFAULT_PARTITION__";
+            } else {
+                return defaultPath;
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (needsEscaping(c)) {
+                sb.append('%');
+                sb.append(String.format("%1$02X", (int) c));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static String unescapePathName(String path) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '%' && i + 2 < path.length()) {
+                int code = -1;
+                try {
+                    code = Integer.valueOf(path.substring(i + 1, i + 3), 16);
+                } catch (Exception e) {
+                    code = -1;
+                }
+                if (code >= 0) {
+                    sb.append((char) code);
+                    i += 2;
+                    continue;
+                }
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Recursively lists status for all files starting from a particular directory (or individual file
+     * as base case).
+     *
+     * @param fs         file system
+     * @param fileStatus starting point in file system
+     * @param results    receives enumeration of all files found
+     */
+    public static void listStatusRecursively(FileSystem fs, FileStatus fileStatus,
+                                             List<FileStatus> results) throws IOException {
+
+        if (fileStatus.isDir()) {
+            for (FileStatus stat : fs.listStatus(fileStatus.getPath(), HIDDEN_FILES_PATH_FILTER)) {
+                listStatusRecursively(fs, stat, results);
+            }
+        } else {
+            results.add(fileStatus);
+        }
+    }
+
+    /**
+     * Find the parent of path that exists, if path does not exist
+     *
+     * @param fs   file system
+     * @param path
+     * @return FileStatus for argument path if it exists or the first ancestor in the path that exists
+     * @throws IOException
+     */
+    public static FileStatus getPathOrParentThatExists(FileSystem fs, Path path) throws IOException {
+        FileStatus stat = FileUtils.getFileStatusOrNull(fs, path);
+        if (stat != null) {
+            return stat;
+        }
+        Path parentPath = path.getParent();
+        return getPathOrParentThatExists(fs, parentPath);
+    }
+
+    /**
+     * Perform a check to determine if the user is able to access the file passed in.
+     * If the user name passed in is different from the current user, this method will
+     * attempt to do impersonate the user to do the check; the current user should be
+     * able to create proxy users in this case.
+     *
+     * @param fs     FileSystem of the path to check
+     * @param stat   FileStatus representing the file
+     * @param action FsAction that will be checked
+     * @param user   User name of the user that will be checked for access.  If the user name
+     *               is null or the same as the current user, no user impersonation will be done
+     *               and the check will be done as the current user. Otherwise the file access
+     *               check will be performed within a doAs() block to use the access privileges
+     *               of this user. In this case the user must be configured to impersonate other
+     *               users, otherwise this check will fail with error.
+     * @throws IOException
+     * @throws AccessControlException
+     * @throws InterruptedException
+     * @throws Exception
+     */
+    public static void checkFileAccessWithImpersonation(final FileSystem fs,
+                                                        final FileStatus stat, final FsAction action, final String user)
+            throws IOException, AccessControlException, InterruptedException, Exception {
+        UserGroupInformation ugi = Utils.getUGI();
+        String currentUser = ugi.getShortUserName();
+
+        if (user == null || currentUser.equals(user)) {
+            // No need to impersonate user, do the checks as the currently configured user.
+            ShimLoader.getHadoopShims().checkFileAccess(fs, stat, action);
+            return;
+        }
+
+        // Otherwise, try user impersonation. Current user must be configured to do user impersonation.
+        UserGroupInformation proxyUser = UserGroupInformation.createProxyUser(
+                user, UserGroupInformation.getLoginUser());
+        proxyUser.doAs(new PrivilegedExceptionAction<Object>() {
+            @Override
+            public Object run() throws Exception {
+                FileSystem fsAsUser = FileSystem.get(fs.getUri(), fs.getConf());
+                ShimLoader.getHadoopShims().checkFileAccess(fsAsUser, stat, action);
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Check if user userName has permissions to perform the given FsAction action
+     * on all files under the file whose FileStatus fileStatus is provided
+     *
+     * @param fs
+     * @param fileStatus
+     * @param userName
+     * @param action
+     * @return
+     * @throws IOException
+     */
+    public static boolean isActionPermittedForFileHierarchy(FileSystem fs, FileStatus fileStatus,
+                                                            String userName, FsAction action) throws Exception {
+        boolean isDir = fileStatus.isDir();
+
+        FsAction dirActionNeeded = action;
+        if (isDir) {
+            // for dirs user needs execute privileges as well
+            dirActionNeeded.and(FsAction.EXECUTE);
+        }
+
         try {
-          //set on the entire subtree
-          shim.setFullFileStatus(conf, fullFileStatus, fs, firstNonExistentParent);
-        } catch (Exception e) {
-          LOG.warn("Error setting permissions of " + firstNonExistentParent, e);
+            checkFileAccessWithImpersonation(fs, fileStatus, action, userName);
+        } catch (AccessControlException err) {
+            // Action not permitted for user
+            return false;
+        }
+
+        if (!isDir) {
+            // no sub dirs to be checked
+            return true;
+        }
+        // check all children
+        FileStatus[] childStatuses = fs.listStatus(fileStatus.getPath());
+        for (FileStatus childStatus : childStatuses) {
+            // check children recursively
+            if (!isActionPermittedForFileHierarchy(fs, childStatus, userName, action)) {
+                return false;
+            }
         }
         return true;
-      }
-    }
-  }
-
-  /**
-   * Copies files between filesystems.
-   */
-  public static boolean copy(FileSystem srcFS, Path src,
-    FileSystem dstFS, Path dst,
-    boolean deleteSource,
-    boolean overwrite,
-    HiveConf conf) throws IOException {
-
-    HadoopShims shims = ShimLoader.getHadoopShims();
-    boolean copied;
-
-    /* Run distcp if source file/dir is too big */
-    if (srcFS.getUri().getScheme().equals("hdfs") &&
-        srcFS.getFileStatus(src).getLen() > conf.getLongVar(HiveConf.ConfVars.HIVE_EXEC_COPYFILE_MAXSIZE)) {
-      LOG.info("Source is " + srcFS.getFileStatus(src).getLen() + " bytes. (MAX: " + conf.getLongVar(HiveConf.ConfVars.HIVE_EXEC_COPYFILE_MAXSIZE) + ")");
-      LOG.info("Launch distributed copy (distcp) job.");
-      copied = shims.runDistCp(src, dst, conf);
-      if (copied && deleteSource) {
-        srcFS.delete(src, true);
-      }
-    } else {
-      copied = FileUtil.copy(srcFS, src, dstFS, dst, deleteSource, overwrite, conf);
     }
 
-    boolean inheritPerms = conf.getBoolVar(HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
-    if (copied && inheritPerms) {
-      HdfsFileStatus fullFileStatus = shims.getFullFileStatus(conf, dstFS, dst);
-      try {
-        shims.setFullFileStatus(conf, fullFileStatus, dstFS, dst);
-      } catch (Exception e) {
-        LOG.warn("Error setting permissions or group of " + dst, e);
-      }
-    }
-    return copied;
-  }
-
-  /**
-   * Deletes all files under a directory, sending them to the trash.  Leaves the directory as is.
-   * @param fs FileSystem to use
-   * @param f path of directory
-   * @param conf hive configuration
-   * @return true if deletion successful
-   * @throws FileNotFoundException
-   * @throws IOException
-   */
-  public static boolean trashFilesUnderDir(FileSystem fs, Path f, Configuration conf) throws FileNotFoundException, IOException {
-    FileStatus[] statuses = fs.listStatus(f, HIDDEN_FILES_PATH_FILTER);
-    boolean result = true;
-    for (FileStatus status : statuses) {
-      result = result & moveToTrash(fs, status.getPath(), conf);
-    }
-    return result;
-  }
-
-  /**
-   * Move a particular file or directory to the trash.
-   * @param fs FileSystem to use
-   * @param f path of file or directory to move to trash.
-   * @param conf
-   * @return true if move successful
-   * @throws IOException
-   */
-  public static boolean moveToTrash(FileSystem fs, Path f, Configuration conf) throws IOException {
-    LOG.info("deleting  " + f);
-    HadoopShims hadoopShim = ShimLoader.getHadoopShims();
-
-    if (hadoopShim.moveToAppropriateTrash(fs, f, conf)) {
-      LOG.info("Moved to trash: " + f);
-      return true;
+    /**
+     * A best effort attempt to determine if if the file is a local file
+     *
+     * @param conf
+     * @param fileName
+     * @return true if it was successfully able to determine that it is a local file
+     */
+    public static boolean isLocalFile(HiveConf conf, String fileName) {
+        try {
+            // do best effort to determine if this is a local file
+            return isLocalFile(conf, new URI(fileName));
+        } catch (URISyntaxException e) {
+            LOG.warn("Unable to create URI from " + fileName, e);
+        }
+        return false;
     }
 
-    boolean result = fs.delete(f, true);
-    if (!result) {
-      LOG.error("Failed to delete " + f);
-    }
-    return result;
-  }
-
-  /**
-   * Check if first path is a subdirectory of second path.
-   * Both paths must belong to the same filesystem.
-   *
-   * @param p1 first path
-   * @param p2 second path
-   * @param fs FileSystem, both paths must belong to the same filesystem
-   * @return
-   */
-  public static boolean isSubDir(Path p1, Path p2, FileSystem fs) {
-    String path1 = fs.makeQualified(p1).toString();
-    String path2 = fs.makeQualified(p2).toString();
-    if (path1.startsWith(path2)) {
-      return true;
+    /**
+     * A best effort attempt to determine if if the file is a local file
+     *
+     * @param conf
+     * @param fileUri
+     * @return true if it was successfully able to determine that it is a local file
+     */
+    public static boolean isLocalFile(HiveConf conf, URI fileUri) {
+        try {
+            // do best effort to determine if this is a local file
+            FileSystem fsForFile = FileSystem.get(fileUri, conf);
+            return LocalFileSystem.class.isInstance(fsForFile);
+        } catch (IOException e) {
+            LOG.warn("Unable to get FileSystem for " + fileUri, e);
+        }
+        return false;
     }
 
-    return false;
-  }
+    public static boolean isOwnerOfFileHierarchy(FileSystem fs, FileStatus fileStatus, String userName)
+            throws IOException {
+        if (!fileStatus.getOwner().equals(userName)) {
+            return false;
+        }
 
-  public static boolean renameWithPerms(FileSystem fs, Path sourcePath,
-                               Path destPath, boolean inheritPerms,
-                               Configuration conf) throws IOException {
-    LOG.info("Renaming " + sourcePath + " to " + destPath);
-    if (!inheritPerms) {
-      //just rename the directory
-      return fs.rename(sourcePath, destPath);
-    } else {
-      //rename the directory
-      if (fs.rename(sourcePath, destPath)) {
+        if (!fileStatus.isDir()) {
+            // no sub dirs to be checked
+            return true;
+        }
+        // check all children
+        FileStatus[] childStatuses = fs.listStatus(fileStatus.getPath());
+        for (FileStatus childStatus : childStatuses) {
+            // check children recursively
+            if (!isOwnerOfFileHierarchy(fs, childStatus, userName)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Creates the directory and all necessary parent directories.
+     *
+     * @param fs           FileSystem to use
+     * @param f            path to create.
+     * @param inheritPerms whether directory inherits the permission of the last-existing parent path
+     * @param conf         Hive configuration
+     * @return true if directory created successfully.  False otherwise, including if it exists.
+     * @throws IOException exception in creating the directory
+     */
+    public static boolean mkdir(FileSystem fs, Path f, boolean inheritPerms, Configuration conf) throws IOException {
+        LOG.info("Creating directory if it doesn't exist: " + f);
+        if (!inheritPerms) {
+            //just create the directory
+            return fs.mkdirs(f);
+        } else {
+            //Check if the directory already exists. We want to change the permission
+            //to that of the parent directory only for newly created directories.
+            try {
+                return fs.getFileStatus(f).isDir();
+            } catch (FileNotFoundException ignore) {
+            }
+            //inherit perms: need to find last existing parent path, and apply its permission on entire subtree.
+            Path lastExistingParent = f;
+            Path firstNonExistentParent = null;
+            while (!fs.exists(lastExistingParent)) {
+                firstNonExistentParent = lastExistingParent;
+                lastExistingParent = lastExistingParent.getParent();
+            }
+            boolean success = fs.mkdirs(f);
+            if (!success) {
+                return false;
+            } else {
+                HadoopShims shim = ShimLoader.getHadoopShims();
+                HdfsFileStatus fullFileStatus = shim.getFullFileStatus(conf, fs, lastExistingParent);
+                try {
+                    //set on the entire subtree
+                    shim.setFullFileStatus(conf, fullFileStatus, fs, firstNonExistentParent);
+                } catch (Exception e) {
+                    LOG.warn("Error setting permissions of " + firstNonExistentParent, e);
+                }
+                return true;
+            }
+        }
+    }
+
+    /**
+     * Copies files between filesystems.
+     */
+    public static boolean copy(FileSystem srcFS, Path src,
+                               FileSystem dstFS, Path dst,
+                               boolean deleteSource,
+                               boolean overwrite,
+                               HiveConf conf) throws IOException {
+
         HadoopShims shims = ShimLoader.getHadoopShims();
-        HdfsFileStatus fullFileStatus = shims.getFullFileStatus(conf, fs, destPath.getParent());
-        try {
-          shims.setFullFileStatus(conf, fullFileStatus, fs, destPath);
-        } catch (Exception e) {
-          LOG.warn("Error setting permissions or group of " + destPath, e);
+        boolean copied;
+
+        /* Run distcp if source file/dir is too big */
+        if (srcFS.getUri().getScheme().equals("hdfs") &&
+                srcFS.getFileStatus(src).getLen() > conf.getLongVar(HiveConf.ConfVars.HIVE_EXEC_COPYFILE_MAXSIZE)) {
+            LOG.info("Source is " + srcFS.getFileStatus(src).getLen() + " bytes. (MAX: " + conf.getLongVar(HiveConf.ConfVars.HIVE_EXEC_COPYFILE_MAXSIZE) + ")");
+            LOG.info("Launch distributed copy (distcp) job.");
+            copied = shims.runDistCp(src, dst, conf);
+            if (copied && deleteSource) {
+                srcFS.delete(src, true);
+            }
+        } else {
+            copied = FileUtil.copy(srcFS, src, dstFS, dst, deleteSource, overwrite, conf);
         }
 
-        return true;
-      }
-
-      return false;
-    }
-  }
-
-  /**
-   * @param fs1
-   * @param fs2
-   * @return return true if both file system arguments point to same file system
-   */
-  public static boolean equalsFileSystem(FileSystem fs1, FileSystem fs2) {
-    //When file system cache is disabled, you get different FileSystem objects
-    // for same file system, so '==' can't be used in such cases
-    //FileSystem api doesn't have a .equals() function implemented, so using
-    //the uri for comparison. FileSystem already uses uri+Configuration for
-    //equality in its CACHE .
-    //Once equality has been added in HDFS-4321, we should make use of it
-    return fs1.getUri().equals(fs2.getUri());
-  }
-
-  /**
-   * Checks if delete can be performed on given path by given user.
-   * If file does not exist it just returns without throwing an Exception
-   * @param path
-   * @param conf
-   * @param user
-   * @throws AccessControlException
-   * @throws InterruptedException
-   * @throws Exception
-   */
-  public static void checkDeletePermission(Path path, Configuration conf, String user)
-      throws AccessControlException, InterruptedException, Exception {
-   // This requires ability to delete the given path.
-    // The following 2 conditions should be satisfied for this-
-    // 1. Write permissions on parent dir
-    // 2. If sticky bit is set on parent dir then one of following should be
-    // true
-    //   a. User is owner of the current dir/file
-    //   b. User is owner of the parent dir
-    //   Super users are also allowed to drop the file, but there is no good way of checking
-    //   if a user is a super user. Also super users running hive queries is not a common
-    //   use case. super users can also do a chown to be able to drop the file
-
-    if(path == null) {
-      // no file/dir to be deleted
-      return;
+        boolean inheritPerms = conf.getBoolVar(HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
+        if (copied && inheritPerms) {
+            HdfsFileStatus fullFileStatus = shims.getFullFileStatus(conf, dstFS, dst);
+            try {
+                shims.setFullFileStatus(conf, fullFileStatus, dstFS, dst);
+            } catch (Exception e) {
+                LOG.warn("Error setting permissions or group of " + dst, e);
+            }
+        }
+        return copied;
     }
 
-    final FileSystem fs = path.getFileSystem(conf);
-    // check user has write permissions on the parent dir
-    FileStatus stat = null;
-    try {
-      stat = fs.getFileStatus(path);
-    } catch (FileNotFoundException e) {
-      // ignore
-    }
-    if (stat == null) {
-      // no file/dir to be deleted
-      return;
-    }
-    FileUtils.checkFileAccessWithImpersonation(fs, stat, FsAction.WRITE, user);
+    /**
+     * Deletes all files under a directory, sending them to the trash.  Leaves the directory as is.
+     *
+     * @param fs   FileSystem to use
+     * @param f    path of directory
+     * @param conf hive configuration
+     * @return true if deletion successful
+     * @throws FileNotFoundException
+     * @throws IOException
+     */
+    public static boolean trashFilesUnderDir(final FileSystem fs, Path f, final Configuration conf) throws IOException {
+        FileStatus[] statuses = fs.listStatus(f, HIDDEN_FILES_PATH_FILTER);
+        boolean result = true;
+        //fordeal Patch by zhiyue@2020-03-16
+        final List<Future<Boolean>> futures = new LinkedList<>();
+        final ExecutorService pool = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVE_MOVE_FILES_THREAD_COUNT) > 0 ?
+                Executors.newFixedThreadPool(HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVE_MOVE_FILES_THREAD_COUNT),
+                        new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Delete-Thread-%d").build()) : null;
 
-    HadoopShims shims = ShimLoader.getHadoopShims();
-    if (!shims.supportStickyBit()) {
-      // not supports sticky bit
-      return;
+        for (final FileStatus status : statuses) {
+            if (null == pool) {
+                result &= moveToTrash(fs, status.getPath(), conf);
+            } else {
+                futures.add(pool.submit(new Callable<Boolean>() {
+                    @Override
+                    public Boolean call() throws Exception {
+                        return moveToTrash(fs, status.getPath(), conf);
+                    }
+                }));
+            }
+
+        }
+        if (null != pool) {
+            pool.shutdown();
+            for (Future<Boolean> future : futures) {
+                try {
+                    result &= future.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    LOG.error("Failed to delete: ", e);
+                    pool.shutdown();
+                    throw new IOException(e);
+                }
+            }
+        }
+        return result;
     }
 
-    // check if sticky bit is set on the parent dir
-    FileStatus parStatus = fs.getFileStatus(path.getParent());
-    if (!shims.hasStickyBit(parStatus.getPermission())) {
-      // no sticky bit, so write permission on parent dir is sufficient
-      // no further checks needed
-      return;
+    /**
+     * Move a particular file or directory to the trash.
+     *
+     * @param fs   FileSystem to use
+     * @param f    path of file or directory to move to trash.
+     * @param conf
+     * @return true if move successful
+     * @throws IOException
+     */
+    public static boolean moveToTrash(FileSystem fs, Path f, Configuration conf) throws IOException {
+        LOG.info("deleting  " + f);
+        HadoopShims hadoopShim = ShimLoader.getHadoopShims();
+
+        if (hadoopShim.moveToAppropriateTrash(fs, f, conf)) {
+            LOG.info("Moved to trash: " + f);
+            return true;
+        }
+
+        boolean result = fs.delete(f, true);
+        if (!result) {
+            LOG.error("Failed to delete " + f);
+        }
+        return result;
     }
 
-    // check if user is owner of parent dir
-    if (parStatus.getOwner().equals(user)) {
-      return;
+    /**
+     * Check if first path is a subdirectory of second path.
+     * Both paths must belong to the same filesystem.
+     *
+     * @param p1 first path
+     * @param p2 second path
+     * @param fs FileSystem, both paths must belong to the same filesystem
+     * @return
+     */
+    public static boolean isSubDir(Path p1, Path p2, FileSystem fs) {
+        String path1 = fs.makeQualified(p1).toString();
+        String path2 = fs.makeQualified(p2).toString();
+        if (path1.startsWith(path2)) {
+            return true;
+        }
+
+        return false;
     }
 
-    // check if user is owner of current dir/file
-    FileStatus childStatus = fs.getFileStatus(path);
-    if (childStatus.getOwner().equals(user)) {
-      return;
-    }
-    String msg = String.format("Permission Denied: User %s can't delete %s because sticky bit is"
-        + " set on the parent dir and user does not own this file or its parent", user, path);
-    throw new IOException(msg);
+    public static boolean renameWithPerms(FileSystem fs, Path sourcePath,
+                                          Path destPath, boolean inheritPerms,
+                                          Configuration conf) throws IOException {
+        LOG.info("Renaming " + sourcePath + " to " + destPath);
+        if (!inheritPerms) {
+            //just rename the directory
+            return fs.rename(sourcePath, destPath);
+        } else {
+            //rename the directory
+            if (fs.rename(sourcePath, destPath)) {
+                HadoopShims shims = ShimLoader.getHadoopShims();
+                HdfsFileStatus fullFileStatus = shims.getFullFileStatus(conf, fs, destPath.getParent());
+                try {
+                    shims.setFullFileStatus(conf, fullFileStatus, fs, destPath);
+                } catch (Exception e) {
+                    LOG.warn("Error setting permissions or group of " + destPath, e);
+                }
 
-  }
+                return true;
+            }
 
-  /**
-   * Attempts to get file status.  This method differs from the FileSystem API in that it returns
-   * null instead of throwing FileNotFoundException if the path does not exist.
-   *
-   * @param fs file system to check
-   * @param path file system path to check
-   * @return FileStatus for path or null if path does not exist
-   * @throws IOException if there is an I/O error
-   */
-  public static FileStatus getFileStatusOrNull(FileSystem fs, Path path) throws IOException {
-    try {
-      return fs.getFileStatus(path);
-    } catch (FileNotFoundException e) {
-      return null;
+            return false;
+        }
     }
-  }
+
+    /**
+     * @param fs1
+     * @param fs2
+     * @return return true if both file system arguments point to same file system
+     */
+    public static boolean equalsFileSystem(FileSystem fs1, FileSystem fs2) {
+        //When file system cache is disabled, you get different FileSystem objects
+        // for same file system, so '==' can't be used in such cases
+        //FileSystem api doesn't have a .equals() function implemented, so using
+        //the uri for comparison. FileSystem already uses uri+Configuration for
+        //equality in its CACHE .
+        //Once equality has been added in HDFS-4321, we should make use of it
+        return fs1.getUri().equals(fs2.getUri());
+    }
+
+    /**
+     * Checks if delete can be performed on given path by given user.
+     * If file does not exist it just returns without throwing an Exception
+     *
+     * @param path
+     * @param conf
+     * @param user
+     * @throws AccessControlException
+     * @throws InterruptedException
+     * @throws Exception
+     */
+    public static void checkDeletePermission(Path path, Configuration conf, String user)
+            throws AccessControlException, InterruptedException, Exception {
+        // This requires ability to delete the given path.
+        // The following 2 conditions should be satisfied for this-
+        // 1. Write permissions on parent dir
+        // 2. If sticky bit is set on parent dir then one of following should be
+        // true
+        //   a. User is owner of the current dir/file
+        //   b. User is owner of the parent dir
+        //   Super users are also allowed to drop the file, but there is no good way of checking
+        //   if a user is a super user. Also super users running hive queries is not a common
+        //   use case. super users can also do a chown to be able to drop the file
+
+        if (path == null) {
+            // no file/dir to be deleted
+            return;
+        }
+
+        final FileSystem fs = path.getFileSystem(conf);
+        // check user has write permissions on the parent dir
+        FileStatus stat = null;
+        try {
+            stat = fs.getFileStatus(path);
+        } catch (FileNotFoundException e) {
+            // ignore
+        }
+        if (stat == null) {
+            // no file/dir to be deleted
+            return;
+        }
+        FileUtils.checkFileAccessWithImpersonation(fs, stat, FsAction.WRITE, user);
+
+        HadoopShims shims = ShimLoader.getHadoopShims();
+        if (!shims.supportStickyBit()) {
+            // not supports sticky bit
+            return;
+        }
+
+        // check if sticky bit is set on the parent dir
+        FileStatus parStatus = fs.getFileStatus(path.getParent());
+        if (!shims.hasStickyBit(parStatus.getPermission())) {
+            // no sticky bit, so write permission on parent dir is sufficient
+            // no further checks needed
+            return;
+        }
+
+        // check if user is owner of parent dir
+        if (parStatus.getOwner().equals(user)) {
+            return;
+        }
+
+        // check if user is owner of current dir/file
+        FileStatus childStatus = fs.getFileStatus(path);
+        if (childStatus.getOwner().equals(user)) {
+            return;
+        }
+        String msg = String.format("Permission Denied: User %s can't delete %s because sticky bit is"
+                + " set on the parent dir and user does not own this file or its parent", user, path);
+        throw new IOException(msg);
+
+    }
+
+    /**
+     * Attempts to get file status.  This method differs from the FileSystem API in that it returns
+     * null instead of throwing FileNotFoundException if the path does not exist.
+     *
+     * @param fs   file system to check
+     * @param path file system path to check
+     * @return FileStatus for path or null if path does not exist
+     * @throws IOException if there is an I/O error
+     */
+    public static FileStatus getFileStatusOrNull(FileSystem fs, Path path) throws IOException {
+        try {
+            return fs.getFileStatus(path);
+        } catch (FileNotFoundException e) {
+            return null;
+        }
+    }
 }

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,3045 +60,3077 @@ import com.google.common.base.Joiner;
  * Hive Configuration.
  */
 public class HiveConf extends Configuration {
-  protected String hiveJar;
-  protected Properties origProp;
-  protected String auxJars;
-  private static final Log l4j = LogFactory.getLog(HiveConf.class);
-  private static boolean loadMetastoreConfig = false;
-  private static boolean loadHiveServer2Config = false;
-  private static URL hiveDefaultURL = null;
-  private static URL hiveSiteURL = null;
-  private static URL hivemetastoreSiteUrl = null;
-  private static URL hiveServer2SiteUrl = null;
+    protected String hiveJar;
+    protected Properties origProp;
+    protected String auxJars;
+    private static final Log l4j = LogFactory.getLog(HiveConf.class);
+    private static boolean loadMetastoreConfig = false;
+    private static boolean loadHiveServer2Config = false;
+    private static URL hiveDefaultURL = null;
+    private static URL hiveSiteURL = null;
+    private static URL hivemetastoreSiteUrl = null;
+    private static URL hiveServer2SiteUrl = null;
 
-  private static byte[] confVarByteArray = null;
+    private static byte[] confVarByteArray = null;
 
 
-  private static final Map<String, ConfVars> vars = new HashMap<String, ConfVars>();
-  private static final Map<String, ConfVars> metaConfs = new HashMap<String, ConfVars>();
-  private final List<String> restrictList = new ArrayList<String>();
+    private static final Map<String, ConfVars> vars = new HashMap<String, ConfVars>();
+    private static final Map<String, ConfVars> metaConfs = new HashMap<String, ConfVars>();
+    private final List<String> restrictList = new ArrayList<String>();
 
-  private Pattern modWhiteListPattern = null;
-  private boolean isSparkConfigUpdated = false;
+    private Pattern modWhiteListPattern = null;
+    private boolean isSparkConfigUpdated = false;
 
-  public boolean getSparkConfigUpdated() {
-    return isSparkConfigUpdated;
-  }
-
-  public void setSparkConfigUpdated(boolean isSparkConfigUpdated) {
-    this.isSparkConfigUpdated = isSparkConfigUpdated;
-  }
-
-  static {
-    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-    if (classLoader == null) {
-      classLoader = HiveConf.class.getClassLoader();
+    public boolean getSparkConfigUpdated() {
+        return isSparkConfigUpdated;
     }
 
-    hiveDefaultURL = classLoader.getResource("hive-default.xml");
-
-    // Look for hive-site.xml on the CLASSPATH and log its location if found.
-    hiveSiteURL = classLoader.getResource("hive-site.xml");
-    hivemetastoreSiteUrl = classLoader.getResource("hivemetastore-site.xml");
-    hiveServer2SiteUrl = classLoader.getResource("hiveserver2-site.xml");
-
-    for (ConfVars confVar : ConfVars.values()) {
-      vars.put(confVar.varname, confVar);
-    }
-  }
-
-  /**
-   * Metastore related options that the db is initialized against. When a conf
-   * var in this is list is changed, the metastore instance for the CLI will
-   * be recreated so that the change will take effect.
-   */
-  public static final HiveConf.ConfVars[] metaVars = {
-      HiveConf.ConfVars.METASTOREWAREHOUSE,
-      HiveConf.ConfVars.METASTOREURIS,
-      HiveConf.ConfVars.METASTORETHRIFTCONNECTIONRETRIES,
-      HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES,
-      HiveConf.ConfVars.METASTORE_CLIENT_CONNECT_RETRY_DELAY,
-      HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT,
-      HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_LIFETIME,
-      HiveConf.ConfVars.METASTOREPWD,
-      HiveConf.ConfVars.METASTORECONNECTURLHOOK,
-      HiveConf.ConfVars.METASTORECONNECTURLKEY,
-      HiveConf.ConfVars.METASTORESERVERMINTHREADS,
-      HiveConf.ConfVars.METASTORESERVERMAXTHREADS,
-      HiveConf.ConfVars.METASTORE_TCP_KEEP_ALIVE,
-      HiveConf.ConfVars.METASTORE_INT_ORIGINAL,
-      HiveConf.ConfVars.METASTORE_INT_ARCHIVED,
-      HiveConf.ConfVars.METASTORE_INT_EXTRACTED,
-      HiveConf.ConfVars.METASTORE_KERBEROS_KEYTAB_FILE,
-      HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL,
-      HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL,
-      HiveConf.ConfVars.METASTORE_CACHE_PINOBJTYPES,
-      HiveConf.ConfVars.METASTORE_CONNECTION_POOLING_TYPE,
-      HiveConf.ConfVars.METASTORE_VALIDATE_TABLES,
-      HiveConf.ConfVars.METASTORE_VALIDATE_COLUMNS,
-      HiveConf.ConfVars.METASTORE_VALIDATE_CONSTRAINTS,
-      HiveConf.ConfVars.METASTORE_STORE_MANAGER_TYPE,
-      HiveConf.ConfVars.METASTORE_AUTO_CREATE_SCHEMA,
-      HiveConf.ConfVars.METASTORE_AUTO_START_MECHANISM_MODE,
-      HiveConf.ConfVars.METASTORE_TRANSACTION_ISOLATION,
-      HiveConf.ConfVars.METASTORE_CACHE_LEVEL2,
-      HiveConf.ConfVars.METASTORE_CACHE_LEVEL2_TYPE,
-      HiveConf.ConfVars.METASTORE_IDENTIFIER_FACTORY,
-      HiveConf.ConfVars.METASTORE_PLUGIN_REGISTRY_BUNDLE_CHECK,
-      HiveConf.ConfVars.METASTORE_AUTHORIZATION_STORAGE_AUTH_CHECKS,
-      HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX,
-      HiveConf.ConfVars.METASTORE_EVENT_LISTENERS,
-      HiveConf.ConfVars.METASTORE_EVENT_CLEAN_FREQ,
-      HiveConf.ConfVars.METASTORE_EVENT_EXPIRY_DURATION,
-      HiveConf.ConfVars.METASTORE_FILTER_HOOK,
-      HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL,
-      HiveConf.ConfVars.METASTORE_END_FUNCTION_LISTENERS,
-      HiveConf.ConfVars.METASTORE_PART_INHERIT_TBL_PROPS,
-      HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_TABLE_PARTITION_MAX,
-      HiveConf.ConfVars.METASTORE_INIT_HOOKS,
-      HiveConf.ConfVars.METASTORE_PRE_EVENT_LISTENERS,
-      HiveConf.ConfVars.HMSHANDLERATTEMPTS,
-      HiveConf.ConfVars.HMSHANDLERINTERVAL,
-      HiveConf.ConfVars.HMSHANDLERFORCERELOADCONF,
-      HiveConf.ConfVars.METASTORE_PARTITION_NAME_WHITELIST_PATTERN,
-      HiveConf.ConfVars.METASTORE_ORM_RETRIEVE_MAPNULLS_AS_EMPTY_STRINGS,
-      HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES,
-      HiveConf.ConfVars.USERS_IN_ADMIN_ROLE,
-      HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
-      HiveConf.ConfVars.HIVE_TXN_MANAGER,
-      HiveConf.ConfVars.HIVE_TXN_TIMEOUT,
-      HiveConf.ConfVars.HIVE_TXN_MAX_OPEN_BATCH,
-      HiveConf.ConfVars.HIVE_METASTORE_STATS_NDV_DENSITY_FUNCTION,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_ENABLED,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_SIZE,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_PARTITIONS,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_FPP,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_VARIANCE,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_TTL,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_WRITER_WAIT,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_READER_WAIT,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_FULL,
-      HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_CLEAN_UNTIL
-      };
-
-  /**
-   * User configurable Metastore vars
-   */
-  public static final HiveConf.ConfVars[] metaConfVars = {
-      HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL,
-      HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL_DDL,
-      HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT
-  };
-
-  static {
-    for (ConfVars confVar : metaConfVars) {
-      metaConfs.put(confVar.varname, confVar);
-    }
-  }
-
-  /**
-   * dbVars are the parameters can be set per database. If these
-   * parameters are set as a database property, when switching to that
-   * database, the HiveConf variable will be changed. The change of these
-   * parameters will effectively change the DFS and MapReduce clusters
-   * for different databases.
-   */
-  public static final HiveConf.ConfVars[] dbVars = {
-    HiveConf.ConfVars.HADOOPBIN,
-    HiveConf.ConfVars.METASTOREWAREHOUSE,
-    HiveConf.ConfVars.SCRATCHDIR
-  };
-
-  /**
-   * ConfVars.
-   *
-   * These are the default configuration properties for Hive. Each HiveConf
-   * object is initialized as follows:
-   *
-   * 1) Hadoop configuration properties are applied.
-   * 2) ConfVar properties with non-null values are overlayed.
-   * 3) hive-site.xml properties are overlayed.
-   *
-   * WARNING: think twice before adding any Hadoop configuration properties
-   * with non-null values to this list as they will override any values defined
-   * in the underlying Hadoop configuration.
-   */
-  public static enum ConfVars {
-    // QL execution stuff
-    SCRIPTWRAPPER("hive.exec.script.wrapper", null, ""),
-    PLAN("hive.exec.plan", "", ""),
-    PLAN_SERIALIZATION("hive.plan.serialization.format", "kryo",
-        "Query plan format serialization between client and task nodes. \n" +
-        "Two supported values are : kryo and javaXML. Kryo is default."),
-    STAGINGDIR("hive.exec.stagingdir", ".hive-staging",
-        "Directory name that will be created inside table locations in order to support HDFS encryption. " +
-        "This is replaces ${hive.exec.scratchdir} for query results with the exception of read-only tables. " +
-        "In all cases ${hive.exec.scratchdir} is still used for other temporary files, such as job plans."),
-    SCRATCHDIR("hive.exec.scratchdir", "/tmp/hive",
-        "HDFS root scratch dir for Hive jobs which gets created with write all (733) permission. " +
-        "For each connecting user, an HDFS scratch dir: ${hive.exec.scratchdir}/<username> is created, " +
-        "with ${hive.scratch.dir.permission}."),
-    LOCALSCRATCHDIR("hive.exec.local.scratchdir",
-        "${system:java.io.tmpdir}" + File.separator + "${system:user.name}",
-        "Local scratch space for Hive jobs"),
-    DOWNLOADED_RESOURCES_DIR("hive.downloaded.resources.dir",
-        "${system:java.io.tmpdir}" + File.separator + "${hive.session.id}_resources",
-        "Temporary local directory for added resources in the remote file system."),
-    SCRATCHDIRPERMISSION("hive.scratch.dir.permission", "700",
-        "The permission for the user specific scratch directories that get created."),
-    SUBMITVIACHILD("hive.exec.submitviachild", false, ""),
-    SUBMITLOCALTASKVIACHILD("hive.exec.submit.local.task.via.child", true,
-        "Determines whether local tasks (typically mapjoin hashtable generation phase) runs in \n" +
-        "separate JVM (true recommended) or not. \n" +
-        "Avoids the overhead of spawning new JVM, but can lead to out-of-memory issues."),
-    SCRIPTERRORLIMIT("hive.exec.script.maxerrsize", 100000,
-        "Maximum number of bytes a script is allowed to emit to standard error (per map-reduce task). \n" +
-        "This prevents runaway scripts from filling logs partitions to capacity"),
-    ALLOWPARTIALCONSUMP("hive.exec.script.allow.partial.consumption", false,
-        "When enabled, this option allows a user script to exit successfully without consuming \n" +
-        "all the data from the standard input."),
-    STREAMREPORTERPERFIX("stream.stderr.reporter.prefix", "reporter:",
-        "Streaming jobs that log to standard error with this prefix can log counter or status information."),
-    STREAMREPORTERENABLED("stream.stderr.reporter.enabled", true,
-        "Enable consumption of status and counter messages for streaming jobs."),
-    COMPRESSRESULT("hive.exec.compress.output", false,
-        "This controls whether the final outputs of a query (to a local/HDFS file or a Hive table) is compressed. \n" +
-        "The compression codec and other options are determined from Hadoop config variables mapred.output.compress*"),
-    COMPRESSINTERMEDIATE("hive.exec.compress.intermediate", false,
-        "This controls whether intermediate files produced by Hive between multiple map-reduce jobs are compressed. \n" +
-        "The compression codec and other options are determined from Hadoop config variables mapred.output.compress*"),
-    COMPRESSINTERMEDIATECODEC("hive.intermediate.compression.codec", "", ""),
-    COMPRESSINTERMEDIATETYPE("hive.intermediate.compression.type", "", ""),
-    BYTESPERREDUCER("hive.exec.reducers.bytes.per.reducer", (long) (256 * 1000 * 1000),
-        "size per reducer.The default is 256Mb, i.e if the input size is 1G, it will use 4 reducers."),
-    MAXREDUCERS("hive.exec.reducers.max", 1009,
-        "max number of reducers will be used. If the one specified in the configuration parameter mapred.reduce.tasks is\n" +
-        "negative, Hive will use this one as the max number of reducers when automatically determine number of reducers."),
-    PREEXECHOOKS("hive.exec.pre.hooks", "",
-        "Comma-separated list of pre-execution hooks to be invoked for each statement. \n" +
-        "A pre-execution hook is specified as the name of a Java class which implements the \n" +
-        "org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext interface."),
-    POSTEXECHOOKS("hive.exec.post.hooks", "",
-        "Comma-separated list of post-execution hooks to be invoked for each statement. \n" +
-        "A post-execution hook is specified as the name of a Java class which implements the \n" +
-        "org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext interface."),
-    ONFAILUREHOOKS("hive.exec.failure.hooks", "",
-        "Comma-separated list of on-failure hooks to be invoked for each statement. \n" +
-        "An on-failure hook is specified as the name of Java class which implements the \n" +
-        "org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext interface."),
-    QUERYREDACTORHOOKS("hive.exec.query.redactor.hooks", "",
-        "Comma-separated list of hooks to be invoked for each query which can \n" +
-        "tranform the query before it's placed in the job.xml file. Must be a Java class which \n" +
-        "extends from the org.apache.hadoop.hive.ql.hooks.Redactor abstract class."),
-    CLIENTSTATSPUBLISHERS("hive.client.stats.publishers", "",
-        "Comma-separated list of statistics publishers to be invoked on counters on each job. \n" +
-        "A client stats publisher is specified as the name of a Java class which implements the \n" +
-        "org.apache.hadoop.hive.ql.stats.ClientStatsPublisher interface."),
-    EXECPARALLEL("hive.exec.parallel", false, "Whether to execute jobs in parallel"),
-    EXECPARALLETHREADNUMBER("hive.exec.parallel.thread.number", 8,
-        "How many jobs at most can be executed in parallel"),
-    HIVESPECULATIVEEXECREDUCERS("hive.mapred.reduce.tasks.speculative.execution", true,
-        "Whether speculative execution for reducers should be turned on. "),
-    HIVECOUNTERSPULLINTERVAL("hive.exec.counters.pull.interval", 1000L,
-        "The interval with which to poll the JobTracker for the counters the running job. \n" +
-        "The smaller it is the more load there will be on the jobtracker, the higher it is the less granular the caught will be."),
-    DYNAMICPARTITIONING("hive.exec.dynamic.partition", true,
-        "Whether or not to allow dynamic partitions in DML/DDL."),
-    DYNAMICPARTITIONINGMODE("hive.exec.dynamic.partition.mode", "strict",
-        "In strict mode, the user must specify at least one static partition\n" +
-        "in case the user accidentally overwrites all partitions.\n" +
-        "In nonstrict mode all partitions are allowed to be dynamic."),
-    DYNAMICPARTITIONMAXPARTS("hive.exec.max.dynamic.partitions", 1000,
-        "Maximum number of dynamic partitions allowed to be created in total."),
-    DYNAMICPARTITIONMAXPARTSPERNODE("hive.exec.max.dynamic.partitions.pernode", 100,
-        "Maximum number of dynamic partitions allowed to be created in each mapper/reducer node."),
-    MAXCREATEDFILES("hive.exec.max.created.files", 100000L,
-        "Maximum number of HDFS files created by all mappers/reducers in a MapReduce job."),
-    DEFAULTPARTITIONNAME("hive.exec.default.partition.name", "__HIVE_DEFAULT_PARTITION__",
-        "The default partition name in case the dynamic partition column value is null/empty string or any other values that cannot be escaped. \n" +
-        "This value must not contain any special character used in HDFS URI (e.g., ':', '%', '/' etc). \n" +
-        "The user has to be aware that the dynamic partition value should not contain this value to avoid confusions."),
-    DEFAULT_ZOOKEEPER_PARTITION_NAME("hive.lockmgr.zookeeper.default.partition.name", "__HIVE_DEFAULT_ZOOKEEPER_PARTITION__", ""),
-
-    // Whether to show a link to the most failed task + debugging tips
-    SHOW_JOB_FAIL_DEBUG_INFO("hive.exec.show.job.failure.debug.info", true,
-        "If a job fails, whether to provide a link in the CLI to the task with the\n" +
-        "most failures, along with debugging hints if applicable."),
-    JOB_DEBUG_CAPTURE_STACKTRACES("hive.exec.job.debug.capture.stacktraces", true,
-        "Whether or not stack traces parsed from the task logs of a sampled failed task \n" +
-        "for each failed job should be stored in the SessionState"),
-    JOB_DEBUG_TIMEOUT("hive.exec.job.debug.timeout", 30000, ""),
-    TASKLOG_DEBUG_TIMEOUT("hive.exec.tasklog.debug.timeout", 20000, ""),
-    OUTPUT_FILE_EXTENSION("hive.output.file.extension", null,
-        "String used as a file extension for output files. \n" +
-        "If not set, defaults to the codec extension for text files (e.g. \".gz\"), or no extension otherwise."),
-
-    HIVE_IN_TEST("hive.in.test", false, "internal usage only, true in test mode", true),
-
-    HIVE_IN_TEZ_TEST("hive.in.tez.test", false, "internal use only, true when in testing tez",
-        true),
-
-    LOCALMODEAUTO("hive.exec.mode.local.auto", false,
-        "Let Hive determine whether to run in local mode automatically"),
-    LOCALMODEMAXBYTES("hive.exec.mode.local.auto.inputbytes.max", 134217728L,
-        "When hive.exec.mode.local.auto is true, input bytes should less than this for local mode."),
-    LOCALMODEMAXINPUTFILES("hive.exec.mode.local.auto.input.files.max", 4,
-        "When hive.exec.mode.local.auto is true, the number of tasks should less than this for local mode."),
-
-    DROPIGNORESNONEXISTENT("hive.exec.drop.ignorenonexistent", true,
-        "Do not report an error if DROP TABLE/VIEW/Index/Function specifies a non-existent table/view/index/function"),
-
-    HIVEIGNOREMAPJOINHINT("hive.ignore.mapjoin.hint", true, "Ignore the mapjoin hint"),
-
-    HIVE_FILE_MAX_FOOTER("hive.file.max.footer", 100,
-        "maximum number of lines for footer user can define for a table file"),
-
-    HIVE_RESULTSET_USE_UNIQUE_COLUMN_NAMES("hive.resultset.use.unique.column.names", true,
-        "Make column names unique in the result set by qualifying column names with table alias if needed.\n" +
-        "Table alias will be added to column names for queries of type \"select *\" or \n" +
-        "if query explicitly uses table alias \"select r1.x..\"."),
-
-    // Hadoop Configuration Properties
-    // Properties with null values are ignored and exist only for the purpose of giving us
-    // a symbolic name to reference in the Hive source code. Properties with non-null
-    // values will override any values set in the underlying Hadoop configuration.
-    HADOOPBIN("hadoop.bin.path", findHadoopBinary(), "", true),
-    HIVE_FS_HAR_IMPL("fs.har.impl", "org.apache.hadoop.hive.shims.HiveHarFileSystem",
-        "The implementation for accessing Hadoop Archives. Note that this won't be applicable to Hadoop versions less than 0.20"),
-    HADOOPFS(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPFS"), null, "", true),
-    HADOOPMAPFILENAME(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPMAPFILENAME"), null, "", true),
-    HADOOPMAPREDINPUTDIR(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPMAPREDINPUTDIR"), null, "", true),
-    HADOOPMAPREDINPUTDIRRECURSIVE(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPMAPREDINPUTDIRRECURSIVE"), false, "", true),
-    MAPREDMAXSPLITSIZE(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMAXSPLITSIZE"), 256000000L, "", true),
-    MAPREDMINSPLITSIZE(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMINSPLITSIZE"), 1L, "", true),
-    MAPREDMINSPLITSIZEPERNODE(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMINSPLITSIZEPERNODE"), 1L, "", true),
-    MAPREDMINSPLITSIZEPERRACK(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMINSPLITSIZEPERRACK"), 1L, "", true),
-    // The number of reduce tasks per job. Hadoop sets this value to 1 by default
-    // By setting this property to -1, Hive will automatically determine the correct
-    // number of reducers.
-    HADOOPNUMREDUCERS(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPNUMREDUCERS"), -1, "", true),
-    HADOOPJOBNAME(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPJOBNAME"), null, "", true),
-    HADOOPSPECULATIVEEXECREDUCERS(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPSPECULATIVEEXECREDUCERS"), true, "", true),
-    MAPREDSETUPCLEANUPNEEDED(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDSETUPCLEANUPNEEDED"), false, "", true),
-    MAPREDTASKCLEANUPNEEDED(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDTASKCLEANUPNEEDED"), false, "", true),
-
-    // Metastore stuff. Be sure to update HiveConf.metaVars when you add something here!
-    METASTOREWAREHOUSE("hive.metastore.warehouse.dir", "/user/hive/warehouse",
-        "location of default database for the warehouse"),
-    METASTOREURIS("hive.metastore.uris", "",
-        "Thrift URI for the remote metastore. Used by metastore client to connect to remote metastore."),
-
-    METASTORETHRIFTCONNECTIONRETRIES("hive.metastore.connect.retries", 3,
-        "Number of retries while opening a connection to metastore"),
-    METASTORETHRIFTFAILURERETRIES("hive.metastore.failure.retries", 1,
-        "Number of retries upon failure of Thrift metastore calls"),
-
-    METASTORE_CLIENT_CONNECT_RETRY_DELAY("hive.metastore.client.connect.retry.delay", "1s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Number of seconds for the client to wait between consecutive connection attempts"),
-    METASTORE_CLIENT_SOCKET_TIMEOUT("hive.metastore.client.socket.timeout", "600s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "MetaStore Client socket timeout in seconds"),
-    METASTORE_CLIENT_SOCKET_LIFETIME("hive.metastore.client.socket.lifetime", "0s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "MetaStore Client socket lifetime in seconds. After this time is exceeded, client\n" +
-        "reconnects on the next MetaStore operation. A value of 0s means the connection\n" +
-        "has an infinite lifetime."),
-    METASTOREPWD("javax.jdo.option.ConnectionPassword", "mine",
-        "password to use against metastore database"),
-    METASTORECONNECTURLHOOK("hive.metastore.ds.connection.url.hook", "",
-        "Name of the hook to use for retrieving the JDO connection URL. If empty, the value in javax.jdo.option.ConnectionURL is used"),
-    METASTOREMULTITHREADED("javax.jdo.option.Multithreaded", true,
-        "Set this to true if multiple threads access metastore through JDO concurrently."),
-    METASTORECONNECTURLKEY("javax.jdo.option.ConnectionURL",
-        "jdbc:derby:;databaseName=metastore_db;create=true",
-        "JDBC connect string for a JDBC metastore"),
-    HMSHANDLERATTEMPTS("hive.hmshandler.retry.attempts", 10,
-        "The number of times to retry a HMSHandler call if there were a connection error."),
-    HMSHANDLERINTERVAL("hive.hmshandler.retry.interval", "2000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS), "The time between HMSHandler retry attempts on failure."),
-    HMSHANDLERFORCERELOADCONF("hive.hmshandler.force.reload.conf", false,
-        "Whether to force reloading of the HMSHandler configuration (including\n" +
-        "the connection URL, before the next metastore query that accesses the\n" +
-        "datastore. Once reloaded, this value is reset to false. Used for\n" +
-        "testing only."),
-    METASTORESERVERMAXMESSAGESIZE("hive.metastore.server.max.message.size", 100*1024*1024,
-        "Maximum message size in bytes a HMS will accept."),
-    METASTORESERVERMINTHREADS("hive.metastore.server.min.threads", 200,
-        "Minimum number of worker threads in the Thrift server's pool."),
-    METASTORESERVERMAXTHREADS("hive.metastore.server.max.threads", 1000,
-        "Maximum number of worker threads in the Thrift server's pool."),
-    METASTORE_TCP_KEEP_ALIVE("hive.metastore.server.tcp.keepalive", true,
-        "Whether to enable TCP keepalive for the metastore server. Keepalive will prevent accumulation of half-open connections."),
-
-    METASTORE_INT_ORIGINAL("hive.metastore.archive.intermediate.original",
-        "_INTERMEDIATE_ORIGINAL",
-        "Intermediate dir suffixes used for archiving. Not important what they\n" +
-        "are, as long as collisions are avoided"),
-    METASTORE_INT_ARCHIVED("hive.metastore.archive.intermediate.archived",
-        "_INTERMEDIATE_ARCHIVED", ""),
-    METASTORE_INT_EXTRACTED("hive.metastore.archive.intermediate.extracted",
-        "_INTERMEDIATE_EXTRACTED", ""),
-    METASTORE_KERBEROS_KEYTAB_FILE("hive.metastore.kerberos.keytab.file", "",
-        "The path to the Kerberos Keytab file containing the metastore Thrift server's service principal."),
-    METASTORE_KERBEROS_PRINCIPAL("hive.metastore.kerberos.principal",
-        "hive-metastore/_HOST@EXAMPLE.COM",
-        "The service principal for the metastore Thrift server. \n" +
-        "The special string _HOST will be replaced automatically with the correct host name."),
-    METASTORE_USE_THRIFT_SASL("hive.metastore.sasl.enabled", false,
-        "If true, the metastore Thrift interface will be secured with SASL. Clients must authenticate with Kerberos."),
-    METASTORE_USE_THRIFT_FRAMED_TRANSPORT("hive.metastore.thrift.framed.transport.enabled", false,
-        "If true, the metastore Thrift interface will use TFramedTransport. When false (default) a standard TTransport is used."),
-    METASTORE_USE_THRIFT_COMPACT_PROTOCOL("hive.metastore.thrift.compact.protocol.enabled", false,
-        "If true, the metastore Thrift interface will use TCompactProtocol. When false (default) TBinaryProtocol will be used.\n" +
-        "Setting it to true will break compatibility with older clients running TBinaryProtocol."),
-    METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_CLS("hive.cluster.delegation.token.store.class",
-        "org.apache.hadoop.hive.thrift.MemoryTokenStore",
-        "The delegation token store implementation. Set to org.apache.hadoop.hive.thrift.ZooKeeperTokenStore for load-balanced cluster."),
-    METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_ZK_CONNECTSTR(
-        "hive.cluster.delegation.token.store.zookeeper.connectString", "",
-        "The ZooKeeper token store connect string. You can re-use the configuration value\n" +
-        "set in hive.zookeeper.quorum, by leaving this parameter unset."),
-    METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_ZK_ZNODE(
-        "hive.cluster.delegation.token.store.zookeeper.znode", "/hivedelegation",
-        "The root path for token store data. Note that this is used by both HiveServer2 and\n" +
-        "MetaStore to store delegation Token. One directory gets created for each of them.\n" +
-        "The final directory names would have the servername appended to it (HIVESERVER2,\n" +
-        "METASTORE)."),
-    METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_ZK_ACL(
-        "hive.cluster.delegation.token.store.zookeeper.acl", "",
-        "ACL for token store entries. Comma separated list of ACL entries. For example:\n" +
-        "sasl:hive/host1@MY.DOMAIN:cdrwa,sasl:hive/host2@MY.DOMAIN:cdrwa\n" +
-        "Defaults to all permissions for the hiveserver2/metastore process user."),
-    METASTORE_CACHE_PINOBJTYPES("hive.metastore.cache.pinobjtypes", "Table,StorageDescriptor,SerDeInfo,Partition,Database,Type,FieldSchema,Order",
-        "List of comma separated metastore object types that should be pinned in the cache"),
-    METASTORE_CONNECTION_POOLING_TYPE("datanucleus.connectionPoolingType", "BONECP",
-        "Specify connection pool library for datanucleus"),
-    METASTORE_VALIDATE_TABLES("datanucleus.validateTables", false,
-        "validates existing schema against code. turn this on if you want to verify existing schema"),
-    METASTORE_VALIDATE_COLUMNS("datanucleus.validateColumns", false,
-        "validates existing schema against code. turn this on if you want to verify existing schema"),
-    METASTORE_VALIDATE_CONSTRAINTS("datanucleus.validateConstraints", false,
-        "validates existing schema against code. turn this on if you want to verify existing schema"),
-    METASTORE_STORE_MANAGER_TYPE("datanucleus.storeManagerType", "rdbms", "metadata store type"),
-    METASTORE_AUTO_CREATE_SCHEMA("datanucleus.autoCreateSchema", true,
-        "creates necessary schema on a startup if one doesn't exist. set this to false, after creating it once"),
-    METASTORE_FIXED_DATASTORE("datanucleus.fixedDatastore", false, ""),
-    METASTORE_SCHEMA_VERIFICATION("hive.metastore.schema.verification", false,
-        "Enforce metastore schema version consistency.\n" +
-        "True: Verify that version information stored in metastore matches with one from Hive jars.  Also disable automatic\n" +
-        "      schema migration attempt. Users are required to manually migrate schema after Hive upgrade which ensures\n" +
-        "      proper metastore schema migration. (Default)\n" +
-        "False: Warn if the version information stored in metastore doesn't match with one from in Hive jars."),
-    METASTORE_SCHEMA_VERIFICATION_RECORD_VERSION("hive.metastore.schema.verification.record.version", true,
-      "When true the current MS version is recorded in the VERSION table. If this is disabled and verification is\n" +
-      " enabled the MS will be unusable."),
-    METASTORE_AUTO_START_MECHANISM_MODE("datanucleus.autoStartMechanismMode", "checked",
-        "throw exception if metadata tables are incorrect"),
-    METASTORE_TRANSACTION_ISOLATION("datanucleus.transactionIsolation", "read-committed",
-        "Default transaction isolation level for identity generation."),
-    METASTORE_CACHE_LEVEL2("datanucleus.cache.level2", false,
-        "Use a level 2 cache. Turn this off if metadata is changed independently of Hive metastore server"),
-    METASTORE_CACHE_LEVEL2_TYPE("datanucleus.cache.level2.type", "none", ""),
-    METASTORE_IDENTIFIER_FACTORY("datanucleus.identifierFactory", "datanucleus1",
-        "Name of the identifier factory to use when generating table/column names etc. \n" +
-        "'datanucleus1' is used for backward compatibility with DataNucleus v1"),
-    METASTORE_USE_LEGACY_VALUE_STRATEGY("datanucleus.rdbms.useLegacyNativeValueStrategy", true, ""),
-    METASTORE_PLUGIN_REGISTRY_BUNDLE_CHECK("datanucleus.plugin.pluginRegistryBundleCheck", "LOG",
-        "Defines what happens when plugin bundles are found and are duplicated [EXCEPTION|LOG|NONE]"),
-    METASTORE_BATCH_RETRIEVE_MAX("hive.metastore.batch.retrieve.max", 300,
-        "Maximum number of objects (tables/partitions) can be retrieved from metastore in one batch. \n" +
-        "The higher the number, the less the number of round trips is needed to the Hive metastore server, \n" +
-        "but it may also cause higher memory requirement at the client side."),
-    METASTORE_BATCH_RETRIEVE_TABLE_PARTITION_MAX(
-        "hive.metastore.batch.retrieve.table.partition.max", 1000,
-        "Maximum number of table partitions that metastore internally retrieves in one batch."),
-
-    METASTORE_INIT_HOOKS("hive.metastore.init.hooks", "",
-        "A comma separated list of hooks to be invoked at the beginning of HMSHandler initialization. \n" +
-        "An init hook is specified as the name of Java class which extends org.apache.hadoop.hive.metastore.MetaStoreInitListener."),
-    METASTORE_PRE_EVENT_LISTENERS("hive.metastore.pre.event.listeners", "",
-        "List of comma separated listeners for metastore events."),
-    METASTORE_EVENT_LISTENERS("hive.metastore.event.listeners", "", ""),
-    METASTORE_EVENT_DB_LISTENER_TTL("hive.metastore.event.db.listener.timetolive", "86400s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "time after which events will be removed from the database listener queue"),
-    METASTORE_AUTHORIZATION_STORAGE_AUTH_CHECKS("hive.metastore.authorization.storage.checks", false,
-        "Should the metastore do authorization checks against the underlying storage (usually hdfs) \n" +
-        "for operations like drop-partition (disallow the drop-partition if the user in\n" +
-        "question doesn't have permissions to delete the corresponding directory\n" +
-        "on the storage)."),
-    METASTORE_EVENT_CLEAN_FREQ("hive.metastore.event.clean.freq", "0s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Frequency at which timer task runs to purge expired events in metastore."),
-    METASTORE_EVENT_EXPIRY_DURATION("hive.metastore.event.expiry.duration", "0s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Duration after which events expire from events table"),
-    METASTORE_EXECUTE_SET_UGI("hive.metastore.execute.setugi", true,
-        "In unsecure mode, setting this property to true will cause the metastore to execute DFS operations using \n" +
-        "the client's reported user and group permissions. Note that this property must be set on \n" +
-        "both the client and server sides. Further note that its best effort. \n" +
-        "If client sets its to true and server sets it to false, client setting will be ignored."),
-    METASTORE_PARTITION_NAME_WHITELIST_PATTERN("hive.metastore.partition.name.whitelist.pattern", "",
-        "Partition names will be checked against this regex pattern and rejected if not matched."),
-
-    METASTORE_INTEGER_JDO_PUSHDOWN("hive.metastore.integral.jdo.pushdown", false,
-        "Allow JDO query pushdown for integral partition columns in metastore. Off by default. This\n" +
-        "improves metastore perf for integral columns, especially if there's a large number of partitions.\n" +
-        "However, it doesn't work correctly with integral values that are not normalized (e.g. have\n" +
-        "leading zeroes, like 0012). If metastore direct SQL is enabled and works, this optimization\n" +
-        "is also irrelevant."),
-    METASTORE_TRY_DIRECT_SQL("hive.metastore.try.direct.sql", true,
-        "Whether the Hive metastore should try to use direct SQL queries instead of the\n" +
-        "DataNucleus for certain read paths. This can improve metastore performance when\n" +
-        "fetching many partitions or column statistics by orders of magnitude; however, it\n" +
-        "is not guaranteed to work on all RDBMS-es and all versions. In case of SQL failures,\n" +
-        "the metastore will fall back to the DataNucleus, so it's safe even if SQL doesn't\n" +
-        "work for all queries on your datastore. If all SQL queries fail (for example, your\n" +
-        "metastore is backed by MongoDB), you might want to disable this to save the\n" +
-        "try-and-fall-back cost."),
-    METASTORE_DIRECT_SQL_PARTITION_BATCH_SIZE("hive.metastore.direct.sql.batch.size", 0,
-        "Batch size for partition and other object retrieval from the underlying DB in direct\n" +
-        "SQL. For some DBs like Oracle and MSSQL, there are hardcoded or perf-based limitations\n" +
-        "that necessitate this. For DBs that can handle the queries, this isn't necessary and\n" +
-        "may impede performance. -1 means no batching, 0 means automatic batching."),
-    METASTORE_TRY_DIRECT_SQL_DDL("hive.metastore.try.direct.sql.ddl", true,
-        "Same as hive.metastore.try.direct.sql, for read statements within a transaction that\n" +
-        "modifies metastore data. Due to non-standard behavior in Postgres, if a direct SQL\n" +
-        "select query has incorrect syntax or something similar inside a transaction, the\n" +
-        "entire transaction will fail and fall-back to DataNucleus will not be possible. You\n" +
-        "should disable the usage of direct SQL inside transactions if that happens in your case."),
-    METASTORE_ORM_RETRIEVE_MAPNULLS_AS_EMPTY_STRINGS("hive.metastore.orm.retrieveMapNullsAsEmptyStrings",false,
-        "Thrift does not support nulls in maps, so any nulls present in maps retrieved from ORM must " +
-        "either be pruned or converted to empty strings. Some backing dbs such as Oracle persist empty strings " +
-        "as nulls, so we should set this parameter if we wish to reverse that behaviour. For others, " +
-        "pruning is the correct behaviour"),
-    METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES(
-        "hive.metastore.disallow.incompatible.col.type.changes", false,
-        "If true (default is false), ALTER TABLE operations which change the type of a\n" +
-        "column (say STRING) to an incompatible type (say MAP) are disallowed.\n" +
-        "RCFile default SerDe (ColumnarSerDe) serializes the values in such a way that the\n" +
-        "datatypes can be converted from string to any type. The map is also serialized as\n" +
-        "a string, which can be read as a string as well. However, with any binary\n" +
-        "serialization, this is not true. Blocking the ALTER TABLE prevents ClassCastExceptions\n" +
-        "when subsequently trying to access old partitions.\n" +
-        "\n" +
-        "Primitive types like INT, STRING, BIGINT, etc., are compatible with each other and are\n" +
-        "not blocked.\n" +
-        "\n" +
-        "See HIVE-4409 for more details."),
-
-    NEWTABLEDEFAULTPARA("hive.table.parameters.default", "",
-        "Default property values for newly created tables"),
-    DDL_CTL_PARAMETERS_WHITELIST("hive.ddl.createtablelike.properties.whitelist", "",
-        "Table Properties to copy over when executing a Create Table Like."),
-    METASTORE_RAW_STORE_IMPL("hive.metastore.rawstore.impl", "org.apache.hadoop.hive.metastore.ObjectStore",
-        "Name of the class that implements org.apache.hadoop.hive.metastore.rawstore interface. \n" +
-        "This class is used to store and retrieval of raw metadata objects such as table, database"),
-    METASTORE_CONNECTION_DRIVER("javax.jdo.option.ConnectionDriverName", "org.apache.derby.jdbc.EmbeddedDriver",
-        "Driver class name for a JDBC metastore"),
-    METASTORE_MANAGER_FACTORY_CLASS("javax.jdo.PersistenceManagerFactoryClass",
-        "org.datanucleus.api.jdo.JDOPersistenceManagerFactory",
-        "class implementing the jdo persistence"),
-    METASTORE_EXPRESSION_PROXY_CLASS("hive.metastore.expression.proxy",
-        "org.apache.hadoop.hive.ql.optimizer.ppr.PartitionExpressionForMetastore", ""),
-    METASTORE_DETACH_ALL_ON_COMMIT("javax.jdo.option.DetachAllOnCommit", true,
-        "Detaches all objects from session so that they can be used after transaction is committed"),
-    METASTORE_NON_TRANSACTIONAL_READ("javax.jdo.option.NonTransactionalRead", true,
-        "Reads outside of transactions"),
-    METASTORE_CONNECTION_USER_NAME("javax.jdo.option.ConnectionUserName", "APP",
-        "Username to use against metastore database"),
-    METASTORE_END_FUNCTION_LISTENERS("hive.metastore.end.function.listeners", "",
-        "List of comma separated listeners for the end of metastore functions."),
-    METASTORE_PART_INHERIT_TBL_PROPS("hive.metastore.partition.inherit.table.properties", "",
-        "List of comma separated keys occurring in table properties which will get inherited to newly created partitions. \n" +
-        "* implies all the keys will get inherited."),
-    METASTORE_FILTER_HOOK("hive.metastore.filter.hook", "org.apache.hadoop.hive.metastore.DefaultMetaStoreFilterHookImpl",
-        "Metastore hook class for filtering the metadata read results. If hive.security.authorization.manager"
-        + "is set to instance of HiveAuthorizerFactory, then this value is ignored."),
-    FIRE_EVENTS_FOR_DML("hive.metastore.dml.events", false, "If true, the metastore will be asked" +
-        " to fire events for DML operations"),
-    METASTORE_CLIENT_DROP_PARTITIONS_WITH_EXPRESSIONS("hive.metastore.client.drop.partitions.using.expressions", true,
-        "Choose whether dropping partitions with HCatClient pushes the partition-predicate to the metastore, " +
-            "or drops partitions iteratively"),
-
-    METASTORE_AGGREGATE_STATS_CACHE_ENABLED("hive.metastore.aggregate.stats.cache.enabled", true,
-        "Whether aggregate stats caching is enabled or not."),
-    METASTORE_AGGREGATE_STATS_CACHE_SIZE("hive.metastore.aggregate.stats.cache.size", 10000,
-        "Maximum number of aggregate stats nodes that we will place in the metastore aggregate stats cache."),
-    METASTORE_AGGREGATE_STATS_CACHE_MAX_PARTITIONS("hive.metastore.aggregate.stats.cache.max.partitions", 10000,
-        "Maximum number of partitions that are aggregated per cache node."),
-    METASTORE_AGGREGATE_STATS_CACHE_FPP("hive.metastore.aggregate.stats.cache.fpp", (float) 0.01,
-        "Maximum false positive probability for the Bloom Filter used in each aggregate stats cache node (default 1%)."),
-    METASTORE_AGGREGATE_STATS_CACHE_MAX_VARIANCE("hive.metastore.aggregate.stats.cache.max.variance", (float) 0.01,
-        "Maximum tolerable variance in number of partitions between a cached node and our request (default 1%)."),
-    METASTORE_AGGREGATE_STATS_CACHE_TTL("hive.metastore.aggregate.stats.cache.ttl", "600s", new TimeValidator(TimeUnit.SECONDS),
-        "Number of seconds for a cached node to be active in the cache before they become stale."),
-    METASTORE_AGGREGATE_STATS_CACHE_MAX_WRITER_WAIT("hive.metastore.aggregate.stats.cache.max.writer.wait", "5000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Number of milliseconds a writer will wait to acquire the writelock before giving up."),
-    METASTORE_AGGREGATE_STATS_CACHE_MAX_READER_WAIT("hive.metastore.aggregate.stats.cache.max.reader.wait", "1000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Number of milliseconds a reader will wait to acquire the readlock before giving up."),
-    METASTORE_AGGREGATE_STATS_CACHE_MAX_FULL("hive.metastore.aggregate.stats.cache.max.full", (float) 0.9,
-        "Maximum cache full % after which the cache cleaner thread kicks in."),
-    METASTORE_AGGREGATE_STATS_CACHE_CLEAN_UNTIL("hive.metastore.aggregate.stats.cache.clean.until", (float) 0.8,
-        "The cleaner thread cleans until cache reaches this % full size."),
-
-    // Parameters for exporting metadata on table drop (requires the use of the)
-    // org.apache.hadoop.hive.ql.parse.MetaDataExportListener preevent listener
-    METADATA_EXPORT_LOCATION("hive.metadata.export.location", "",
-        "When used in conjunction with the org.apache.hadoop.hive.ql.parse.MetaDataExportListener pre event listener, \n" +
-        "it is the location to which the metadata will be exported. The default is an empty string, which results in the \n" +
-        "metadata being exported to the current user's home directory on HDFS."),
-    MOVE_EXPORTED_METADATA_TO_TRASH("hive.metadata.move.exported.metadata.to.trash", true,
-        "When used in conjunction with the org.apache.hadoop.hive.ql.parse.MetaDataExportListener pre event listener, \n" +
-        "this setting determines if the metadata that is exported will subsequently be moved to the user's trash directory \n" +
-        "alongside the dropped table data. This ensures that the metadata will be cleaned up along with the dropped table data."),
-
-    // CLI
-    CLIIGNOREERRORS("hive.cli.errors.ignore", false, ""),
-    CLIPRINTCURRENTDB("hive.cli.print.current.db", false,
-        "Whether to include the current database in the Hive prompt."),
-    CLIPROMPT("hive.cli.prompt", "hive",
-        "Command line prompt configuration value. Other hiveconf can be used in this configuration value. \n" +
-        "Variable substitution will only be invoked at the Hive CLI startup."),
-    CLIPRETTYOUTPUTNUMCOLS("hive.cli.pretty.output.num.cols", -1,
-        "The number of columns to use when formatting output generated by the DESCRIBE PRETTY table_name command.\n" +
-        "If the value of this property is -1, then Hive will use the auto-detected terminal width."),
-
-    HIVE_METASTORE_FS_HANDLER_CLS("hive.metastore.fs.handler.class", "org.apache.hadoop.hive.metastore.HiveMetaStoreFsImpl", ""),
-
-    // Things we log in the jobconf
-
-    // session identifier
-    HIVESESSIONID("hive.session.id", "", ""),
-    // whether session is running in silent mode or not
-    HIVESESSIONSILENT("hive.session.silent", false, ""),
-
-    HIVE_SESSION_HISTORY_ENABLED("hive.session.history.enabled", false,
-        "Whether to log Hive query, query plan, runtime statistics etc."),
-
-    HIVEQUERYSTRING("hive.query.string", "",
-        "Query being executed (might be multiple per a session)"),
-
-    HIVEQUERYID("hive.query.id", "",
-        "ID for query being executed (might be multiple per a session)"),
-
-    HIVEJOBNAMELENGTH("hive.jobname.length", 50, "max jobname length"),
-
-    // hive jar
-    HIVEJAR("hive.jar.path", "",
-        "The location of hive_cli.jar that is used when submitting jobs in a separate jvm."),
-    HIVEAUXJARS("hive.aux.jars.path", "",
-        "The location of the plugin jars that contain implementations of user defined functions and serdes."),
-
-    // reloadable jars
-    HIVERELOADABLEJARS("hive.reloadable.aux.jars.path", "",
-        "Jars can be renewed by executing reload command. And these jars can be "
-            + "used as the auxiliary classes like creating a UDF or SerDe."),
-
-    // hive added files and jars
-    HIVEADDEDFILES("hive.added.files.path", "", "This an internal parameter."),
-    HIVEADDEDJARS("hive.added.jars.path", "", "This an internal parameter."),
-    HIVEADDEDARCHIVES("hive.added.archives.path", "", "This an internal parameter."),
-
-    HIVE_CURRENT_DATABASE("hive.current.database", "", "Database name used by current session. Internal usage only.", true),
-
-    // for hive script operator
-    HIVES_AUTO_PROGRESS_TIMEOUT("hive.auto.progress.timeout", "0s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "How long to run autoprogressor for the script/UDTF operators.\n" +
-        "Set to 0 for forever."),
-    HIVESCRIPTAUTOPROGRESS("hive.script.auto.progress", false,
-        "Whether Hive Transform/Map/Reduce Clause should automatically send progress information to TaskTracker \n" +
-        "to avoid the task getting killed because of inactivity.  Hive sends progress information when the script is \n" +
-        "outputting to stderr.  This option removes the need of periodically producing stderr messages, \n" +
-        "but users should be cautious because this may prevent infinite loops in the scripts to be killed by TaskTracker."),
-    HIVESCRIPTIDENVVAR("hive.script.operator.id.env.var", "HIVE_SCRIPT_OPERATOR_ID",
-        "Name of the environment variable that holds the unique script operator ID in the user's \n" +
-        "transform function (the custom mapper/reducer that the user has specified in the query)"),
-    HIVESCRIPTTRUNCATEENV("hive.script.operator.truncate.env", false,
-        "Truncate each environment variable for external script in scripts operator to 20KB (to fit system limits)"),
-    HIVESCRIPT_ENV_BLACKLIST("hive.script.operator.env.blacklist",
-        "hive.txn.valid.txns,hive.script.operator.env.blacklist",
-        "Comma separated list of keys from the configuration file not to convert to environment " +
-        "variables when envoking the script operator"),
-    HIVEMAPREDMODE("hive.mapred.mode", "nonstrict",
-        "The mode in which the Hive operations are being performed. \n" +
-        "In strict mode, some risky queries are not allowed to run. They include:\n" +
-        "  Cartesian Product.\n" +
-        "  No partition being picked up for a query.\n" +
-        "  Comparing bigints and strings.\n" +
-        "  Comparing bigints and doubles.\n" +
-        "  Orderby without limit."),
-    HIVEALIAS("hive.alias", "", ""),
-    HIVEMAPSIDEAGGREGATE("hive.map.aggr", true, "Whether to use map-side aggregation in Hive Group By queries"),
-    HIVEGROUPBYSKEW("hive.groupby.skewindata", false, "Whether there is skew in data to optimize group by queries"),
-    HIVEJOINEMITINTERVAL("hive.join.emit.interval", 1000,
-        "How many rows in the right-most join operand Hive should buffer before emitting the join result."),
-    HIVEJOINCACHESIZE("hive.join.cache.size", 25000,
-        "How many rows in the joining tables (except the streaming table) should be cached in memory."),
-
-    // CBO related
-    HIVE_CBO_ENABLED("hive.cbo.enable", true, "Flag to control enabling Cost Based Optimizations using Calcite framework."),
-    HIVE_CBO_RETPATH_HIVEOP("hive.cbo.returnpath.hiveop", false, "Flag to control calcite plan to hive operator conversion"),
-    HIVE_CBO_EXTENDED_COST_MODEL("hive.cbo.costmodel.extended", false, "Flag to control enabling the extended cost model based on"
-                                 + "CPU, IO and cardinality. Otherwise, the cost model is based on cardinality."),
-    HIVE_CBO_COST_MODEL_CPU("hive.cbo.costmodel.cpu", "0.000001", "Default cost of a comparison"),
-    HIVE_CBO_COST_MODEL_NET("hive.cbo.costmodel.network", "150.0", "Default cost of a transfering a byte over network;"
-                                                                  + " expressed as multiple of CPU cost"),
-    HIVE_CBO_COST_MODEL_LFS_WRITE("hive.cbo.costmodel.local.fs.write", "4.0", "Default cost of writing a byte to local FS;"
-                                                                             + " expressed as multiple of NETWORK cost"),
-    HIVE_CBO_COST_MODEL_LFS_READ("hive.cbo.costmodel.local.fs.read", "4.0", "Default cost of reading a byte from local FS;"
-                                                                           + " expressed as multiple of NETWORK cost"),
-    HIVE_CBO_COST_MODEL_HDFS_WRITE("hive.cbo.costmodel.hdfs.write", "10.0", "Default cost of writing a byte to HDFS;"
-                                                                 + " expressed as multiple of Local FS write cost"),
-    HIVE_CBO_COST_MODEL_HDFS_READ("hive.cbo.costmodel.hdfs.read", "1.5", "Default cost of reading a byte from HDFS;"
-                                                                 + " expressed as multiple of Local FS read cost"),
-
-
-    // hive.mapjoin.bucket.cache.size has been replaced by hive.smbjoin.cache.row,
-    // need to remove by hive .13. Also, do not change default (see SMB operator)
-    HIVEMAPJOINBUCKETCACHESIZE("hive.mapjoin.bucket.cache.size", 100, ""),
-
-    HIVEMAPJOINUSEOPTIMIZEDTABLE("hive.mapjoin.optimized.hashtable", true,
-        "Whether Hive should use memory-optimized hash table for MapJoin. Only works on Tez,\n" +
-        "because memory-optimized hashtable cannot be serialized."),
-    HIVEUSEHYBRIDGRACEHASHJOIN("hive.mapjoin.hybridgrace.hashtable", true, "Whether to use hybrid" +
-        "grace hash join as the join method for mapjoin. Tez only."),
-    HIVEHYBRIDGRACEHASHJOINMEMCHECKFREQ("hive.mapjoin.hybridgrace.memcheckfrequency", 1024, "For " +
-        "hybrid grace hash join, how often (how many rows apart) we check if memory is full. " +
-        "This number should be power of 2."),
-    HIVEHYBRIDGRACEHASHJOINMINWBSIZE("hive.mapjoin.hybridgrace.minwbsize", 524288, "For hybrid grace" +
-        " hash join, the minimum write buffer size used by optimized hashtable. Default is 512 KB."),
-    HIVEHYBRIDGRACEHASHJOINMINNUMPARTITIONS("hive.mapjoin.hybridgrace.minnumpartitions", 16, "For" +
-        " hybrid grace hash join, the minimum number of partitions to create."),
-    HIVEHASHTABLEWBSIZE("hive.mapjoin.optimized.hashtable.wbsize", 10 * 1024 * 1024,
-        "Optimized hashtable (see hive.mapjoin.optimized.hashtable) uses a chain of buffers to\n" +
-        "store data. This is one buffer size. HT may be slightly faster if this is larger, but for small\n" +
-        "joins unnecessary memory will be allocated and then trimmed."),
-
-    HIVESMBJOINCACHEROWS("hive.smbjoin.cache.rows", 10000,
-        "How many rows with the same key value should be cached in memory per smb joined table."),
-    HIVEGROUPBYMAPINTERVAL("hive.groupby.mapaggr.checkinterval", 100000,
-        "Number of rows after which size of the grouping keys/aggregation classes is performed"),
-    HIVEMAPAGGRHASHMEMORY("hive.map.aggr.hash.percentmemory", (float) 0.5,
-        "Portion of total memory to be used by map-side group aggregation hash table"),
-    HIVEMAPJOINFOLLOWEDBYMAPAGGRHASHMEMORY("hive.mapjoin.followby.map.aggr.hash.percentmemory", (float) 0.3,
-        "Portion of total memory to be used by map-side group aggregation hash table, when this group by is followed by map join"),
-    HIVEMAPAGGRMEMORYTHRESHOLD("hive.map.aggr.hash.force.flush.memory.threshold", (float) 0.9,
-        "The max memory to be used by map-side group aggregation hash table.\n" +
-        "If the memory usage is higher than this number, force to flush data"),
-    HIVEMAPAGGRHASHMINREDUCTION("hive.map.aggr.hash.min.reduction", (float) 0.5,
-        "Hash aggregation will be turned off if the ratio between hash  table size and input rows is bigger than this number. \n" +
-        "Set to 1 to make sure hash aggregation is never turned off."),
-    HIVEMULTIGROUPBYSINGLEREDUCER("hive.multigroupby.singlereducer", true,
-        "Whether to optimize multi group by query to generate single M/R  job plan. If the multi group by query has \n" +
-        "common group by keys, it will be optimized to generate single M/R job."),
-    HIVE_MAP_GROUPBY_SORT("hive.map.groupby.sorted", false,
-        "If the bucketing/sorting properties of the table exactly match the grouping key, whether to perform \n" +
-        "the group by in the mapper by using BucketizedHiveInputFormat. The only downside to this\n" +
-        "is that it limits the number of mappers to the number of files."),
-    HIVE_MAP_GROUPBY_SORT_TESTMODE("hive.map.groupby.sorted.testmode", false,
-        "If the bucketing/sorting properties of the table exactly match the grouping key, whether to perform \n" +
-        "the group by in the mapper by using BucketizedHiveInputFormat. If the test mode is set, the plan\n" +
-        "is not converted, but a query property is set to denote the same."),
-    HIVE_GROUPBY_ORDERBY_POSITION_ALIAS("hive.groupby.orderby.position.alias", false,
-        "Whether to enable using Column Position Alias in Group By or Order By"),
-    HIVE_NEW_JOB_GROUPING_SET_CARDINALITY("hive.new.job.grouping.set.cardinality", 30,
-        "Whether a new map-reduce job should be launched for grouping sets/rollups/cubes.\n" +
-        "For a query like: select a, b, c, count(1) from T group by a, b, c with rollup;\n" +
-        "4 rows are created per row: (a, b, c), (a, b, null), (a, null, null), (null, null, null).\n" +
-        "This can lead to explosion across map-reduce boundary if the cardinality of T is very high,\n" +
-        "and map-side aggregation does not do a very good job. \n" +
-        "\n" +
-        "This parameter decides if Hive should add an additional map-reduce job. If the grouping set\n" +
-        "cardinality (4 in the example above), is more than this value, a new MR job is added under the\n" +
-        "assumption that the original group by will reduce the data size."),
-
-    // Max filesize used to do a single copy (after that, distcp is used)
-    HIVE_EXEC_COPYFILE_MAXSIZE("hive.exec.copyfile.maxsize", 32L * 1024 * 1024 /*32M*/,
-        "Maximum file size (in Mb) that Hive uses to do single HDFS copies between directories." +
-        "Distributed copies (distcp) will be used instead for bigger files so that copies can be done faster."),
-
-    // for hive udtf operator
-    HIVEUDTFAUTOPROGRESS("hive.udtf.auto.progress", false,
-        "Whether Hive should automatically send progress information to TaskTracker \n" +
-        "when using UDTF's to prevent the task getting killed because of inactivity.  Users should be cautious \n" +
-        "because this may prevent TaskTracker from killing tasks with infinite loops."),
-
-    HIVEDEFAULTFILEFORMAT("hive.default.fileformat", "TextFile", new StringSet("TextFile", "SequenceFile", "RCfile", "ORC"),
-        "Default file format for CREATE TABLE statement. Users can explicitly override it by CREATE TABLE ... STORED AS [FORMAT]"),
-    HIVEDEFAULTMANAGEDFILEFORMAT("hive.default.fileformat.managed", "none",
-	new StringSet("none", "TextFile", "SequenceFile", "RCfile", "ORC"),
-	"Default file format for CREATE TABLE statement applied to managed tables only. External tables will be \n" +
-	"created with format specified by hive.default.fileformat. Leaving this null will result in using hive.default.fileformat \n" +
-	"for all tables."),
-    HIVEQUERYRESULTFILEFORMAT("hive.query.result.fileformat", "TextFile", new StringSet("TextFile", "SequenceFile", "RCfile"),
-        "Default file format for storing result of the query."),
-    HIVECHECKFILEFORMAT("hive.fileformat.check", true, "Whether to check file format or not when loading data files"),
-
-    // default serde for rcfile
-    HIVEDEFAULTRCFILESERDE("hive.default.rcfile.serde",
-        "org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe",
-        "The default SerDe Hive will use for the RCFile format"),
-
-    HIVEDEFAULTSERDE("hive.default.serde",
-        "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-        "The default SerDe Hive will use for storage formats that do not specify a SerDe."),
-
-    SERDESUSINGMETASTOREFORSCHEMA("hive.serdes.using.metastore.for.schema",
-        "org.apache.hadoop.hive.ql.io.orc.OrcSerde,org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe," +
-        "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe,org.apache.hadoop.hive.serde2.dynamic_type.DynamicSerDe," +
-        "org.apache.hadoop.hive.serde2.MetadataTypedColumnsetSerDe,org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe," +
-        "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe,org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe",
-        "SerDes retriving schema from metastore. This an internal parameter. Check with the hive dev. team"),
-
-    HIVEHISTORYFILELOC("hive.querylog.location",
-        "${system:java.io.tmpdir}" + File.separator + "${system:user.name}",
-        "Location of Hive run time structured log file"),
-
-    HIVE_LOG_INCREMENTAL_PLAN_PROGRESS("hive.querylog.enable.plan.progress", true,
-        "Whether to log the plan's progress every time a job's progress is checked.\n" +
-        "These logs are written to the location specified by hive.querylog.location"),
-
-    HIVE_LOG_INCREMENTAL_PLAN_PROGRESS_INTERVAL("hive.querylog.plan.progress.interval", "60000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "The interval to wait between logging the plan's progress.\n" +
-        "If there is a whole number percentage change in the progress of the mappers or the reducers,\n" +
-        "the progress is logged regardless of this value.\n" +
-        "The actual interval will be the ceiling of (this value divided by the value of\n" +
-        "hive.exec.counters.pull.interval) multiplied by the value of hive.exec.counters.pull.interval\n" +
-        "I.e. if it is not divide evenly by the value of hive.exec.counters.pull.interval it will be\n" +
-        "logged less frequently than specified.\n" +
-        "This only has an effect if hive.querylog.enable.plan.progress is set to true."),
-
-    HIVESCRIPTSERDE("hive.script.serde", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-        "The default SerDe for transmitting input data to and reading output data from the user scripts. "),
-    HIVESCRIPTRECORDREADER("hive.script.recordreader",
-        "org.apache.hadoop.hive.ql.exec.TextRecordReader",
-        "The default record reader for reading data from the user scripts. "),
-    HIVESCRIPTRECORDWRITER("hive.script.recordwriter",
-        "org.apache.hadoop.hive.ql.exec.TextRecordWriter",
-        "The default record writer for writing data to the user scripts. "),
-    HIVESCRIPTESCAPE("hive.transform.escape.input", false,
-        "This adds an option to escape special chars (newlines, carriage returns and\n" +
-        "tabs) when they are passed to the user script. This is useful if the Hive tables\n" +
-        "can contain data that contains special characters."),
-    HIVEBINARYRECORDMAX("hive.binary.record.max.length", 1000,
-        "Read from a binary stream and treat each hive.binary.record.max.length bytes as a record. \n" +
-        "The last record before the end of stream can have less than hive.binary.record.max.length bytes"),
-
-    // HWI
-    HIVEHWILISTENHOST("hive.hwi.listen.host", "0.0.0.0", "This is the host address the Hive Web Interface will listen on"),
-    HIVEHWILISTENPORT("hive.hwi.listen.port", "9999", "This is the port the Hive Web Interface will listen on"),
-    HIVEHWIWARFILE("hive.hwi.war.file", "${env:HWI_WAR_FILE}",
-        "This sets the path to the HWI war file, relative to ${HIVE_HOME}. "),
-
-    HIVEHADOOPMAXMEM("hive.mapred.local.mem", 0, "mapper/reducer memory in local mode"),
-
-    //small table file size
-    HIVESMALLTABLESFILESIZE("hive.mapjoin.smalltable.filesize", 25000000L,
-        "The threshold for the input file size of the small tables; if the file size is smaller \n" +
-        "than this threshold, it will try to convert the common join into map join"),
-
-    HIVESAMPLERANDOMNUM("hive.sample.seednumber", 0,
-        "A number used to percentage sampling. By changing this number, user will change the subsets of data sampled."),
-
-    // test mode in hive mode
-    HIVETESTMODE("hive.test.mode", false,
-        "Whether Hive is running in test mode. If yes, it turns on sampling and prefixes the output tablename.",
-        false),
-    HIVETESTMODEPREFIX("hive.test.mode.prefix", "test_",
-        "In test mode, specfies prefixes for the output table", false),
-    HIVETESTMODESAMPLEFREQ("hive.test.mode.samplefreq", 32,
-        "In test mode, specfies sampling frequency for table, which is not bucketed,\n" +
-        "For example, the following query:\n" +
-        "  INSERT OVERWRITE TABLE dest SELECT col1 from src\n" +
-        "would be converted to\n" +
-        "  INSERT OVERWRITE TABLE test_dest\n" +
-        "  SELECT col1 from src TABLESAMPLE (BUCKET 1 out of 32 on rand(1))", false),
-    HIVETESTMODENOSAMPLE("hive.test.mode.nosamplelist", "",
-        "In test mode, specifies comma separated table names which would not apply sampling", false),
-    HIVETESTMODEDUMMYSTATAGGR("hive.test.dummystats.aggregator", "", "internal variable for test", false),
-    HIVETESTMODEDUMMYSTATPUB("hive.test.dummystats.publisher", "", "internal variable for test", false),
-    HIVETESTCURRENTTIMESTAMP("hive.test.currenttimestamp", null, "current timestamp for test", false),
-
-    HIVEMERGEMAPFILES("hive.merge.mapfiles", true,
-        "Merge small files at the end of a map-only job"),
-    HIVEMERGEMAPREDFILES("hive.merge.mapredfiles", false,
-        "Merge small files at the end of a map-reduce job"),
-    HIVEMERGETEZFILES("hive.merge.tezfiles", false, "Merge small files at the end of a Tez DAG"),
-    HIVEMERGESPARKFILES("hive.merge.sparkfiles", false, "Merge small files at the end of a Spark DAG Transformation"),
-    HIVEMERGEMAPFILESSIZE("hive.merge.size.per.task", (long) (256 * 1000 * 1000),
-        "Size of merged files at the end of the job"),
-    HIVEMERGEMAPFILESAVGSIZE("hive.merge.smallfiles.avgsize", (long) (16 * 1000 * 1000),
-        "When the average output file size of a job is less than this number, Hive will start an additional \n" +
-        "map-reduce job to merge the output files into bigger files. This is only done for map-only jobs \n" +
-        "if hive.merge.mapfiles is true, and for map-reduce jobs if hive.merge.mapredfiles is true."),
-    HIVEMERGERCFILEBLOCKLEVEL("hive.merge.rcfile.block.level", true, ""),
-    HIVEMERGEORCFILESTRIPELEVEL("hive.merge.orcfile.stripe.level", true,
-        "When hive.merge.mapfiles, hive.merge.mapredfiles or hive.merge.tezfiles is enabled\n" +
-        "while writing a table with ORC file format, enabling this config will do stripe-level\n" +
-        "fast merge for small ORC files. Note that enabling this config will not honor the\n" +
-        "padding tolerance config (hive.exec.orc.block.padding.tolerance)."),
-
-    HIVEUSEEXPLICITRCFILEHEADER("hive.exec.rcfile.use.explicit.header", true,
-        "If this is set the header for RCFiles will simply be RCF.  If this is not\n" +
-        "set the header will be that borrowed from sequence files, e.g. SEQ- followed\n" +
-        "by the input and output RCFile formats."),
-    HIVEUSERCFILESYNCCACHE("hive.exec.rcfile.use.sync.cache", true, ""),
-
-    HIVE_RCFILE_RECORD_INTERVAL("hive.io.rcfile.record.interval", Integer.MAX_VALUE, ""),
-    HIVE_RCFILE_COLUMN_NUMBER_CONF("hive.io.rcfile.column.number.conf", 0, ""),
-    HIVE_RCFILE_TOLERATE_CORRUPTIONS("hive.io.rcfile.tolerate.corruptions", false, ""),
-    HIVE_RCFILE_RECORD_BUFFER_SIZE("hive.io.rcfile.record.buffer.size", 4194304, ""),   // 4M
-
-    PARQUET_MEMORY_POOL_RATIO("parquet.memory.pool.ratio", 0.5f,
-        "Maximum fraction of heap that can be used by Parquet file writers in one task.\n" +
-        "It is for avoiding OutOfMemory error in tasks. Work with Parquet 1.6.0 and above.\n" +
-        "This config parameter is defined in Parquet, so that it does not start with 'hive.'."),
-    HIVE_PARQUET_TIMESTAMP_SKIP_CONVERSION("hive.parquet.timestamp.skip.conversion", true,
-      "Current Hive implementation of parquet stores timestamps to UTC, this flag allows skipping of the conversion" +
-      "on reading parquet files from other tools"),
-    HIVE_INT_TIMESTAMP_CONVERSION_IN_SECONDS("hive.int.timestamp.conversion.in.seconds", false,
-        "Boolean/tinyint/smallint/int/bigint value is interpreted as milliseconds during the timestamp conversion.\n" +
-        "Set this flag to true to interpret the value as seconds to be consistent with float/double." ),
-    HIVE_ORC_FILE_MEMORY_POOL("hive.exec.orc.memory.pool", 0.5f,
-        "Maximum fraction of heap that can be used by ORC file writers"),
-    HIVE_ORC_WRITE_FORMAT("hive.exec.orc.write.format", null,
-        "Define the version of the file to write. Possible values are 0.11 and 0.12.\n" +
-        "If this parameter is not defined, ORC will use the run length encoding (RLE)\n" +
-        "introduced in Hive 0.12. Any value other than 0.11 results in the 0.12 encoding."),
-    HIVE_ORC_DEFAULT_STRIPE_SIZE("hive.exec.orc.default.stripe.size",
-        64L * 1024 * 1024,
-        "Define the default ORC stripe size, in bytes."),
-    HIVE_ORC_DEFAULT_BLOCK_SIZE("hive.exec.orc.default.block.size", 256L * 1024 * 1024,
-        "Define the default file system block size for ORC files."),
-
-    HIVE_ORC_DICTIONARY_KEY_SIZE_THRESHOLD("hive.exec.orc.dictionary.key.size.threshold", 0.8f,
-        "If the number of keys in a dictionary is greater than this fraction of the total number of\n" +
-        "non-null rows, turn off dictionary encoding.  Use 1 to always use dictionary encoding."),
-    HIVE_ORC_DEFAULT_ROW_INDEX_STRIDE("hive.exec.orc.default.row.index.stride", 10000,
-        "Define the default ORC index stride in number of rows. (Stride is the number of rows\n" +
-        "an index entry represents.)"),
-    HIVE_ORC_ROW_INDEX_STRIDE_DICTIONARY_CHECK("hive.orc.row.index.stride.dictionary.check", true,
-        "If enabled dictionary check will happen after first row index stride (default 10000 rows)\n" +
-        "else dictionary check will happen before writing first stripe. In both cases, the decision\n" +
-        "to use dictionary or not will be retained thereafter."),
-    HIVE_ORC_DEFAULT_BUFFER_SIZE("hive.exec.orc.default.buffer.size", 256 * 1024,
-        "Define the default ORC buffer size, in bytes."),
-    HIVE_ORC_DEFAULT_BLOCK_PADDING("hive.exec.orc.default.block.padding", true,
-        "Define the default block padding, which pads stripes to the HDFS block boundaries."),
-    HIVE_ORC_BLOCK_PADDING_TOLERANCE("hive.exec.orc.block.padding.tolerance", 0.05f,
-        "Define the tolerance for block padding as a decimal fraction of stripe size (for\n" +
-        "example, the default value 0.05 is 5% of the stripe size). For the defaults of 64Mb\n" +
-        "ORC stripe and 256Mb HDFS blocks, the default block padding tolerance of 5% will\n" +
-        "reserve a maximum of 3.2Mb for padding within the 256Mb block. In that case, if the\n" +
-        "available size within the block is more than 3.2Mb, a new smaller stripe will be\n" +
-        "inserted to fit within that space. This will make sure that no stripe written will\n" +
-        "cross block boundaries and cause remote reads within a node local task."),
-    HIVE_ORC_DEFAULT_COMPRESS("hive.exec.orc.default.compress", "ZLIB", "Define the default compression codec for ORC file"),
-
-    HIVE_ORC_ENCODING_STRATEGY("hive.exec.orc.encoding.strategy", "SPEED", new StringSet("SPEED", "COMPRESSION"),
-        "Define the encoding strategy to use while writing data. Changing this will\n" +
-        "only affect the light weight encoding for integers. This flag will not\n" +
-        "change the compression level of higher level compression codec (like ZLIB)."),
-
-    HIVE_ORC_COMPRESSION_STRATEGY("hive.exec.orc.compression.strategy", "SPEED", new StringSet("SPEED", "COMPRESSION"),
-         "Define the compression strategy to use while writing data. \n" +
-         "This changes the compression level of higher level compression codec (like ZLIB)."),
-
-    HIVE_ORC_SPLIT_STRATEGY("hive.exec.orc.split.strategy", "HYBRID", new StringSet("HYBRID", "BI", "ETL"),
-        "This is not a user level config. BI strategy is used when the requirement is to spend less time in split generation" +
-        " as opposed to query execution (split generation does not read or cache file footers)." +
-        " ETL strategy is used when spending little more time in split generation is acceptable" +
-        " (split generation reads and caches file footers). HYBRID chooses between the above strategies" +
-        " based on heuristics."),
-
-    HIVE_ORC_INCLUDE_FILE_FOOTER_IN_SPLITS("hive.orc.splits.include.file.footer", false,
-        "If turned on splits generated by orc will include metadata about the stripes in the file. This\n" +
-        "data is read remotely (from the client or HS2 machine) and sent to all the tasks."),
-    HIVE_ORC_CACHE_STRIPE_DETAILS_SIZE("hive.orc.cache.stripe.details.size", 10000,
-        "Cache size for keeping meta info about orc splits cached in the client."),
-    HIVE_ORC_COMPUTE_SPLITS_NUM_THREADS("hive.orc.compute.splits.num.threads", 10,
-        "How many threads orc should use to create splits in parallel."),
-    HIVE_ORC_SKIP_CORRUPT_DATA("hive.exec.orc.skip.corrupt.data", false,
-        "If ORC reader encounters corrupt data, this value will be used to determine\n" +
-        "whether to skip the corrupt data or throw exception. The default behavior is to throw exception."),
-
-    HIVE_ORC_ZEROCOPY("hive.exec.orc.zerocopy", false,
-        "Use zerocopy reads with ORC. (This requires Hadoop 2.3 or later.)"),
-
-    HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL("hive.lazysimple.extended_boolean_literal", false,
-        "LazySimpleSerde uses this property to determine if it treats 'T', 't', 'F', 'f',\n" +
-        "'1', and '0' as extened, legal boolean literal, in addition to 'TRUE' and 'FALSE'.\n" +
-        "The default is false, which means only 'TRUE' and 'FALSE' are treated as legal\n" +
-        "boolean literal."),
-
-    HIVESKEWJOIN("hive.optimize.skewjoin", false,
-        "Whether to enable skew join optimization. \n" +
-        "The algorithm is as follows: At runtime, detect the keys with a large skew. Instead of\n" +
-        "processing those keys, store them temporarily in an HDFS directory. In a follow-up map-reduce\n" +
-        "job, process those skewed keys. The same key need not be skewed for all the tables, and so,\n" +
-        "the follow-up map-reduce job (for the skewed keys) would be much faster, since it would be a\n" +
-        "map-join."),
-    HIVECONVERTJOIN("hive.auto.convert.join", true,
-        "Whether Hive enables the optimization about converting common join into mapjoin based on the input file size"),
-    HIVECONVERTJOINNOCONDITIONALTASK("hive.auto.convert.join.noconditionaltask", true,
-        "Whether Hive enables the optimization about converting common join into mapjoin based on the input file size. \n" +
-        "If this parameter is on, and the sum of size for n-1 of the tables/partitions for a n-way join is smaller than the\n" +
-        "specified size, the join is directly converted to a mapjoin (there is no conditional task)."),
-
-    HIVECONVERTJOINNOCONDITIONALTASKTHRESHOLD("hive.auto.convert.join.noconditionaltask.size",
-        10000000L,
-        "If hive.auto.convert.join.noconditionaltask is off, this parameter does not take affect. \n" +
-        "However, if it is on, and the sum of size for n-1 of the tables/partitions for a n-way join is smaller than this size, \n" +
-        "the join is directly converted to a mapjoin(there is no conditional task). The default is 10MB"),
-    HIVECONVERTJOINUSENONSTAGED("hive.auto.convert.join.use.nonstaged", false,
-        "For conditional joins, if input stream from a small alias can be directly applied to join operator without \n" +
-        "filtering or projection, the alias need not to be pre-staged in distributed cache via mapred local task.\n" +
-        "Currently, this is not working with vectorization or tez execution engine."),
-    HIVESKEWJOINKEY("hive.skewjoin.key", 100000,
-        "Determine if we get a skew key in join. If we see more than the specified number of rows with the same key in join operator,\n" +
-        "we think the key as a skew join key. "),
-    HIVESKEWJOINMAPJOINNUMMAPTASK("hive.skewjoin.mapjoin.map.tasks", 10000,
-        "Determine the number of map task used in the follow up map join job for a skew join.\n" +
-        "It should be used together with hive.skewjoin.mapjoin.min.split to perform a fine grained control."),
-    HIVESKEWJOINMAPJOINMINSPLIT("hive.skewjoin.mapjoin.min.split", 33554432L,
-        "Determine the number of map task at most used in the follow up map join job for a skew join by specifying \n" +
-        "the minimum split size. It should be used together with hive.skewjoin.mapjoin.map.tasks to perform a fine grained control."),
-
-    HIVESENDHEARTBEAT("hive.heartbeat.interval", 1000,
-        "Send a heartbeat after this interval - used by mapjoin and filter operators"),
-    HIVELIMITMAXROWSIZE("hive.limit.row.max.size", 100000L,
-        "When trying a smaller subset of data for simple LIMIT, how much size we need to guarantee each row to have at least."),
-    HIVELIMITOPTLIMITFILE("hive.limit.optimize.limit.file", 10,
-        "When trying a smaller subset of data for simple LIMIT, maximum number of files we can sample."),
-    HIVELIMITOPTENABLE("hive.limit.optimize.enable", false,
-        "Whether to enable to optimization to trying a smaller subset of data for simple LIMIT first."),
-    HIVELIMITOPTMAXFETCH("hive.limit.optimize.fetch.max", 50000,
-        "Maximum number of rows allowed for a smaller subset of data for simple LIMIT, if it is a fetch query. \n" +
-        "Insert queries are not restricted by this limit."),
-    HIVELIMITPUSHDOWNMEMORYUSAGE("hive.limit.pushdown.memory.usage", -1f,
-        "The max memory to be used for hash in RS operator for top K selection."),
-    HIVELIMITTABLESCANPARTITION("hive.limit.query.max.table.partition", -1,
-        "This controls how many partitions can be scanned for each partitioned table.\n" +
-        "The default value \"-1\" means no limit."),
-
-    HIVEHASHTABLEKEYCOUNTADJUSTMENT("hive.hashtable.key.count.adjustment", 1.0f,
-        "Adjustment to mapjoin hashtable size derived from table and column statistics; the estimate" +
-        " of the number of keys is divided by this value. If the value is 0, statistics are not used" +
-        "and hive.hashtable.initialCapacity is used instead."),
-    HIVEHASHTABLETHRESHOLD("hive.hashtable.initialCapacity", 100000, "Initial capacity of " +
-        "mapjoin hashtable if statistics are absent, or if hive.hashtable.stats.key.estimate.adjustment is set to 0"),
-    HIVEHASHTABLELOADFACTOR("hive.hashtable.loadfactor", (float) 0.75, ""),
-    HIVEHASHTABLEFOLLOWBYGBYMAXMEMORYUSAGE("hive.mapjoin.followby.gby.localtask.max.memory.usage", (float) 0.55,
-        "This number means how much memory the local task can take to hold the key/value into an in-memory hash table \n" +
-        "when this map join is followed by a group by. If the local task's memory usage is more than this number, \n" +
-        "the local task will abort by itself. It means the data of the small table is too large to be held in memory."),
-    HIVEHASHTABLEMAXMEMORYUSAGE("hive.mapjoin.localtask.max.memory.usage", (float) 0.90,
-        "This number means how much memory the local task can take to hold the key/value into an in-memory hash table. \n" +
-        "If the local task's memory usage is more than this number, the local task will abort by itself. \n" +
-        "It means the data of the small table is too large to be held in memory."),
-    HIVEHASHTABLESCALE("hive.mapjoin.check.memory.rows", (long)100000,
-        "The number means after how many rows processed it needs to check the memory usage"),
-
-    HIVEDEBUGLOCALTASK("hive.debug.localtask",false, ""),
-
-    HIVEINPUTFORMAT("hive.input.format", "org.apache.hadoop.hive.ql.io.CombineHiveInputFormat",
-        "The default input format. Set this to HiveInputFormat if you encounter problems with CombineHiveInputFormat."),
-    HIVETEZINPUTFORMAT("hive.tez.input.format", "org.apache.hadoop.hive.ql.io.HiveInputFormat",
-        "The default input format for tez. Tez groups splits in the AM."),
-
-    HIVETEZCONTAINERSIZE("hive.tez.container.size", -1,
-        "By default Tez will spawn containers of the size of a mapper. This can be used to overwrite."),
-    HIVETEZCPUVCORES("hive.tez.cpu.vcores", -1,
-        "By default Tez will ask for however many cpus map-reduce is configured to use per container.\n" +
-        "This can be used to overwrite."),
-    HIVETEZJAVAOPTS("hive.tez.java.opts", null,
-        "By default Tez will use the Java options from map tasks. This can be used to overwrite."),
-    HIVETEZLOGLEVEL("hive.tez.log.level", "INFO",
-        "The log level to use for tasks executing as part of the DAG.\n" +
-        "Used only if hive.tez.java.opts is used to configure Java options."),
-
-    HIVEENFORCEBUCKETING("hive.enforce.bucketing", false,
-        "Whether bucketing is enforced. If true, while inserting into the table, bucketing is enforced."),
-    HIVEENFORCESORTING("hive.enforce.sorting", false,
-        "Whether sorting is enforced. If true, while inserting into the table, sorting is enforced."),
-    HIVEOPTIMIZEBUCKETINGSORTING("hive.optimize.bucketingsorting", true,
-        "If hive.enforce.bucketing or hive.enforce.sorting is true, don't create a reducer for enforcing \n" +
-        "bucketing/sorting for queries of the form: \n" +
-        "insert overwrite table T2 select * from T1;\n" +
-        "where T1 and T2 are bucketed/sorted by the same keys into the same number of buckets."),
-    HIVEPARTITIONER("hive.mapred.partitioner", "org.apache.hadoop.hive.ql.io.DefaultHivePartitioner", ""),
-    HIVEENFORCESORTMERGEBUCKETMAPJOIN("hive.enforce.sortmergebucketmapjoin", false,
-        "If the user asked for sort-merge bucketed map-side join, and it cannot be performed, should the query fail or not ?"),
-    HIVEENFORCEBUCKETMAPJOIN("hive.enforce.bucketmapjoin", false,
-        "If the user asked for bucketed map-side join, and it cannot be performed, \n" +
-        "should the query fail or not ? For example, if the buckets in the tables being joined are\n" +
-        "not a multiple of each other, bucketed map-side join cannot be performed, and the\n" +
-        "query will fail if hive.enforce.bucketmapjoin is set to true."),
-
-    HIVE_AUTO_SORTMERGE_JOIN("hive.auto.convert.sortmerge.join", false,
-        "Will the join be automatically converted to a sort-merge join, if the joined tables pass the criteria for sort-merge join."),
-    HIVE_AUTO_SORTMERGE_JOIN_BIGTABLE_SELECTOR(
-        "hive.auto.convert.sortmerge.join.bigtable.selection.policy",
-        "org.apache.hadoop.hive.ql.optimizer.AvgPartitionSizeBasedBigTableSelectorForAutoSMJ",
-        "The policy to choose the big table for automatic conversion to sort-merge join. \n" +
-        "By default, the table with the largest partitions is assigned the big table. All policies are:\n" +
-        ". based on position of the table - the leftmost table is selected\n" +
-        "org.apache.hadoop.hive.ql.optimizer.LeftmostBigTableSMJ.\n" +
-        ". based on total size (all the partitions selected in the query) of the table \n" +
-        "org.apache.hadoop.hive.ql.optimizer.TableSizeBasedBigTableSelectorForAutoSMJ.\n" +
-        ". based on average size (all the partitions selected in the query) of the table \n" +
-        "org.apache.hadoop.hive.ql.optimizer.AvgPartitionSizeBasedBigTableSelectorForAutoSMJ.\n" +
-        "New policies can be added in future."),
-    HIVE_AUTO_SORTMERGE_JOIN_TOMAPJOIN(
-        "hive.auto.convert.sortmerge.join.to.mapjoin", false,
-        "If hive.auto.convert.sortmerge.join is set to true, and a join was converted to a sort-merge join, \n" +
-        "this parameter decides whether each table should be tried as a big table, and effectively a map-join should be\n" +
-        "tried. That would create a conditional task with n+1 children for a n-way join (1 child for each table as the\n" +
-        "big table), and the backup task will be the sort-merge join. In some cases, a map-join would be faster than a\n" +
-        "sort-merge join, if there is no advantage of having the output bucketed and sorted. For example, if a very big sorted\n" +
-        "and bucketed table with few files (say 10 files) are being joined with a very small sorter and bucketed table\n" +
-        "with few files (10 files), the sort-merge join will only use 10 mappers, and a simple map-only join might be faster\n" +
-        "if the complete small table can fit in memory, and a map-join can be performed."),
-
-    HIVESCRIPTOPERATORTRUST("hive.exec.script.trust", false, ""),
-    HIVEROWOFFSET("hive.exec.rowoffset", false,
-        "Whether to provide the row offset virtual column"),
-
-    HIVE_COMBINE_INPUT_FORMAT_SUPPORTS_SPLITTABLE("hive.hadoop.supports.splittable.combineinputformat", false, ""),
-
-    // Optimizer
-    HIVEOPTINDEXFILTER("hive.optimize.index.filter", false,
-        "Whether to enable automatic use of indexes"),
-    HIVEINDEXAUTOUPDATE("hive.optimize.index.autoupdate", false,
-        "Whether to update stale indexes automatically"),
-    HIVEOPTPPD("hive.optimize.ppd", true,
-        "Whether to enable predicate pushdown"),
-    HIVEPPDRECOGNIZETRANSITIVITY("hive.ppd.recognizetransivity", true,
-        "Whether to transitively replicate predicate filters over equijoin conditions."),
-    HIVEPPDREMOVEDUPLICATEFILTERS("hive.ppd.remove.duplicatefilters", true,
-        "Whether to push predicates down into storage handlers.  Ignored when hive.optimize.ppd is false."),
-    // Constant propagation optimizer
-    HIVEOPTCONSTANTPROPAGATION("hive.optimize.constant.propagation", true, "Whether to enable constant propagation optimizer"),
-    HIVEIDENTITYPROJECTREMOVER("hive.optimize.remove.identity.project", true, "Removes identity project from operator tree"),
-    HIVEMETADATAONLYQUERIES("hive.optimize.metadataonly", true, ""),
-    HIVENULLSCANOPTIMIZE("hive.optimize.null.scan", true, "Dont scan relations which are guaranteed to not generate any rows"),
-    HIVEOPTPPD_STORAGE("hive.optimize.ppd.storage", true,
-        "Whether to push predicates down to storage handlers"),
-    HIVEOPTGROUPBY("hive.optimize.groupby", true,
-        "Whether to enable the bucketed group by from bucketed partitions/tables."),
-    HIVEOPTBUCKETMAPJOIN("hive.optimize.bucketmapjoin", false,
-        "Whether to try bucket mapjoin"),
-    HIVEOPTSORTMERGEBUCKETMAPJOIN("hive.optimize.bucketmapjoin.sortedmerge", false,
-        "Whether to try sorted bucket merge map join"),
-    HIVEOPTREDUCEDEDUPLICATION("hive.optimize.reducededuplication", true,
-        "Remove extra map-reduce jobs if the data is already clustered by the same key which needs to be used again. \n" +
-        "This should always be set to true. Since it is a new feature, it has been made configurable."),
-    HIVEOPTREDUCEDEDUPLICATIONMINREDUCER("hive.optimize.reducededuplication.min.reducer", 4,
-        "Reduce deduplication merges two RSs by moving key/parts/reducer-num of the child RS to parent RS. \n" +
-        "That means if reducer-num of the child RS is fixed (order by or forced bucketing) and small, it can make very slow, single MR.\n" +
-        "The optimization will be automatically disabled if number of reducers would be less than specified value."),
-
-    HIVEOPTSORTDYNAMICPARTITION("hive.optimize.sort.dynamic.partition", false,
-        "When enabled dynamic partitioning column will be globally sorted.\n" +
-        "This way we can keep only one record writer open for each partition value\n" +
-        "in the reducer thereby reducing the memory pressure on reducers."),
-
-    HIVESAMPLINGFORORDERBY("hive.optimize.sampling.orderby", false, "Uses sampling on order-by clause for parallel execution."),
-    HIVESAMPLINGNUMBERFORORDERBY("hive.optimize.sampling.orderby.number", 1000, "Total number of samples to be obtained."),
-    HIVESAMPLINGPERCENTFORORDERBY("hive.optimize.sampling.orderby.percent", 0.1f, new RatioValidator(),
-        "Probability with which a row will be chosen."),
-    HIVEOPTIMIZEDISTINCTREWRITE("hive.optimize.distinct.rewrite", true, "When applicable this "
-        + "optimization rewrites distinct aggregates from a single stage to multi-stage "
-        + "aggregation. This may not be optimal in all cases. Ideally, whether to trigger it or "
-        + "not should be cost based decision. Until Hive formalizes cost model for this, this is config driven."),
-    // whether to optimize union followed by select followed by filesink
-    // It creates sub-directories in the final output, so should not be turned on in systems
-    // where MAPREDUCE-1501 is not present
-    HIVE_OPTIMIZE_UNION_REMOVE("hive.optimize.union.remove", false,
-        "Whether to remove the union and push the operators between union and the filesink above union. \n" +
-        "This avoids an extra scan of the output by union. This is independently useful for union\n" +
-        "queries, and specially useful when hive.optimize.skewjoin.compiletime is set to true, since an\n" +
-        "extra union is inserted.\n" +
-        "\n" +
-        "The merge is triggered if either of hive.merge.mapfiles or hive.merge.mapredfiles is set to true.\n" +
-        "If the user has set hive.merge.mapfiles to true and hive.merge.mapredfiles to false, the idea was the\n" +
-        "number of reducers are few, so the number of files anyway are small. However, with this optimization,\n" +
-        "we are increasing the number of files possibly by a big margin. So, we merge aggressively."),
-    HIVEOPTCORRELATION("hive.optimize.correlation", false, "exploit intra-query correlations."),
-
-    HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES("hive.mapred.supports.subdirectories", false,
-        "Whether the version of Hadoop which is running supports sub-directories for tables/partitions. \n" +
-        "Many Hive optimizations can be applied if the Hadoop version supports sub-directories for\n" +
-        "tables/partitions. It was added by MAPREDUCE-1501"),
-
-    HIVE_OPTIMIZE_SKEWJOIN_COMPILETIME("hive.optimize.skewjoin.compiletime", false,
-        "Whether to create a separate plan for skewed keys for the tables in the join.\n" +
-        "This is based on the skewed keys stored in the metadata. At compile time, the plan is broken\n" +
-        "into different joins: one for the skewed keys, and the other for the remaining keys. And then,\n" +
-        "a union is performed for the 2 joins generated above. So unless the same skewed key is present\n" +
-        "in both the joined tables, the join for the skewed key will be performed as a map-side join.\n" +
-        "\n" +
-        "The main difference between this parameter and hive.optimize.skewjoin is that this parameter\n" +
-        "uses the skew information stored in the metastore to optimize the plan at compile time itself.\n" +
-        "If there is no skew information in the metadata, this parameter will not have any affect.\n" +
-        "Both hive.optimize.skewjoin.compiletime and hive.optimize.skewjoin should be set to true.\n" +
-        "Ideally, hive.optimize.skewjoin should be renamed as hive.optimize.skewjoin.runtime, but not doing\n" +
-        "so for backward compatibility.\n" +
-        "\n" +
-        "If the skew information is correctly stored in the metadata, hive.optimize.skewjoin.compiletime\n" +
-        "would change the query plan to take care of it, and hive.optimize.skewjoin will be a no-op."),
-
-    // Indexes
-    HIVEOPTINDEXFILTER_COMPACT_MINSIZE("hive.optimize.index.filter.compact.minsize", (long) 5 * 1024 * 1024 * 1024,
-        "Minimum size (in bytes) of the inputs on which a compact index is automatically used."), // 5G
-    HIVEOPTINDEXFILTER_COMPACT_MAXSIZE("hive.optimize.index.filter.compact.maxsize", (long) -1,
-        "Maximum size (in bytes) of the inputs on which a compact index is automatically used.  A negative number is equivalent to infinity."), // infinity
-    HIVE_INDEX_COMPACT_QUERY_MAX_ENTRIES("hive.index.compact.query.max.entries", (long) 10000000,
-        "The maximum number of index entries to read during a query that uses the compact index. Negative value is equivalent to infinity."), // 10M
-    HIVE_INDEX_COMPACT_QUERY_MAX_SIZE("hive.index.compact.query.max.size", (long) 10 * 1024 * 1024 * 1024,
-        "The maximum number of bytes that a query using the compact index can read. Negative value is equivalent to infinity."), // 10G
-    HIVE_INDEX_COMPACT_BINARY_SEARCH("hive.index.compact.binary.search", true,
-        "Whether or not to use a binary search to find the entries in an index table that match the filter, where possible"),
-
-    // Statistics
-    HIVESTATSAUTOGATHER("hive.stats.autogather", true,
-        "A flag to gather statistics automatically during the INSERT OVERWRITE command."),
-    HIVESTATSDBCLASS("hive.stats.dbclass", "fs", new PatternSet("jdbc(:.*)", "hbase", "counter", "custom", "fs"),
-        "The storage that stores temporary Hive statistics. In filesystem based statistics collection ('fs'), \n" +
-        "each task writes statistics it has collected in a file on the filesystem, which will be aggregated \n" +
-        "after the job has finished. Supported values are fs (filesystem), jdbc:database (where database \n" +
-        "can be derby, mysql, etc.), hbase, counter, and custom as defined in StatsSetupConst.java."), // StatsSetupConst.StatDB
-    HIVESTATSJDBCDRIVER("hive.stats.jdbcdriver",
-        "org.apache.derby.jdbc.EmbeddedDriver",
-        "The JDBC driver for the database that stores temporary Hive statistics."),
-    HIVESTATSDBCONNECTIONSTRING("hive.stats.dbconnectionstring",
-        "jdbc:derby:;databaseName=TempStatsStore;create=true",
-        "The default connection string for the database that stores temporary Hive statistics."), // automatically create database
-    HIVE_STATS_DEFAULT_PUBLISHER("hive.stats.default.publisher", "",
-        "The Java class (implementing the StatsPublisher interface) that is used by default if hive.stats.dbclass is custom type."),
-    HIVE_STATS_DEFAULT_AGGREGATOR("hive.stats.default.aggregator", "",
-        "The Java class (implementing the StatsAggregator interface) that is used by default if hive.stats.dbclass is custom type."),
-    HIVE_STATS_JDBC_TIMEOUT("hive.stats.jdbc.timeout", "30s", new TimeValidator(TimeUnit.SECONDS),
-        "Timeout value used by JDBC connection and statements."),
-    HIVE_STATS_ATOMIC("hive.stats.atomic", false,
-        "whether to update metastore stats only if all stats are available"),
-    HIVE_STATS_RETRIES_MAX("hive.stats.retries.max", 0,
-        "Maximum number of retries when stats publisher/aggregator got an exception updating intermediate database. \n" +
-        "Default is no tries on failures."),
-    HIVE_STATS_RETRIES_WAIT("hive.stats.retries.wait", "3000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "The base waiting window before the next retry. The actual wait time is calculated by " +
-        "baseWindow * failures baseWindow * (failure + 1) * (random number between [0.0,1.0])."),
-    HIVE_STATS_COLLECT_RAWDATASIZE("hive.stats.collect.rawdatasize", true,
-        "should the raw data size be collected when analyzing tables"),
-    CLIENT_STATS_COUNTERS("hive.client.stats.counters", "",
-        "Subset of counters that should be of interest for hive.client.stats.publishers (when one wants to limit their publishing). \n" +
-        "Non-display names should be used"),
-    //Subset of counters that should be of interest for hive.client.stats.publishers (when one wants to limit their publishing). Non-display names should be used".
-    HIVE_STATS_RELIABLE("hive.stats.reliable", false,
-        "Whether queries will fail because stats cannot be collected completely accurately. \n" +
-        "If this is set to true, reading/writing from/into a partition may fail because the stats\n" +
-        "could not be computed accurately."),
-    HIVE_STATS_COLLECT_PART_LEVEL_STATS("hive.analyze.stmt.collect.partlevel.stats", true,
-        "analyze table T compute statistics for columns. Queries like these should compute partition"
-        + "level stats for partitioned table even when no part spec is specified."),
-    HIVE_STATS_GATHER_NUM_THREADS("hive.stats.gather.num.threads", 10,
-        "Number of threads used by partialscan/noscan analyze command for partitioned tables.\n" +
-        "This is applicable only for file formats that implement StatsProvidingRecordReader (like ORC)."),
-    // Collect table access keys information for operators that can benefit from bucketing
-    HIVE_STATS_COLLECT_TABLEKEYS("hive.stats.collect.tablekeys", false,
-        "Whether join and group by keys on tables are derived and maintained in the QueryPlan.\n" +
-        "This is useful to identify how tables are accessed and to determine if they should be bucketed."),
-    // Collect column access information
-    HIVE_STATS_COLLECT_SCANCOLS("hive.stats.collect.scancols", false,
-        "Whether column accesses are tracked in the QueryPlan.\n" +
-        "This is useful to identify how tables are accessed and to determine if there are wasted columns that can be trimmed."),
-    // standard error allowed for ndv estimates. A lower value indicates higher accuracy and a
-    // higher compute cost.
-    HIVE_STATS_NDV_ERROR("hive.stats.ndv.error", (float)20.0,
-        "Standard error expressed in percentage. Provides a tradeoff between accuracy and compute cost. \n" +
-        "A lower value for error indicates higher accuracy and a higher compute cost."),
-    HIVE_METASTORE_STATS_NDV_DENSITY_FUNCTION("hive.metastore.stats.ndv.densityfunction", false,
-        "Whether to use density function to estimate the NDV for the whole table based on the NDV of partitions"),
-    HIVE_STATS_KEY_PREFIX_MAX_LENGTH("hive.stats.key.prefix.max.length", 150,
-        "Determines if when the prefix of the key used for intermediate stats collection\n" +
-        "exceeds a certain length, a hash of the key is used instead.  If the value < 0 then hashing"),
-    HIVE_STATS_KEY_PREFIX_RESERVE_LENGTH("hive.stats.key.prefix.reserve.length", 24,
-        "Reserved length for postfix of stats key. Currently only meaningful for counter type which should\n" +
-        "keep length of full stats key smaller than max length configured by hive.stats.key.prefix.max.length.\n" +
-        "For counter type, it should be bigger than the length of LB spec if exists."),
-    HIVE_STATS_KEY_PREFIX("hive.stats.key.prefix", "", "", true), // internal usage only
-    // if length of variable length data type cannot be determined this length will be used.
-    HIVE_STATS_MAX_VARIABLE_LENGTH("hive.stats.max.variable.length", 100,
-        "To estimate the size of data flowing through operators in Hive/Tez(for reducer estimation etc.),\n" +
-        "average row size is multiplied with the total number of rows coming out of each operator.\n" +
-        "Average row size is computed from average column size of all columns in the row. In the absence\n" +
-        "of column statistics, for variable length columns (like string, bytes etc.), this value will be\n" +
-        "used. For fixed length columns their corresponding Java equivalent sizes are used\n" +
-        "(float - 4 bytes, double - 8 bytes etc.)."),
-    // if number of elements in list cannot be determined, this value will be used
-    HIVE_STATS_LIST_NUM_ENTRIES("hive.stats.list.num.entries", 10,
-        "To estimate the size of data flowing through operators in Hive/Tez(for reducer estimation etc.),\n" +
-        "average row size is multiplied with the total number of rows coming out of each operator.\n" +
-        "Average row size is computed from average column size of all columns in the row. In the absence\n" +
-        "of column statistics and for variable length complex columns like list, the average number of\n" +
-        "entries/values can be specified using this config."),
-    // if number of elements in map cannot be determined, this value will be used
-    HIVE_STATS_MAP_NUM_ENTRIES("hive.stats.map.num.entries", 10,
-        "To estimate the size of data flowing through operators in Hive/Tez(for reducer estimation etc.),\n" +
-        "average row size is multiplied with the total number of rows coming out of each operator.\n" +
-        "Average row size is computed from average column size of all columns in the row. In the absence\n" +
-        "of column statistics and for variable length complex columns like map, the average number of\n" +
-        "entries/values can be specified using this config."),
-    // statistics annotation fetches stats for each partition, which can be expensive. turning
-    // this off will result in basic sizes being fetched from namenode instead
-    HIVE_STATS_FETCH_PARTITION_STATS("hive.stats.fetch.partition.stats", true,
-        "Annotation of operator tree with statistics information requires partition level basic\n" +
-        "statistics like number of rows, data size and file size. Partition statistics are fetched from\n" +
-        "metastore. Fetching partition statistics for each needed partition can be expensive when the\n" +
-        "number of partitions is high. This flag can be used to disable fetching of partition statistics\n" +
-        "from metastore. When this flag is disabled, Hive will make calls to filesystem to get file sizes\n" +
-        "and will estimate the number of rows from row schema."),
-    // statistics annotation fetches column statistics for all required columns which can
-    // be very expensive sometimes
-    HIVE_STATS_FETCH_COLUMN_STATS("hive.stats.fetch.column.stats", false,
-        "Annotation of operator tree with statistics information requires column statistics.\n" +
-        "Column statistics are fetched from metastore. Fetching column statistics for each needed column\n" +
-        "can be expensive when the number of columns is high. This flag can be used to disable fetching\n" +
-        "of column statistics from metastore."),
-    // in the absence of column statistics, the estimated number of rows/data size that will
-    // be emitted from join operator will depend on this factor
-    HIVE_STATS_JOIN_FACTOR("hive.stats.join.factor", (float) 1.1,
-        "Hive/Tez optimizer estimates the data size flowing through each of the operators. JOIN operator\n" +
-        "uses column statistics to estimate the number of rows flowing out of it and hence the data size.\n" +
-        "In the absence of column statistics, this factor determines the amount of rows that flows out\n" +
-        "of JOIN operator."),
-    // in the absence of uncompressed/raw data size, total file size will be used for statistics
-    // annotation. But the file may be compressed, encoded and serialized which may be lesser in size
-    // than the actual uncompressed/raw data size. This factor will be multiplied to file size to estimate
-    // the raw data size.
-    HIVE_STATS_DESERIALIZATION_FACTOR("hive.stats.deserialization.factor", (float) 1.0,
-        "Hive/Tez optimizer estimates the data size flowing through each of the operators. In the absence\n" +
-        "of basic statistics like number of rows and data size, file size is used to estimate the number\n" +
-        "of rows and data size. Since files in tables/partitions are serialized (and optionally\n" +
-        "compressed) the estimates of number of rows and data size cannot be reliably determined.\n" +
-        "This factor is multiplied with the file size to account for serialization and compression."),
-
-    // Concurrency
-    HIVE_SUPPORT_CONCURRENCY("hive.support.concurrency", false,
-        "Whether Hive supports concurrency control or not. \n" +
-        "A ZooKeeper instance must be up and running when using zookeeper Hive lock manager "),
-    HIVE_LOCK_MANAGER("hive.lock.manager", "org.apache.hadoop.hive.ql.lockmgr.zookeeper.ZooKeeperHiveLockManager", ""),
-    HIVE_LOCK_NUMRETRIES("hive.lock.numretries", 100,
-        "The number of times you want to try to get all the locks"),
-    HIVE_UNLOCK_NUMRETRIES("hive.unlock.numretries", 10,
-        "The number of times you want to retry to do one unlock"),
-    HIVE_LOCK_SLEEP_BETWEEN_RETRIES("hive.lock.sleep.between.retries", "60s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "The sleep time between various retries"),
-    HIVE_LOCK_MAPRED_ONLY("hive.lock.mapred.only.operation", false,
-        "This param is to control whether or not only do lock on queries\n" +
-        "that need to execute at least one mapred job."),
-
-     // Zookeeper related configs
-    HIVE_ZOOKEEPER_QUORUM("hive.zookeeper.quorum", "",
-        "List of ZooKeeper servers to talk to. This is needed for: \n" +
-        "1. Read/write locks - when hive.lock.manager is set to \n" +
-        "org.apache.hadoop.hive.ql.lockmgr.zookeeper.ZooKeeperHiveLockManager, \n" +
-        "2. When HiveServer2 supports service discovery via Zookeeper.\n" +
-        "3. For delegation token storage if zookeeper store is used, if\n" +
-        "hive.cluster.delegation.token.store.zookeeper.connectString is not set"),
-
-    HIVE_ZOOKEEPER_CLIENT_PORT("hive.zookeeper.client.port", "2181",
-        "The port of ZooKeeper servers to talk to.\n" +
-        "If the list of Zookeeper servers specified in hive.zookeeper.quorum\n" +
-        "does not contain port numbers, this value is used."),
-    HIVE_ZOOKEEPER_SESSION_TIMEOUT("hive.zookeeper.session.timeout", "1200000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "ZooKeeper client's session timeout (in milliseconds). The client is disconnected, and as a result, all locks released, \n" +
-        "if a heartbeat is not sent in the timeout."),
-    HIVE_ZOOKEEPER_NAMESPACE("hive.zookeeper.namespace", "hive_zookeeper_namespace",
-        "The parent node under which all ZooKeeper nodes are created."),
-    HIVE_ZOOKEEPER_CLEAN_EXTRA_NODES("hive.zookeeper.clean.extra.nodes", false,
-        "Clean extra nodes at the end of the session."),
-    HIVE_ZOOKEEPER_CONNECTION_MAX_RETRIES("hive.zookeeper.connection.max.retries", 3,
-        "Max number of times to retry when connecting to the ZooKeeper server."),
-    HIVE_ZOOKEEPER_CONNECTION_BASESLEEPTIME("hive.zookeeper.connection.basesleeptime", "1000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Initial amount of time (in milliseconds) to wait between retries\n" +
-        "when connecting to the ZooKeeper server when using ExponentialBackoffRetry policy."),
-
-    // Transactions
-    HIVE_TXN_MANAGER("hive.txn.manager",
-        "org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager",
-        "Set to org.apache.hadoop.hive.ql.lockmgr.DbTxnManager as part of turning on Hive\n" +
-        "transactions, which also requires appropriate settings for hive.compactor.initiator.on,\n" +
-        "hive.compactor.worker.threads, hive.support.concurrency (true), hive.enforce.bucketing\n" +
-        "(true), and hive.exec.dynamic.partition.mode (nonstrict).\n" +
-        "The default DummyTxnManager replicates pre-Hive-0.13 behavior and provides\n" +
-        "no transactions."),
-    HIVE_TXN_TIMEOUT("hive.txn.timeout", "300s", new TimeValidator(TimeUnit.SECONDS),
-        "time after which transactions are declared aborted if the client has not sent a heartbeat."),
-
-    HIVE_TXN_MAX_OPEN_BATCH("hive.txn.max.open.batch", 1000,
-        "Maximum number of transactions that can be fetched in one call to open_txns().\n" +
-        "This controls how many transactions streaming agents such as Flume or Storm open\n" +
-        "simultaneously. The streaming agent then writes that number of entries into a single\n" +
-        "file (per Flume agent or Storm bolt). Thus increasing this value decreases the number\n" +
-        "of delta files created by streaming agents. But it also increases the number of open\n" +
-        "transactions that Hive has to track at any given time, which may negatively affect\n" +
-        "read performance."),
-
-    HIVE_COMPACTOR_INITIATOR_ON("hive.compactor.initiator.on", false,
-        "Whether to run the initiator and cleaner threads on this metastore instance or not.\n" +
-        "Set this to true on one instance of the Thrift metastore service as part of turning\n" +
-        "on Hive transactions. For a complete list of parameters required for turning on\n" +
-        "transactions, see hive.txn.manager."),
-
-    HIVE_COMPACTOR_WORKER_THREADS("hive.compactor.worker.threads", 0,
-        "How many compactor worker threads to run on this metastore instance. Set this to a\n" +
-        "positive number on one or more instances of the Thrift metastore service as part of\n" +
-        "turning on Hive transactions. For a complete list of parameters required for turning\n" +
-        "on transactions, see hive.txn.manager.\n" +
-        "Worker threads spawn MapReduce jobs to do compactions. They do not do the compactions\n" +
-        "themselves. Increasing the number of worker threads will decrease the time it takes\n" +
-        "tables or partitions to be compacted once they are determined to need compaction.\n" +
-        "It will also increase the background load on the Hadoop cluster as more MapReduce jobs\n" +
-        "will be running in the background."),
-
-    HIVE_COMPACTOR_WORKER_TIMEOUT("hive.compactor.worker.timeout", "86400s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Time in seconds after which a compaction job will be declared failed and the\n" +
-        "compaction re-queued."),
-
-    HIVE_COMPACTOR_CHECK_INTERVAL("hive.compactor.check.interval", "300s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Time in seconds between checks to see if any tables or partitions need to be\n" +
-        "compacted. This should be kept high because each check for compaction requires\n" +
-        "many calls against the NameNode.\n" +
-        "Decreasing this value will reduce the time it takes for compaction to be started\n" +
-        "for a table or partition that requires compaction. However, checking if compaction\n" +
-        "is needed requires several calls to the NameNode for each table or partition that\n" +
-        "has had a transaction done on it since the last major compaction. So decreasing this\n" +
-        "value will increase the load on the NameNode."),
-
-    HIVE_COMPACTOR_DELTA_NUM_THRESHOLD("hive.compactor.delta.num.threshold", 10,
-        "Number of delta directories in a table or partition that will trigger a minor\n" +
-        "compaction."),
-
-    HIVE_COMPACTOR_DELTA_PCT_THRESHOLD("hive.compactor.delta.pct.threshold", 0.1f,
-        "Percentage (fractional) size of the delta files relative to the base that will trigger\n" +
-        "a major compaction. (1.0 = 100%, so the default 0.1 = 10%.)"),
-
-    HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD("hive.compactor.abortedtxn.threshold", 1000,
-        "Number of aborted transactions involving a given table or partition that will trigger\n" +
-        "a major compaction."),
-
-    HIVE_COMPACTOR_CLEANER_RUN_INTERVAL("hive.compactor.cleaner.run.interval", "5000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS), "Time between runs of the cleaner thread"),
-
-    // For HBase storage handler
-    HIVE_HBASE_WAL_ENABLED("hive.hbase.wal.enabled", true,
-        "Whether writes to HBase should be forced to the write-ahead log. \n" +
-        "Disabling this improves HBase write performance at the risk of lost writes in case of a crash."),
-    HIVE_HBASE_GENERATE_HFILES("hive.hbase.generatehfiles", false,
-        "True when HBaseStorageHandler should generate hfiles instead of operate against the online table."),
-    HIVE_HBASE_SNAPSHOT_NAME("hive.hbase.snapshot.name", null, "The HBase table snapshot name to use."),
-    HIVE_HBASE_SNAPSHOT_RESTORE_DIR("hive.hbase.snapshot.restoredir", "/tmp", "The directory in which to " +
-        "restore the HBase table snapshot."),
-
-    // For har files
-    HIVEARCHIVEENABLED("hive.archive.enabled", false, "Whether archiving operations are permitted"),
-
-    HIVEOPTGBYUSINGINDEX("hive.optimize.index.groupby", false,
-        "Whether to enable optimization of group-by queries using Aggregate indexes."),
-
-    HIVEOUTERJOINSUPPORTSFILTERS("hive.outerjoin.supports.filters", true, ""),
-
-    HIVEFETCHTASKCONVERSION("hive.fetch.task.conversion", "more", new StringSet("none", "minimal", "more"),
-        "Some select queries can be converted to single FETCH task minimizing latency.\n" +
-        "Currently the query should be single sourced not having any subquery and should not have\n" +
-        "any aggregations or distincts (which incurs RS), lateral views and joins.\n" +
-        "0. none : disable hive.fetch.task.conversion\n" +
-        "1. minimal : SELECT STAR, FILTER on partition columns, LIMIT only\n" +
-        "2. more    : SELECT, FILTER, LIMIT only (support TABLESAMPLE and virtual columns)"
-    ),
-    HIVEFETCHTASKCONVERSIONTHRESHOLD("hive.fetch.task.conversion.threshold", 1073741824L,
-        "Input threshold for applying hive.fetch.task.conversion. If target table is native, input length\n" +
-        "is calculated by summation of file lengths. If it's not native, storage handler for the table\n" +
-        "can optionally implement org.apache.hadoop.hive.ql.metadata.InputEstimator interface."),
-
-    HIVEFETCHTASKAGGR("hive.fetch.task.aggr", false,
-        "Aggregation queries with no group-by clause (for example, select count(*) from src) execute\n" +
-        "final aggregations in single reduce task. If this is set true, Hive delegates final aggregation\n" +
-        "stage to fetch task, possibly decreasing the query time."),
-
-    HIVEOPTIMIZEMETADATAQUERIES("hive.compute.query.using.stats", false,
-        "When set to true Hive will answer a few queries like count(1) purely using stats\n" +
-        "stored in metastore. For basic stats collection turn on the config hive.stats.autogather to true.\n" +
-        "For more advanced stats collection need to run analyze table queries."),
-
-    // Serde for FetchTask
-    HIVEFETCHOUTPUTSERDE("hive.fetch.output.serde", "org.apache.hadoop.hive.serde2.DelimitedJSONSerDe",
-        "The SerDe used by FetchTask to serialize the fetch output."),
-
-    HIVEEXPREVALUATIONCACHE("hive.cache.expr.evaluation", true,
-        "If true, the evaluation result of a deterministic expression referenced twice or more\n" +
-        "will be cached.\n" +
-        "For example, in a filter condition like '.. where key + 10 = 100 or key + 10 = 0'\n" +
-        "the expression 'key + 10' will be evaluated/cached once and reused for the following\n" +
-        "expression ('key + 10 = 0'). Currently, this is applied only to expressions in select\n" +
-        "or filter operators."),
-
-    // Hive Variables
-    HIVEVARIABLESUBSTITUTE("hive.variable.substitute", true,
-        "This enables substitution using syntax like ${var} ${system:var} and ${env:var}."),
-    HIVEVARIABLESUBSTITUTEDEPTH("hive.variable.substitute.depth", 40,
-        "The maximum replacements the substitution engine will do."),
-
-    HIVECONFVALIDATION("hive.conf.validation", true,
-        "Enables type checking for registered Hive configurations"),
-
-    SEMANTIC_ANALYZER_HOOK("hive.semantic.analyzer.hook", "", ""),
-    HIVE_TEST_AUTHORIZATION_SQLSTD_HS2_MODE(
-        "hive.test.authz.sstd.hs2.mode", false, "test hs2 mode from .q tests", true),
-    HIVE_AUTHORIZATION_ENABLED("hive.security.authorization.enabled", false,
-        "enable or disable the Hive client authorization"),
-    HIVE_AUTHORIZATION_MANAGER("hive.security.authorization.manager",
-        "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider",
-        "The Hive client authorization manager class name. The user defined authorization class should implement \n" +
-        "interface org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider."),
-    HIVE_AUTHENTICATOR_MANAGER("hive.security.authenticator.manager",
-        "org.apache.hadoop.hive.ql.security.HadoopDefaultAuthenticator",
-        "hive client authenticator manager class name. The user defined authenticator should implement \n" +
-        "interface org.apache.hadoop.hive.ql.security.HiveAuthenticationProvider."),
-    HIVE_METASTORE_AUTHORIZATION_MANAGER("hive.security.metastore.authorization.manager",
-        "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveMetastoreAuthorizationProvider",
-        "Names of authorization manager classes (comma separated) to be used in the metastore\n" +
-        "for authorization. The user defined authorization class should implement interface\n" +
-        "org.apache.hadoop.hive.ql.security.authorization.HiveMetastoreAuthorizationProvider.\n" +
-        "All authorization manager classes have to successfully authorize the metastore API\n" +
-        "call for the command execution to be allowed."),
-    HIVE_METASTORE_AUTHORIZATION_AUTH_READS("hive.security.metastore.authorization.auth.reads", true,
-        "If this is true, metastore authorizer authorizes read actions on database, table"),
-    HIVE_METASTORE_AUTHENTICATOR_MANAGER("hive.security.metastore.authenticator.manager",
-        "org.apache.hadoop.hive.ql.security.HadoopDefaultMetastoreAuthenticator",
-        "authenticator manager class name to be used in the metastore for authentication. \n" +
-        "The user defined authenticator should implement interface org.apache.hadoop.hive.ql.security.HiveAuthenticationProvider."),
-    HIVE_AUTHORIZATION_TABLE_USER_GRANTS("hive.security.authorization.createtable.user.grants", "",
-        "the privileges automatically granted to some users whenever a table gets created.\n" +
-        "An example like \"userX,userY:select;userZ:create\" will grant select privilege to userX and userY,\n" +
-        "and grant create privilege to userZ whenever a new table created."),
-    HIVE_AUTHORIZATION_TABLE_GROUP_GRANTS("hive.security.authorization.createtable.group.grants",
-        "",
-        "the privileges automatically granted to some groups whenever a table gets created.\n" +
-        "An example like \"groupX,groupY:select;groupZ:create\" will grant select privilege to groupX and groupY,\n" +
-        "and grant create privilege to groupZ whenever a new table created."),
-    HIVE_AUTHORIZATION_TABLE_ROLE_GRANTS("hive.security.authorization.createtable.role.grants", "",
-        "the privileges automatically granted to some roles whenever a table gets created.\n" +
-        "An example like \"roleX,roleY:select;roleZ:create\" will grant select privilege to roleX and roleY,\n" +
-        "and grant create privilege to roleZ whenever a new table created."),
-    HIVE_AUTHORIZATION_TABLE_OWNER_GRANTS("hive.security.authorization.createtable.owner.grants",
-        "",
-        "The privileges automatically granted to the owner whenever a table gets created.\n" +
-        "An example like \"select,drop\" will grant select and drop privilege to the owner\n" +
-        "of the table. Note that the default gives the creator of a table no access to the\n" +
-        "table (but see HIVE-8067)."),
-    HIVE_AUTHORIZATION_TASK_FACTORY("hive.security.authorization.task.factory",
-        "org.apache.hadoop.hive.ql.parse.authorization.HiveAuthorizationTaskFactoryImpl",
-        "Authorization DDL task factory implementation"),
-
-    // if this is not set default value is set during config initialization
-    // Default value can't be set in this constructor as it would refer names in other ConfVars
-    // whose constructor would not have been called
-    HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST(
-        "hive.security.authorization.sqlstd.confwhitelist", "",
-        "List of comma separated Java regexes. Configurations parameters that match these\n" +
-        "regexes can be modified by user when SQL standard authorization is enabled.\n" +
-        "To get the default value, use the 'set <param>' command.\n" +
-        "Note that the hive.conf.restricted.list checks are still enforced after the white list\n" +
-        "check"),
-
-    HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST_APPEND(
-        "hive.security.authorization.sqlstd.confwhitelist.append", "",
-        "List of comma separated Java regexes, to be appended to list set in\n" +
-        "hive.security.authorization.sqlstd.confwhitelist. Using this list instead\n" +
-        "of updating the original list means that you can append to the defaults\n" +
-        "set by SQL standard authorization instead of replacing it entirely."),
-
-    HIVE_CLI_PRINT_HEADER("hive.cli.print.header", false, "Whether to print the names of the columns in query output."),
-
-    HIVE_ERROR_ON_EMPTY_PARTITION("hive.error.on.empty.partition", false,
-        "Whether to throw an exception if dynamic partition insert generates empty results."),
-
-    HIVE_INDEX_COMPACT_FILE("hive.index.compact.file", "", "internal variable"),
-    HIVE_INDEX_BLOCKFILTER_FILE("hive.index.blockfilter.file", "", "internal variable"),
-    HIVE_INDEX_IGNORE_HDFS_LOC("hive.index.compact.file.ignore.hdfs", false,
-        "When true the HDFS location stored in the index file will be ignored at runtime.\n" +
-        "If the data got moved or the name of the cluster got changed, the index data should still be usable."),
-
-    HIVE_EXIM_URI_SCHEME_WL("hive.exim.uri.scheme.whitelist", "hdfs,pfile",
-        "A comma separated list of acceptable URI schemes for import and export."),
-    // temporary variable for testing. This is added just to turn off this feature in case of a bug in
-    // deployment. It has not been documented in hive-default.xml intentionally, this should be removed
-    // once the feature is stable
-    HIVE_EXIM_RESTRICT_IMPORTS_INTO_REPLICATED_TABLES("hive.exim.strict.repl.tables",true,
-        "Parameter that determines if 'regular' (non-replication) export dumps can be\n" +
-        "imported on to tables that are the target of replication. If this parameter is\n" +
-        "set, regular imports will check if the destination table(if it exists) has a " +
-        "'repl.last.id' set on it. If so, it will fail."),
-    HIVE_REPL_TASK_FACTORY("hive.repl.task.factory",
-        "org.apache.hive.hcatalog.api.repl.exim.EximReplicationTaskFactory",
-        "Parameter that can be used to override which ReplicationTaskFactory will be\n" +
-        "used to instantiate ReplicationTask events. Override for third party repl plugins"),
-    HIVE_MAPPER_CANNOT_SPAN_MULTIPLE_PARTITIONS("hive.mapper.cannot.span.multiple.partitions", false, ""),
-    HIVE_REWORK_MAPREDWORK("hive.rework.mapredwork", false,
-        "should rework the mapred work or not.\n" +
-        "This is first introduced by SymlinkTextInputFormat to replace symlink files with real paths at compile time."),
-    HIVE_CONCATENATE_CHECK_INDEX ("hive.exec.concatenate.check.index", true,
-        "If this is set to true, Hive will throw error when doing\n" +
-        "'alter table tbl_name [partSpec] concatenate' on a table/partition\n" +
-        "that has indexes on it. The reason the user want to set this to true\n" +
-        "is because it can help user to avoid handling all index drop, recreation,\n" +
-        "rebuild work. This is very helpful for tables with thousands of partitions."),
-    HIVE_IO_EXCEPTION_HANDLERS("hive.io.exception.handlers", "",
-        "A list of io exception handler class names. This is used\n" +
-        "to construct a list exception handlers to handle exceptions thrown\n" +
-        "by record readers"),
-
-    // operation log configuration
-    HIVE_SERVER2_LOGGING_OPERATION_ENABLED("hive.server2.logging.operation.enabled", true,
-        "When true, HS2 will save operation logs and make them available for clients"),
-    HIVE_SERVER2_LOGGING_OPERATION_LOG_LOCATION("hive.server2.logging.operation.log.location",
-        "${system:java.io.tmpdir}" + File.separator + "${system:user.name}" + File.separator +
-            "operation_logs",
-        "Top level directory where operation logs are stored if logging functionality is enabled"),
-    HIVE_SERVER2_LOGGING_OPERATION_LEVEL("hive.server2.logging.operation.level", "EXECUTION",
-        new StringSet("NONE", "EXECUTION", "PERFORMANCE", "VERBOSE"),
-        "HS2 operation logging mode available to clients to be set at session level.\n" +
-        "For this to work, hive.server2.logging.operation.enabled should be set to true.\n" +
-        "  NONE: Ignore any logging\n" +
-        "  EXECUTION: Log completion of tasks\n" +
-        "  PERFORMANCE: Execution + Performance logs \n" +
-        "  VERBOSE: All logs" ),
-    // logging configuration
-    HIVE_LOG4J_FILE("hive.log4j.file", "",
-        "Hive log4j configuration file.\n" +
-        "If the property is not set, then logging will be initialized using hive-log4j.properties found on the classpath.\n" +
-        "If the property is set, the value must be a valid URI (java.net.URI, e.g. \"file:///tmp/my-logging.properties\"), \n" +
-        "which you can then extract a URL from and pass to PropertyConfigurator.configure(URL)."),
-    HIVE_EXEC_LOG4J_FILE("hive.exec.log4j.file", "",
-        "Hive log4j configuration file for execution mode(sub command).\n" +
-        "If the property is not set, then logging will be initialized using hive-exec-log4j.properties found on the classpath.\n" +
-        "If the property is set, the value must be a valid URI (java.net.URI, e.g. \"file:///tmp/my-logging.properties\"), \n" +
-        "which you can then extract a URL from and pass to PropertyConfigurator.configure(URL)."),
-
-    HIVE_LOG_EXPLAIN_OUTPUT("hive.log.explain.output", false,
-        "Whether to log explain output for every query.\n" +
-        "When enabled, will log EXPLAIN EXTENDED output for the query at INFO log4j log level."),
-    HIVE_EXPLAIN_USER("hive.explain.user", false,
-        "Whether to show explain result at user level.\n" +
-        "When enabled, will log EXPLAIN output for the query at user level."),
-
-    // prefix used to auto generated column aliases (this should be started with '_')
-    HIVE_AUTOGEN_COLUMNALIAS_PREFIX_LABEL("hive.autogen.columnalias.prefix.label", "_c",
-        "String used as a prefix when auto generating column alias.\n" +
-        "By default the prefix label will be appended with a column position number to form the column alias. \n" +
-        "Auto generation would happen if an aggregate function is used in a select clause without an explicit alias."),
-    HIVE_AUTOGEN_COLUMNALIAS_PREFIX_INCLUDEFUNCNAME(
-        "hive.autogen.columnalias.prefix.includefuncname", false,
-        "Whether to include function name in the column alias auto generated by Hive."),
-
-    HIVE_PERF_LOGGER("hive.exec.perf.logger", "org.apache.hadoop.hive.ql.log.PerfLogger",
-        "The class responsible for logging client side performance metrics. \n" +
-        "Must be a subclass of org.apache.hadoop.hive.ql.log.PerfLogger"),
-    HIVE_START_CLEANUP_SCRATCHDIR("hive.start.cleanup.scratchdir", false,
-        "To cleanup the Hive scratchdir when starting the Hive Server"),
-    HIVE_INSERT_INTO_MULTILEVEL_DIRS("hive.insert.into.multilevel.dirs", false,
-        "Where to insert into multilevel directories like\n" +
-        "\"insert directory '/HIVEFT25686/chinna/' from table\""),
-    HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS("hive.warehouse.subdir.inherit.perms", true,
-        "Set this to false if the table directories should be created\n" +
-        "with the permissions derived from dfs umask instead of\n" +
-        "inheriting the permission of the warehouse or database directory."),
-    HIVE_INSERT_INTO_EXTERNAL_TABLES("hive.insert.into.external.tables", true,
-        "whether insert into external tables is allowed"),
-    HIVE_TEMPORARY_TABLE_STORAGE(
-        "hive.exec.temporary.table.storage", "default", new StringSet("memory",
-         "ssd", "default"), "Define the storage policy for temporary tables." +
-         "Choices between memory, ssd and default"),
-
-    HIVE_DRIVER_RUN_HOOKS("hive.exec.driver.run.hooks", "",
-        "A comma separated list of hooks which implement HiveDriverRunHook. Will be run at the beginning " +
-        "and end of Driver.run, these will be run in the order specified."),
-    HIVE_DDL_OUTPUT_FORMAT("hive.ddl.output.format", null,
-        "The data format to use for DDL output.  One of \"text\" (for human\n" +
-        "readable text) or \"json\" (for a json object)."),
-    HIVE_ENTITY_SEPARATOR("hive.entity.separator", "@",
-        "Separator used to construct names of tables and partitions. For example, dbname@tablename@partitionname"),
-    HIVE_CAPTURE_TRANSFORM_ENTITY("hive.entity.capture.transform", false,
-        "Compiler to capture transform URI referred in the query"),
-    HIVE_DISPLAY_PARTITION_COLUMNS_SEPARATELY("hive.display.partition.cols.separately", true,
-        "In older Hive version (0.10 and earlier) no distinction was made between\n" +
-        "partition columns or non-partition columns while displaying columns in describe\n" +
-        "table. From 0.12 onwards, they are displayed separately. This flag will let you\n" +
-        "get old behavior, if desired. See, test-case in patch for HIVE-6689."),
-
-    HIVE_SSL_PROTOCOL_BLACKLIST("hive.ssl.protocol.blacklist", "SSLv2,SSLv3",
-        "SSL Versions to disable for all Hive Servers"),
-
-     // HiveServer2 specific configs
-    HIVE_SERVER2_MAX_START_ATTEMPTS("hive.server2.max.start.attempts", 30L, new RangeValidator(0L, null),
-        "Number of times HiveServer2 will attempt to start before exiting, sleeping 60 seconds " +
-        "between retries. \n The default of 30 will keep trying for 30 minutes."),
-    HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY("hive.server2.support.dynamic.service.discovery", false,
-        "Whether HiveServer2 supports dynamic service discovery for its clients. " +
-        "To support this, each instance of HiveServer2 currently uses ZooKeeper to register itself, " +
-        "when it is brought up. JDBC/ODBC clients should use the ZooKeeper ensemble: " +
-        "hive.zookeeper.quorum in their connection string."),
-    HIVE_SERVER2_ZOOKEEPER_NAMESPACE("hive.server2.zookeeper.namespace", "hiveserver2",
-        "The parent node in ZooKeeper used by HiveServer2 when supporting dynamic service discovery."),
-    // HiveServer2 global init file location
-    HIVE_SERVER2_GLOBAL_INIT_FILE_LOCATION("hive.server2.global.init.file.location", "${env:HIVE_CONF_DIR}",
-        "Either the location of a HS2 global init file or a directory containing a .hiverc file. If the \n" +
-        "property is set, the value must be a valid path to an init file or directory where the init file is located."),
-    HIVE_SERVER2_TRANSPORT_MODE("hive.server2.transport.mode", "binary", new StringSet("binary", "http"),
-        "Transport mode of HiveServer2."),
-    HIVE_SERVER2_THRIFT_BIND_HOST("hive.server2.thrift.bind.host", "",
-        "Bind host on which to run the HiveServer2 Thrift service."),
-
-    // http (over thrift) transport settings
-    HIVE_SERVER2_THRIFT_HTTP_PORT("hive.server2.thrift.http.port", 10001,
-        "Port number of HiveServer2 Thrift interface when hive.server2.transport.mode is 'http'."),
-    HIVE_SERVER2_THRIFT_HTTP_PATH("hive.server2.thrift.http.path", "cliservice",
-        "Path component of URL endpoint when in HTTP mode."),
-    HIVE_SERVER2_THRIFT_MAX_MESSAGE_SIZE("hive.server2.thrift.max.message.size", 100*1024*1024,
-        "Maximum message size in bytes a HS2 server will accept."),
-    HIVE_SERVER2_THRIFT_HTTP_MAX_IDLE_TIME("hive.server2.thrift.http.max.idle.time", "1800s",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Maximum idle time for a connection on the server when in HTTP mode."),
-    HIVE_SERVER2_THRIFT_HTTP_WORKER_KEEPALIVE_TIME("hive.server2.thrift.http.worker.keepalive.time", "60s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Keepalive time for an idle http worker thread. When the number of workers exceeds min workers, " +
-        "excessive threads are killed after this time interval."),
-
-    // Cookie based authentication
-    HIVE_SERVER2_THRIFT_HTTP_COOKIE_AUTH_ENABLED("hive.server2.thrift.http.cookie.auth.enabled", true,
-        "When true, HiveServer2 in HTTP transport mode, will use cookie based authentication mechanism."),
-    HIVE_SERVER2_THRIFT_HTTP_COOKIE_MAX_AGE("hive.server2.thrift.http.cookie.max.age", "86400s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Maximum age in seconds for server side cookie used by HS2 in HTTP mode."),
-    HIVE_SERVER2_THRIFT_HTTP_COOKIE_DOMAIN("hive.server2.thrift.http.cookie.domain", null,
-        "Domain for the HS2 generated cookies"),
-    HIVE_SERVER2_THRIFT_HTTP_COOKIE_PATH("hive.server2.thrift.http.cookie.path", null,
-        "Path for the HS2 generated cookies"),
-    HIVE_SERVER2_THRIFT_HTTP_COOKIE_IS_SECURE("hive.server2.thrift.http.cookie.is.secure", true,
-        "Secure attribute of the HS2 generated cookie."),
-    HIVE_SERVER2_THRIFT_HTTP_COOKIE_IS_HTTPONLY("hive.server2.thrift.http.cookie.is.httponly", true,
-        "HttpOnly attribute of the HS2 generated cookie."),
-
-    // binary transport settings
-    HIVE_SERVER2_THRIFT_PORT("hive.server2.thrift.port", 10000,
-        "Port number of HiveServer2 Thrift interface when hive.server2.transport.mode is 'binary'."),
-    HIVE_SERVER2_THRIFT_SASL_QOP("hive.server2.thrift.sasl.qop", "auth",
-        new StringSet("auth", "auth-int", "auth-conf"),
-        "Sasl QOP value; set it to one of following values to enable higher levels of\n" +
-        "protection for HiveServer2 communication with clients.\n" +
-        "Setting hadoop.rpc.protection to a higher level than HiveServer2 does not\n" +
-        "make sense in most situations. HiveServer2 ignores hadoop.rpc.protection in favor\n" +
-        "of hive.server2.thrift.sasl.qop.\n" +
-        "  \"auth\" - authentication only (default)\n" +
-        "  \"auth-int\" - authentication plus integrity protection\n" +
-        "  \"auth-conf\" - authentication plus integrity and confidentiality protection\n" +
-        "This is applicable only if HiveServer2 is configured to use Kerberos authentication."),
-    HIVE_SERVER2_THRIFT_MIN_WORKER_THREADS("hive.server2.thrift.min.worker.threads", 5,
-        "Minimum number of Thrift worker threads"),
-    HIVE_SERVER2_THRIFT_MAX_WORKER_THREADS("hive.server2.thrift.max.worker.threads", 500,
-        "Maximum number of Thrift worker threads"),
-    HIVE_SERVER2_THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH(
-        "hive.server2.thrift.exponential.backoff.slot.length", "100ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Binary exponential backoff slot time for Thrift clients during login to HiveServer2,\n" +
-        "for retries until hitting Thrift client timeout"),
-    HIVE_SERVER2_THRIFT_LOGIN_TIMEOUT("hive.server2.thrift.login.timeout", "20s",
-        new TimeValidator(TimeUnit.SECONDS), "Timeout for Thrift clients during login to HiveServer2"),
-    HIVE_SERVER2_THRIFT_WORKER_KEEPALIVE_TIME("hive.server2.thrift.worker.keepalive.time", "60s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Keepalive time (in seconds) for an idle worker thread. When the number of workers exceeds min workers, " +
-        "excessive threads are killed after this time interval."),
-    // Configuration for async thread pool in SessionManager
-    HIVE_SERVER2_ASYNC_EXEC_THREADS("hive.server2.async.exec.threads", 100,
-        "Number of threads in the async thread pool for HiveServer2"),
-    HIVE_SERVER2_ASYNC_EXEC_SHUTDOWN_TIMEOUT("hive.server2.async.exec.shutdown.timeout", "10s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "How long HiveServer2 shutdown will wait for async threads to terminate."),
-    HIVE_SERVER2_ASYNC_EXEC_WAIT_QUEUE_SIZE("hive.server2.async.exec.wait.queue.size", 100,
-        "Size of the wait queue for async thread pool in HiveServer2.\n" +
-        "After hitting this limit, the async thread pool will reject new requests."),
-    HIVE_SERVER2_ASYNC_EXEC_KEEPALIVE_TIME("hive.server2.async.exec.keepalive.time", "10s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Time that an idle HiveServer2 async thread (from the thread pool) will wait for a new task\n" +
-        "to arrive before terminating"),
-    HIVE_SERVER2_LONG_POLLING_TIMEOUT("hive.server2.long.polling.timeout", "5000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Time that HiveServer2 will wait before responding to asynchronous calls that use long polling"),
-
-    // HiveServer2 auth configuration
-    HIVE_SERVER2_AUTHENTICATION("hive.server2.authentication", "NONE",
-      new StringSet("NOSASL", "NONE", "LDAP", "KERBEROS", "PAM", "CUSTOM"),
-        "Client authentication types.\n" +
-        "  NONE: no authentication check\n" +
-        "  LDAP: LDAP/AD based authentication\n" +
-        "  KERBEROS: Kerberos/GSSAPI authentication\n" +
-        "  CUSTOM: Custom authentication provider\n" +
-        "          (Use with property hive.server2.custom.authentication.class)\n" +
-        "  PAM: Pluggable authentication module\n" +
-        "  NOSASL:  Raw transport"),
-    HIVE_SERVER2_ALLOW_USER_SUBSTITUTION("hive.server2.allow.user.substitution", true,
-        "Allow alternate user to be specified as part of HiveServer2 open connection request."),
-    HIVE_SERVER2_KERBEROS_KEYTAB("hive.server2.authentication.kerberos.keytab", "",
-        "Kerberos keytab file for server principal"),
-    HIVE_SERVER2_KERBEROS_PRINCIPAL("hive.server2.authentication.kerberos.principal", "",
-        "Kerberos server principal"),
-    HIVE_SERVER2_SPNEGO_KEYTAB("hive.server2.authentication.spnego.keytab", "",
-        "keytab file for SPNego principal, optional,\n" +
-        "typical value would look like /etc/security/keytabs/spnego.service.keytab,\n" +
-        "This keytab would be used by HiveServer2 when Kerberos security is enabled and \n" +
-        "HTTP transport mode is used.\n" +
-        "This needs to be set only if SPNEGO is to be used in authentication.\n" +
-        "SPNego authentication would be honored only if valid\n" +
-        "  hive.server2.authentication.spnego.principal\n" +
-        "and\n" +
-        "  hive.server2.authentication.spnego.keytab\n" +
-        "are specified."),
-    HIVE_SERVER2_SPNEGO_PRINCIPAL("hive.server2.authentication.spnego.principal", "",
-        "SPNego service principal, optional,\n" +
-        "typical value would look like HTTP/_HOST@EXAMPLE.COM\n" +
-        "SPNego service principal would be used by HiveServer2 when Kerberos security is enabled\n" +
-        "and HTTP transport mode is used.\n" +
-        "This needs to be set only if SPNEGO is to be used in authentication."),
-    HIVE_SERVER2_PLAIN_LDAP_URL("hive.server2.authentication.ldap.url", null,
-        "LDAP connection URL(s),\n" +
-         "this value could contain URLs to mutiple LDAP servers instances for HA,\n" +
-         "each LDAP URL is separated by a SPACE character. URLs are used in the \n" +
-         " order specified until a connection is successful."),
-    HIVE_SERVER2_PLAIN_LDAP_BASEDN("hive.server2.authentication.ldap.baseDN", null, "LDAP base DN"),
-    HIVE_SERVER2_PLAIN_LDAP_DOMAIN("hive.server2.authentication.ldap.Domain", null, ""),
-    HIVE_SERVER2_CUSTOM_AUTHENTICATION_CLASS("hive.server2.custom.authentication.class", null,
-        "Custom authentication class. Used when property\n" +
-        "'hive.server2.authentication' is set to 'CUSTOM'. Provided class\n" +
-        "must be a proper implementation of the interface\n" +
-        "org.apache.hive.service.auth.PasswdAuthenticationProvider. HiveServer2\n" +
-        "will call its Authenticate(user, passed) method to authenticate requests.\n" +
-        "The implementation may optionally implement Hadoop's\n" +
-        "org.apache.hadoop.conf.Configurable class to grab Hive's Configuration object."),
-    HIVE_SERVER2_PAM_SERVICES("hive.server2.authentication.pam.services", null,
-      "List of the underlying pam services that should be used when auth type is PAM\n" +
-      "A file with the same name must exist in /etc/pam.d"),
-
-    HIVE_SERVER2_ENABLE_DOAS("hive.server2.enable.doAs", true,
-        "Setting this property to true will have HiveServer2 execute\n" +
-        "Hive operations as the user making the calls to it."),
-    HIVE_SERVER2_TABLE_TYPE_MAPPING("hive.server2.table.type.mapping", "CLASSIC", new StringSet("CLASSIC", "HIVE"),
-        "This setting reflects how HiveServer2 will report the table types for JDBC and other\n" +
-        "client implementations that retrieve the available tables and supported table types\n" +
-        "  HIVE : Exposes Hive's native table types like MANAGED_TABLE, EXTERNAL_TABLE, VIRTUAL_VIEW\n" +
-        "  CLASSIC : More generic types like TABLE and VIEW"),
-    HIVE_SERVER2_SESSION_HOOK("hive.server2.session.hook", "", ""),
-    HIVE_SERVER2_USE_SSL("hive.server2.use.SSL", false,
-        "Set this to true for using SSL encryption in HiveServer2."),
-    HIVE_SERVER2_SSL_KEYSTORE_PATH("hive.server2.keystore.path", "",
-        "SSL certificate keystore location."),
-    HIVE_SERVER2_SSL_KEYSTORE_PASSWORD("hive.server2.keystore.password", "",
-        "SSL certificate keystore password."),
-    HIVE_SERVER2_MAP_FAIR_SCHEDULER_QUEUE("hive.server2.map.fair.scheduler.queue", true,
-        "If the YARN fair scheduler is configured and HiveServer2 is running in non-impersonation mode,\n" +
-        "this setting determines the user for fair scheduler queue mapping.\n" +
-        "If set to true (default), the logged-in user determines the fair scheduler queue\n" +
-        "for submitted jobs, so that map reduce resource usage can be tracked by user.\n" +
-        "If set to false, all Hive jobs go to the 'hive' user's queue."),
-    HIVE_SERVER2_BUILTIN_UDF_WHITELIST("hive.server2.builtin.udf.whitelist", "",
-        "Comma separated list of builtin udf names allowed in queries.\n" +
-        "An empty whitelist allows all builtin udfs to be executed. " +
-        " The udf black list takes precedence over udf white list"),
-    HIVE_SERVER2_BUILTIN_UDF_BLACKLIST("hive.server2.builtin.udf.blacklist", "",
-         "Comma separated list of udfs names. These udfs will not be allowed in queries." +
-         " The udf black list takes precedence over udf white list"),
-
-    HIVE_SECURITY_COMMAND_WHITELIST("hive.security.command.whitelist", "set,reset,dfs,add,list,delete,reload,compile",
-        "Comma separated list of non-SQL Hive commands users are authorized to execute"),
-
-    HIVE_SERVER2_SESSION_CHECK_INTERVAL("hive.server2.session.check.interval", "6h",
-        new TimeValidator(TimeUnit.MILLISECONDS, 3000l, true, null, false),
-        "The check interval for session/operation timeout, which can be disabled by setting to zero or negative value."),
-    HIVE_SERVER2_IDLE_SESSION_TIMEOUT("hive.server2.idle.session.timeout", "7d",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Session will be closed when it's not accessed for this duration, which can be disabled by setting to zero or negative value."),
-    HIVE_SERVER2_IDLE_OPERATION_TIMEOUT("hive.server2.idle.operation.timeout", "5d",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Operation will be closed when it's not accessed for this duration of time, which can be disabled by setting to zero value.\n" +
-        "  With positive value, it's checked for operations in terminal state only (FINISHED, CANCELED, CLOSED, ERROR).\n" +
-        "  With negative value, it's checked for all of the operations regardless of state."),
-    HIVE_SERVER2_IDLE_SESSION_CHECK_OPERATION("hive.server2.idle.session.check.operation", true,
-        "Session will be considered to be idle only if there is no activity, and there is no pending operation.\n" +
-        " This setting takes effect only if session idle timeout (hive.server2.idle.session.timeout) and checking\n" +
-        "(hive.server2.session.check.interval) are enabled."),
-
-    HIVE_CONF_RESTRICTED_LIST("hive.conf.restricted.list",
-        "hive.security.authenticator.manager,hive.security.authorization.manager,hive.users.in.admin.role",
-        "Comma separated list of configuration options which are immutable at runtime"),
-
-    // If this is set all move tasks at the end of a multi-insert query will only begin once all
-    // outputs are ready
-    HIVE_MULTI_INSERT_MOVE_TASKS_SHARE_DEPENDENCIES(
-        "hive.multi.insert.move.tasks.share.dependencies", false,
-        "If this is set all move tasks for tables/partitions (not directories) at the end of a\n" +
-        "multi-insert query will only begin once the dependencies for all these move tasks have been\n" +
-        "met.\n" +
-        "Advantages: If concurrency is enabled, the locks will only be released once the query has\n" +
-        "            finished, so with this config enabled, the time when the table/partition is\n" +
-        "            generated will be much closer to when the lock on it is released.\n" +
-        "Disadvantages: If concurrency is not enabled, with this disabled, the tables/partitions which\n" +
-        "               are produced by this query and finish earlier will be available for querying\n" +
-        "               much earlier.  Since the locks are only released once the query finishes, this\n" +
-        "               does not apply if concurrency is enabled."),
-
-    HIVE_INFER_BUCKET_SORT("hive.exec.infer.bucket.sort", false,
-        "If this is set, when writing partitions, the metadata will include the bucketing/sorting\n" +
-        "properties with which the data was written if any (this will not overwrite the metadata\n" +
-        "inherited from the table if the table is bucketed/sorted)"),
-
-    HIVE_INFER_BUCKET_SORT_NUM_BUCKETS_POWER_TWO(
-        "hive.exec.infer.bucket.sort.num.buckets.power.two", false,
-        "If this is set, when setting the number of reducers for the map reduce task which writes the\n" +
-        "final output files, it will choose a number which is a power of two, unless the user specifies\n" +
-        "the number of reducers to use using mapred.reduce.tasks.  The number of reducers\n" +
-        "may be set to a power of two, only to be followed by a merge task meaning preventing\n" +
-        "anything from being inferred.\n" +
-        "With hive.exec.infer.bucket.sort set to true:\n" +
-        "Advantages:  If this is not set, the number of buckets for partitions will seem arbitrary,\n" +
-        "             which means that the number of mappers used for optimized joins, for example, will\n" +
-        "             be very low.  With this set, since the number of buckets used for any partition is\n" +
-        "             a power of two, the number of mappers used for optimized joins will be the least\n" +
-        "             number of buckets used by any partition being joined.\n" +
-        "Disadvantages: This may mean a much larger or much smaller number of reducers being used in the\n" +
-        "               final map reduce job, e.g. if a job was originally going to take 257 reducers,\n" +
-        "               it will now take 512 reducers, similarly if the max number of reducers is 511,\n" +
-        "               and a job was going to use this many, it will now use 256 reducers."),
-
-    HIVEOPTLISTBUCKETING("hive.optimize.listbucketing", false,
-        "Enable list bucketing optimizer. Default value is false so that we disable it by default."),
-
-    // Allow TCP Keep alive socket option for for HiveServer or a maximum timeout for the socket.
-    SERVER_READ_SOCKET_TIMEOUT("hive.server.read.socket.timeout", "10s",
-        new TimeValidator(TimeUnit.SECONDS),
-        "Timeout for the HiveServer to close the connection if no response from the client. By default, 10 seconds."),
-    SERVER_TCP_KEEP_ALIVE("hive.server.tcp.keepalive", true,
-        "Whether to enable TCP keepalive for the Hive Server. Keepalive will prevent accumulation of half-open connections."),
-
-    HIVE_DECODE_PARTITION_NAME("hive.decode.partition.name", false,
-        "Whether to show the unquoted partition names in query results."),
-
-    HIVE_EXECUTION_ENGINE("hive.execution.engine", "mr", new StringSet("mr", "tez", "spark"),
-        "Chooses execution engine. Options are: mr (Map reduce, default), tez (hadoop 2 only), spark"),
-    HIVE_JAR_DIRECTORY("hive.jar.directory", null,
-        "This is the location hive in tez mode will look for to find a site wide \n" +
-        "installed hive instance."),
-    HIVE_USER_INSTALL_DIR("hive.user.install.directory", "hdfs:///user/",
-        "If hive (in tez mode only) cannot find a usable hive jar in \"hive.jar.directory\", \n" +
-        "it will upload the hive jar to \"hive.user.install.directory/user.name\"\n" +
-        "and use it to run queries."),
-
-    // Vectorization enabled
-    HIVE_VECTORIZATION_ENABLED("hive.vectorized.execution.enabled", false,
-        "This flag should be set to true to enable vectorized mode of query execution.\n" +
-        "The default value is false."),
-    HIVE_VECTORIZATION_REDUCE_ENABLED("hive.vectorized.execution.reduce.enabled", true,
-        "This flag should be set to true to enable vectorized mode of the reduce-side of query execution.\n" +
-        "The default value is true."),
-    HIVE_VECTORIZATION_REDUCE_GROUPBY_ENABLED("hive.vectorized.execution.reduce.groupby.enabled", true,
-        "This flag should be set to true to enable vectorized mode of the reduce-side GROUP BY query execution.\n" +
-        "The default value is true."),
-    HIVE_VECTORIZATION_MAPJOIN_NATIVE_ENABLED("hive.vectorized.execution.mapjoin.native.enabled", true,
-         "This flag should be set to true to enable native (i.e. non-pass through) vectorization\n" +
-         "of queries using MapJoin.\n" +
-         "The default value is true."),
-    HIVE_VECTORIZATION_MAPJOIN_NATIVE_MULTIKEY_ONLY_ENABLED("hive.vectorized.execution.mapjoin.native.multikey.only.enabled", false,
-         "This flag should be set to true to restrict use of native vector map join hash tables to\n" +
-         "the MultiKey in queries using MapJoin.\n" +
-         "The default value is false."),
-    HIVE_VECTORIZATION_MAPJOIN_NATIVE_MINMAX_ENABLED("hive.vectorized.execution.mapjoin.minmax.enabled", false,
-         "This flag should be set to true to enable vector map join hash tables to\n" +
-         "use max / max filtering for integer join queries using MapJoin.\n" +
-         "The default value is false."),
-    HIVE_VECTORIZATION_MAPJOIN_NATIVE_OVERFLOW_REPEATED_THRESHOLD("hive.vectorized.execution.mapjoin.overflow.repeated.threshold", -1,
-         "The number of small table rows for a match in vector map join hash tables\n" +
-         "where we use the repeated field optimization in overflow vectorized row batch for join queries using MapJoin.\n" +
-         "A value of -1 means do use the join result optimization.  Otherwise, threshold value can be 0 to maximum integer."),
-    HIVE_VECTORIZATION_MAPJOIN_NATIVE_FAST_HASHTABLE_ENABLED("hive.vectorized.execution.mapjoin.native.fast.hashtable.enabled", false,
-         "This flag should be set to true to enable use of native fast vector map join hash tables in\n" +
-         "queries using MapJoin.\n" +
-         "The default value is false."),
-    HIVE_VECTORIZATION_GROUPBY_CHECKINTERVAL("hive.vectorized.groupby.checkinterval", 100000,
-        "Number of entries added to the group by aggregation hash before a recomputation of average entry size is performed."),
-    HIVE_VECTORIZATION_GROUPBY_MAXENTRIES("hive.vectorized.groupby.maxentries", 1000000,
-        "Max number of entries in the vector group by aggregation hashtables. \n" +
-        "Exceeding this will trigger a flush irrelevant of memory pressure condition."),
-    HIVE_VECTORIZATION_GROUPBY_FLUSH_PERCENT("hive.vectorized.groupby.flush.percent", (float) 0.1,
-        "Percent of entries in the group by aggregation hash flushed when the memory threshold is exceeded."),
-
-    HIVE_TYPE_CHECK_ON_INSERT("hive.typecheck.on.insert", true, "This property has been extended to control "
-        + "whether to check, convert, and normalize partition value to conform to its column type in "
-        + "partition operations including but not limited to insert, such as alter, describe etc."),
-
-    HIVE_HADOOP_CLASSPATH("hive.hadoop.classpath", null,
-        "For Windows OS, we need to pass HIVE_HADOOP_CLASSPATH Java parameter while starting HiveServer2 \n" +
-        "using \"-hiveconf hive.hadoop.classpath=%HIVE_LIB%\"."),
-
-    HIVE_RPC_QUERY_PLAN("hive.rpc.query.plan", false,
-        "Whether to send the query plan via local resource or RPC"),
-    HIVE_AM_SPLIT_GENERATION("hive.compute.splits.in.am", true,
-        "Whether to generate the splits locally or in the AM (tez only)"),
-
-    HIVE_PREWARM_ENABLED("hive.prewarm.enabled", false, "Enables container prewarm for Tez (Hadoop 2 only)"),
-    HIVE_PREWARM_NUM_CONTAINERS("hive.prewarm.numcontainers", 10, "Controls the number of containers to prewarm for Tez (Hadoop 2 only)"),
-
-    HIVESTAGEIDREARRANGE("hive.stageid.rearrange", "none", new StringSet("none", "idonly", "traverse", "execution"), ""),
-    HIVEEXPLAINDEPENDENCYAPPENDTASKTYPES("hive.explain.dependency.append.tasktype", false, ""),
-
-    HIVECOUNTERGROUP("hive.counters.group.name", "HIVE",
-        "The name of counter group for internal Hive variables (CREATED_FILE, FATAL_ERROR, etc.)"),
-
-    HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
-        "A list of comma separated values corresponding to YARN queues of the same name.\n" +
-        "When HiveServer2 is launched in Tez mode, this configuration needs to be set\n" +
-        "for multiple Tez sessions to run in parallel on the cluster."),
-    HIVE_SERVER2_TEZ_SESSIONS_PER_DEFAULT_QUEUE("hive.server2.tez.sessions.per.default.queue", 1,
-        "A positive integer that determines the number of Tez sessions that should be\n" +
-        "launched on each of the queues specified by \"hive.server2.tez.default.queues\".\n" +
-        "Determines the parallelism on each queue."),
-    HIVE_SERVER2_TEZ_INITIALIZE_DEFAULT_SESSIONS("hive.server2.tez.initialize.default.sessions", false,
-        "This flag is used in HiveServer2 to enable a user to use HiveServer2 without\n" +
-        "turning on Tez for HiveServer2. The user could potentially want to run queries\n" +
-        "over Tez without the pool of sessions."),
-
-    HIVE_QUOTEDID_SUPPORT("hive.support.quoted.identifiers", "column",
-        new StringSet("none", "column"),
-        "Whether to use quoted identifier. 'none' or 'column' can be used. \n" +
-        "  none: default(past) behavior. Implies only alphaNumeric and underscore are valid characters in identifiers.\n" +
-        "  column: implies column names can contain any character."
-    ),
-    HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS("hive.support.sql11.reserved.keywords", true,
-        "This flag should be set to true to enable support for SQL2011 reserved keywords.\n" +
-        "The default value is true."),
-    // role names are case-insensitive
-    USERS_IN_ADMIN_ROLE("hive.users.in.admin.role", "", false,
-        "Comma separated list of users who are in admin role for bootstrapping.\n" +
-        "More users can be added in ADMIN role later."),
-
-    HIVE_COMPAT("hive.compat", HiveCompat.DEFAULT_COMPAT_LEVEL,
-        "Enable (configurable) deprecated behaviors by setting desired level of backward compatibility.\n" +
-        "Setting to 0.12:\n" +
-        "  Maintains division behavior: int / int = double"),
-    HIVE_CONVERT_JOIN_BUCKET_MAPJOIN_TEZ("hive.convert.join.bucket.mapjoin.tez", false,
-        "Whether joins can be automatically converted to bucket map joins in hive \n" +
-        "when tez is used as the execution engine."),
-
-    HIVE_CHECK_CROSS_PRODUCT("hive.exec.check.crossproducts", true,
-        "Check if a plan contains a Cross Product. If there is one, output a warning to the Session's console."),
-    HIVE_LOCALIZE_RESOURCE_WAIT_INTERVAL("hive.localize.resource.wait.interval", "5000ms",
-        new TimeValidator(TimeUnit.MILLISECONDS),
-        "Time to wait for another thread to localize the same resource for hive-tez."),
-    HIVE_LOCALIZE_RESOURCE_NUM_WAIT_ATTEMPTS("hive.localize.resource.num.wait.attempts", 5,
-        "The number of attempts waiting for localizing a resource in hive-tez."),
-    TEZ_AUTO_REDUCER_PARALLELISM("hive.tez.auto.reducer.parallelism", false,
-        "Turn on Tez' auto reducer parallelism feature. When enabled, Hive will still estimate data sizes\n" +
-        "and set parallelism estimates. Tez will sample source vertices' output sizes and adjust the estimates at runtime as\n" +
-        "necessary."),
-    TEZ_MAX_PARTITION_FACTOR("hive.tez.max.partition.factor", 2f,
-        "When auto reducer parallelism is enabled this factor will be used to over-partition data in shuffle edges."),
-    TEZ_MIN_PARTITION_FACTOR("hive.tez.min.partition.factor", 0.25f,
-        "When auto reducer parallelism is enabled this factor will be used to put a lower limit to the number\n" +
-        "of reducers that tez specifies."),
-    TEZ_DYNAMIC_PARTITION_PRUNING(
-        "hive.tez.dynamic.partition.pruning", true,
-        "When dynamic pruning is enabled, joins on partition keys will be processed by sending\n" +
-        "events from the processing vertices to the Tez application master. These events will be\n" +
-        "used to prune unnecessary partitions."),
-    TEZ_DYNAMIC_PARTITION_PRUNING_MAX_EVENT_SIZE("hive.tez.dynamic.partition.pruning.max.event.size", 1*1024*1024L,
-        "Maximum size of events sent by processors in dynamic pruning. If this size is crossed no pruning will take place."),
-    TEZ_DYNAMIC_PARTITION_PRUNING_MAX_DATA_SIZE("hive.tez.dynamic.partition.pruning.max.data.size", 100*1024*1024L,
-        "Maximum total data size of events in dynamic pruning."),
-    TEZ_SMB_NUMBER_WAVES(
-        "hive.tez.smb.number.waves",
-        (float) 0.5,
-        "The number of waves in which to run the SMB join. Account for cluster being occupied. Ideally should be 1 wave."),
-    TEZ_EXEC_SUMMARY(
-        "hive.tez.exec.print.summary",
-        false,
-        "Display breakdown of execution steps, for every query executed by the shell."),
-    TEZ_EXEC_INPLACE_PROGRESS(
-        "hive.tez.exec.inplace.progress",
-        true,
-        "Updates tez job execution progress in-place in the terminal."),
-    SPARK_CLIENT_FUTURE_TIMEOUT("hive.spark.client.future.timeout",
-      "60s", new TimeValidator(TimeUnit.SECONDS),
-      "Timeout for requests from Hive client to remote Spark driver."),
-    SPARK_JOB_MONITOR_TIMEOUT("hive.spark.job.monitor.timeout",
-      "60s", new TimeValidator(TimeUnit.SECONDS),
-      "Timeout for job monitor to get Spark job state."),
-    SPARK_RPC_CLIENT_CONNECT_TIMEOUT("hive.spark.client.connect.timeout",
-      "1000ms", new TimeValidator(TimeUnit.MILLISECONDS),
-      "Timeout for remote Spark driver in connecting back to Hive client."),
-    SPARK_RPC_CLIENT_HANDSHAKE_TIMEOUT("hive.spark.client.server.connect.timeout",
-      "90000ms", new TimeValidator(TimeUnit.MILLISECONDS),
-      "Timeout for handshake between Hive client and remote Spark driver.  Checked by both processes."),
-    SPARK_RPC_SECRET_RANDOM_BITS("hive.spark.client.secret.bits", "256",
-      "Number of bits of randomness in the generated secret for communication between Hive client and remote Spark driver. " +
-      "Rounded down to the nearest multiple of 8."),
-    SPARK_RPC_MAX_THREADS("hive.spark.client.rpc.threads", 8,
-      "Maximum number of threads for remote Spark driver's RPC event loop."),
-    SPARK_RPC_MAX_MESSAGE_SIZE("hive.spark.client.rpc.max.size", 50 * 1024 * 1024,
-      "Maximum message size in bytes for communication between Hive client and remote Spark driver. Default is 50MB."),
-    SPARK_RPC_CHANNEL_LOG_LEVEL("hive.spark.client.channel.log.level", null,
-      "Channel logging level for remote Spark driver.  One of {DEBUG, ERROR, INFO, TRACE, WARN}."),
-    SPARK_RPC_SASL_MECHANISM("hive.spark.client.rpc.sasl.mechanisms", "DIGEST-MD5",
-      "Name of the SASL mechanism to use for authentication."),
-    NWAYJOINREORDER("hive.reorder.nway.joins", true,
-      "Runs reordering of tables within single n-way join (i.e.: picks streamtable)"),
-    HIVE_LOG_N_RECORDS("hive.log.every.n.records", 0L, new RangeValidator(0L, null),
-      "If value is greater than 0 logs in fixed intervals of size n rather than exponentially.");
-
-    public final String varname;
-    private final String defaultExpr;
-
-    public final String defaultStrVal;
-    public final int defaultIntVal;
-    public final long defaultLongVal;
-    public final float defaultFloatVal;
-    public final boolean defaultBoolVal;
-
-    private final Class<?> valClass;
-    private final VarType valType;
-
-    private final Validator validator;
-
-    private final String description;
-
-    private final boolean excluded;
-    private final boolean caseSensitive;
-
-    ConfVars(String varname, Object defaultVal, String description) {
-      this(varname, defaultVal, null, description, true, false);
+    public void setSparkConfigUpdated(boolean isSparkConfigUpdated) {
+        this.isSparkConfigUpdated = isSparkConfigUpdated;
     }
 
-    ConfVars(String varname, Object defaultVal, String description, boolean excluded) {
-      this(varname, defaultVal, null, description, true, excluded);
-    }
-
-    ConfVars(String varname, String defaultVal, boolean caseSensitive, String description) {
-      this(varname, defaultVal, null, description, caseSensitive, false);
-    }
-
-    ConfVars(String varname, Object defaultVal, Validator validator, String description) {
-      this(varname, defaultVal, validator, description, true, false);
-    }
-
-    ConfVars(String varname, Object defaultVal, Validator validator, String description, boolean caseSensitive, boolean excluded) {
-      this.varname = varname;
-      this.validator = validator;
-      this.description = description;
-      this.defaultExpr = defaultVal == null ? null : String.valueOf(defaultVal);
-      this.excluded = excluded;
-      this.caseSensitive = caseSensitive;
-      if (defaultVal == null || defaultVal instanceof String) {
-        this.valClass = String.class;
-        this.valType = VarType.STRING;
-        this.defaultStrVal = SystemVariables.substitute((String)defaultVal);
-        this.defaultIntVal = -1;
-        this.defaultLongVal = -1;
-        this.defaultFloatVal = -1;
-        this.defaultBoolVal = false;
-      } else if (defaultVal instanceof Integer) {
-        this.valClass = Integer.class;
-        this.valType = VarType.INT;
-        this.defaultStrVal = null;
-        this.defaultIntVal = (Integer)defaultVal;
-        this.defaultLongVal = -1;
-        this.defaultFloatVal = -1;
-        this.defaultBoolVal = false;
-      } else if (defaultVal instanceof Long) {
-        this.valClass = Long.class;
-        this.valType = VarType.LONG;
-        this.defaultStrVal = null;
-        this.defaultIntVal = -1;
-        this.defaultLongVal = (Long)defaultVal;
-        this.defaultFloatVal = -1;
-        this.defaultBoolVal = false;
-      } else if (defaultVal instanceof Float) {
-        this.valClass = Float.class;
-        this.valType = VarType.FLOAT;
-        this.defaultStrVal = null;
-        this.defaultIntVal = -1;
-        this.defaultLongVal = -1;
-        this.defaultFloatVal = (Float)defaultVal;
-        this.defaultBoolVal = false;
-      } else if (defaultVal instanceof Boolean) {
-        this.valClass = Boolean.class;
-        this.valType = VarType.BOOLEAN;
-        this.defaultStrVal = null;
-        this.defaultIntVal = -1;
-        this.defaultLongVal = -1;
-        this.defaultFloatVal = -1;
-        this.defaultBoolVal = (Boolean)defaultVal;
-      } else {
-        throw new IllegalArgumentException("Not supported type value " + defaultVal.getClass() +
-            " for name " + varname);
-      }
-    }
-
-    public boolean isType(String value) {
-      return valType.isType(value);
-    }
-
-    public Validator getValidator() {
-      return validator;
-    }
-
-    public String validate(String value) {
-      return validator == null ? null : validator.validate(value);
-    }
-
-    public String validatorDescription() {
-      return validator == null ? null : validator.toDescription();
-    }
-
-    public String typeString() {
-      String type = valType.typeString();
-      if (valType == VarType.STRING && validator != null) {
-        if (validator instanceof TimeValidator) {
-          type += "(TIME)";
+    static {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = HiveConf.class.getClassLoader();
         }
-      }
-      return type;
-    }
 
-    public String getRawDescription() {
-      return description;
-    }
+        hiveDefaultURL = classLoader.getResource("hive-default.xml");
 
-    public String getDescription() {
-      String validator = validatorDescription();
-      if (validator != null) {
-        return validator + ".\n" + description;
-      }
-      return description;
-    }
+        // Look for hive-site.xml on the CLASSPATH and log its location if found.
+        hiveSiteURL = classLoader.getResource("hive-site.xml");
+        hivemetastoreSiteUrl = classLoader.getResource("hivemetastore-site.xml");
+        hiveServer2SiteUrl = classLoader.getResource("hiveserver2-site.xml");
 
-    public boolean isExcluded() {
-      return excluded;
-    }
-
-    public boolean isCaseSensitive() {
-      return caseSensitive;
-    }
-
-    @Override
-    public String toString() {
-      return varname;
-    }
-
-    private static String findHadoopBinary() {
-      String val = System.getenv("HADOOP_HOME");
-      // In Hadoop 1.X and Hadoop 2.X HADOOP_HOME is gone and replaced with HADOOP_PREFIX
-      if (val == null) {
-        val = System.getenv("HADOOP_PREFIX");
-      }
-      // and if all else fails we can at least try /usr/bin/hadoop
-      val = (val == null ? File.separator + "usr" : val)
-        + File.separator + "bin" + File.separator + "hadoop";
-      // Launch hadoop command file on windows.
-      return val + (Shell.WINDOWS ? ".cmd" : "");
-    }
-
-    public String getDefaultValue() {
-      return valType.defaultValueString(this);
-    }
-
-    public String getDefaultExpr() {
-      return defaultExpr;
-    }
-
-    enum VarType {
-      STRING {
-        @Override
-        void checkType(String value) throws Exception { }
-        @Override
-        String defaultValueString(ConfVars confVar) { return confVar.defaultStrVal; }
-      },
-      INT {
-        @Override
-        void checkType(String value) throws Exception { Integer.valueOf(value); }
-      },
-      LONG {
-        @Override
-        void checkType(String value) throws Exception { Long.valueOf(value); }
-      },
-      FLOAT {
-        @Override
-        void checkType(String value) throws Exception { Float.valueOf(value); }
-      },
-      BOOLEAN {
-        @Override
-        void checkType(String value) throws Exception { Boolean.valueOf(value); }
-      };
-
-      boolean isType(String value) {
-        try { checkType(value); } catch (Exception e) { return false; }
-        return true;
-      }
-      String typeString() { return name().toUpperCase();}
-      String defaultValueString(ConfVars confVar) { return confVar.defaultExpr; }
-      abstract void checkType(String value) throws Exception;
-    }
-  }
-
-  /**
-   * Writes the default ConfVars out to a byte array and returns an input
-   * stream wrapping that byte array.
-   *
-   * We need this in order to initialize the ConfVar properties
-   * in the underling Configuration object using the addResource(InputStream)
-   * method.
-   *
-   * It is important to use a LoopingByteArrayInputStream because it turns out
-   * addResource(InputStream) is broken since Configuration tries to read the
-   * entire contents of the same InputStream repeatedly without resetting it.
-   * LoopingByteArrayInputStream has special logic to handle this.
-   */
-  private static synchronized InputStream getConfVarInputStream() {
-    if (confVarByteArray == null) {
-      try {
-        // Create a Hadoop configuration without inheriting default settings.
-        Configuration conf = new Configuration(false);
-
-        applyDefaultNonNullConfVars(conf);
-
-        ByteArrayOutputStream confVarBaos = new ByteArrayOutputStream();
-        conf.writeXml(confVarBaos);
-        confVarByteArray = confVarBaos.toByteArray();
-      } catch (Exception e) {
-        // We're pretty screwed if we can't load the default conf vars
-        throw new RuntimeException("Failed to initialize default Hive configuration variables!", e);
-      }
-    }
-    return new LoopingByteArrayInputStream(confVarByteArray);
-  }
-
-  public void verifyAndSet(String name, String value) throws IllegalArgumentException {
-    if (modWhiteListPattern != null) {
-      Matcher wlMatcher = modWhiteListPattern.matcher(name);
-      if (!wlMatcher.matches()) {
-        throw new IllegalArgumentException("Cannot modify " + name + " at runtime. "
-            + "It is not in list of params that are allowed to be modified at runtime");
-      }
-    }
-    if (restrictList.contains(name)) {
-      throw new IllegalArgumentException("Cannot modify " + name + " at runtime. It is in the list"
-          + "of parameters that can't be modified at runtime");
-    }
-    isSparkConfigUpdated = isSparkRelatedConfig(name);
-    set(name, value);
-  }
-
-  /**
-   * check whether spark related property is updated, which includes spark configurations,
-   * RSC configurations and yarn configuration in Spark on YARN mode.
-   * @param name
-   * @return
-   */
-  private boolean isSparkRelatedConfig(String name) {
-    boolean result = false;
-    if (name.startsWith("spark")) { // Spark property.
-      result = true;
-    } else if (name.startsWith("yarn")) { // YARN property in Spark on YARN mode.
-      String sparkMaster = get("spark.master");
-      if (sparkMaster != null &&
-        (sparkMaster.equals("yarn-client") || sparkMaster.equals("yarn-cluster"))) {
-        result = true;
-      }
-    } else if (name.startsWith("hive.spark")) { // Remote Spark Context property.
-      result = true;
-    }
-
-    return result;
-  }
-
-  public static int getIntVar(Configuration conf, ConfVars var) {
-    assert (var.valClass == Integer.class) : var.varname;
-    return conf.getInt(var.varname, var.defaultIntVal);
-  }
-
-  public static void setIntVar(Configuration conf, ConfVars var, int val) {
-    assert (var.valClass == Integer.class) : var.varname;
-    conf.setInt(var.varname, val);
-  }
-
-  public int getIntVar(ConfVars var) {
-    return getIntVar(this, var);
-  }
-
-  public void setIntVar(ConfVars var, int val) {
-    setIntVar(this, var, val);
-  }
-
-  public static long getTimeVar(Configuration conf, ConfVars var, TimeUnit outUnit) {
-    return toTime(getVar(conf, var), getDefaultTimeUnit(var), outUnit);
-  }
-
-  public static void setTimeVar(Configuration conf, ConfVars var, long time, TimeUnit timeunit) {
-    assert (var.valClass == String.class) : var.varname;
-    conf.set(var.varname, time + stringFor(timeunit));
-  }
-
-  public long getTimeVar(ConfVars var, TimeUnit outUnit) {
-    return getTimeVar(this, var, outUnit);
-  }
-
-  public void setTimeVar(ConfVars var, long time, TimeUnit outUnit) {
-    setTimeVar(this, var, time, outUnit);
-  }
-
-  private static TimeUnit getDefaultTimeUnit(ConfVars var) {
-    TimeUnit inputUnit = null;
-    if (var.validator instanceof TimeValidator) {
-      inputUnit = ((TimeValidator)var.validator).getTimeUnit();
-    }
-    return inputUnit;
-  }
-
-  public static long toTime(String value, TimeUnit inputUnit, TimeUnit outUnit) {
-    String[] parsed = parseTime(value.trim());
-    return outUnit.convert(Long.valueOf(parsed[0].trim().trim()), unitFor(parsed[1].trim(), inputUnit));
-  }
-
-  private static String[] parseTime(String value) {
-    char[] chars = value.toCharArray();
-    int i = 0;
-    for (; i < chars.length && (chars[i] == '-' || Character.isDigit(chars[i])); i++) {
-    }
-    return new String[] {value.substring(0, i), value.substring(i)};
-  }
-
-  public static TimeUnit unitFor(String unit, TimeUnit defaultUnit) {
-    unit = unit.trim().toLowerCase();
-    if (unit.isEmpty() || unit.equals("l")) {
-      if (defaultUnit == null) {
-        throw new IllegalArgumentException("Time unit is not specified");
-      }
-      return defaultUnit;
-    } else if (unit.equals("d") || unit.startsWith("day")) {
-      return TimeUnit.DAYS;
-    } else if (unit.equals("h") || unit.startsWith("hour")) {
-      return TimeUnit.HOURS;
-    } else if (unit.equals("m") || unit.startsWith("min")) {
-      return TimeUnit.MINUTES;
-    } else if (unit.equals("s") || unit.startsWith("sec")) {
-      return TimeUnit.SECONDS;
-    } else if (unit.equals("ms") || unit.startsWith("msec")) {
-      return TimeUnit.MILLISECONDS;
-    } else if (unit.equals("us") || unit.startsWith("usec")) {
-      return TimeUnit.MICROSECONDS;
-    } else if (unit.equals("ns") || unit.startsWith("nsec")) {
-      return TimeUnit.NANOSECONDS;
-    }
-    throw new IllegalArgumentException("Invalid time unit " + unit);
-  }
-
-  public static String stringFor(TimeUnit timeunit) {
-    switch (timeunit) {
-      case DAYS: return "day";
-      case HOURS: return "hour";
-      case MINUTES: return "min";
-      case SECONDS: return "sec";
-      case MILLISECONDS: return "msec";
-      case MICROSECONDS: return "usec";
-      case NANOSECONDS: return "nsec";
-    }
-    throw new IllegalArgumentException("Invalid timeunit " + timeunit);
-  }
-
-  public static long getLongVar(Configuration conf, ConfVars var) {
-    assert (var.valClass == Long.class) : var.varname;
-    return conf.getLong(var.varname, var.defaultLongVal);
-  }
-
-  public static long getLongVar(Configuration conf, ConfVars var, long defaultVal) {
-    return conf.getLong(var.varname, defaultVal);
-  }
-
-  public static void setLongVar(Configuration conf, ConfVars var, long val) {
-    assert (var.valClass == Long.class) : var.varname;
-    conf.setLong(var.varname, val);
-  }
-
-  public long getLongVar(ConfVars var) {
-    return getLongVar(this, var);
-  }
-
-  public void setLongVar(ConfVars var, long val) {
-    setLongVar(this, var, val);
-  }
-
-  public static float getFloatVar(Configuration conf, ConfVars var) {
-    assert (var.valClass == Float.class) : var.varname;
-    return conf.getFloat(var.varname, var.defaultFloatVal);
-  }
-
-  public static float getFloatVar(Configuration conf, ConfVars var, float defaultVal) {
-    return conf.getFloat(var.varname, defaultVal);
-  }
-
-  public static void setFloatVar(Configuration conf, ConfVars var, float val) {
-    assert (var.valClass == Float.class) : var.varname;
-    conf.setFloat(var.varname, val);
-  }
-
-  public float getFloatVar(ConfVars var) {
-    return getFloatVar(this, var);
-  }
-
-  public void setFloatVar(ConfVars var, float val) {
-    setFloatVar(this, var, val);
-  }
-
-  public static boolean getBoolVar(Configuration conf, ConfVars var) {
-    assert (var.valClass == Boolean.class) : var.varname;
-    return conf.getBoolean(var.varname, var.defaultBoolVal);
-  }
-
-  public static boolean getBoolVar(Configuration conf, ConfVars var, boolean defaultVal) {
-    return conf.getBoolean(var.varname, defaultVal);
-  }
-
-  public static void setBoolVar(Configuration conf, ConfVars var, boolean val) {
-    assert (var.valClass == Boolean.class) : var.varname;
-    conf.setBoolean(var.varname, val);
-  }
-
-  public boolean getBoolVar(ConfVars var) {
-    return getBoolVar(this, var);
-  }
-
-  public void setBoolVar(ConfVars var, boolean val) {
-    setBoolVar(this, var, val);
-  }
-
-  public static String getVar(Configuration conf, ConfVars var) {
-    assert (var.valClass == String.class) : var.varname;
-    return conf.get(var.varname, var.defaultStrVal);
-  }
-
-  public static String getVar(Configuration conf, ConfVars var, String defaultVal) {
-    return conf.get(var.varname, defaultVal);
-  }
-
-  public static void setVar(Configuration conf, ConfVars var, String val) {
-    assert (var.valClass == String.class) : var.varname;
-    conf.set(var.varname, val);
-  }
-
-  public static ConfVars getConfVars(String name) {
-    return vars.get(name);
-  }
-
-  public static ConfVars getMetaConf(String name) {
-    return metaConfs.get(name);
-  }
-
-  public String getVar(ConfVars var) {
-    return getVar(this, var);
-  }
-
-  public void setVar(ConfVars var, String val) {
-    setVar(this, var, val);
-  }
-
-  public void logVars(PrintStream ps) {
-    for (ConfVars one : ConfVars.values()) {
-      ps.println(one.varname + "=" + ((get(one.varname) != null) ? get(one.varname) : ""));
-    }
-  }
-
-  public HiveConf() {
-    super();
-    initialize(this.getClass());
-  }
-
-  public HiveConf(Class<?> cls) {
-    super();
-    initialize(cls);
-  }
-
-  public HiveConf(Configuration other, Class<?> cls) {
-    super(other);
-    initialize(cls);
-  }
-
-  /**
-   * Copy constructor
-   */
-  public HiveConf(HiveConf other) {
-    super(other);
-    hiveJar = other.hiveJar;
-    auxJars = other.auxJars;
-    origProp = (Properties)other.origProp.clone();
-    restrictList.addAll(other.restrictList);
-    modWhiteListPattern = other.modWhiteListPattern;
-  }
-
-  public Properties getAllProperties() {
-    return getProperties(this);
-  }
-
-  private static Properties getProperties(Configuration conf) {
-    Iterator<Map.Entry<String, String>> iter = conf.iterator();
-    Properties p = new Properties();
-    while (iter.hasNext()) {
-      Map.Entry<String, String> e = iter.next();
-      p.setProperty(e.getKey(), e.getValue());
-    }
-    return p;
-  }
-
-  private void initialize(Class<?> cls) {
-    hiveJar = (new JobConf(cls)).getJar();
-
-    // preserve the original configuration
-    origProp = getAllProperties();
-
-    // Overlay the ConfVars. Note that this ignores ConfVars with null values
-    addResource(getConfVarInputStream());
-
-    // Overlay hive-site.xml if it exists
-    if (hiveSiteURL != null) {
-      addResource(hiveSiteURL);
-    }
-
-    // if embedded metastore is to be used as per config so far
-    // then this is considered like the metastore server case
-    String msUri = this.getVar(HiveConf.ConfVars.METASTOREURIS);
-    if(HiveConfUtil.isEmbeddedMetaStore(msUri)){
-      setLoadMetastoreConfig(true);
-    }
-
-    // load hivemetastore-site.xml if this is metastore and file exists
-    if (isLoadMetastoreConfig() && hivemetastoreSiteUrl != null) {
-      addResource(hivemetastoreSiteUrl);
-    }
-
-    // load hiveserver2-site.xml if this is hiveserver2 and file exists
-    // metastore can be embedded within hiveserver2, in such cases
-    // the conf params in hiveserver2-site.xml will override whats defined
-    // in hivemetastore-site.xml
-    if (isLoadHiveServer2Config() && hiveServer2SiteUrl != null) {
-      addResource(hiveServer2SiteUrl);
-    }
-
-    // Overlay the values of any system properties whose names appear in the list of ConfVars
-    applySystemProperties();
-
-    if ((this.get("hive.metastore.ds.retry.attempts") != null) ||
-      this.get("hive.metastore.ds.retry.interval") != null) {
-        l4j.warn("DEPRECATED: hive.metastore.ds.retry.* no longer has any effect.  " +
-        "Use hive.hmshandler.retry.* instead");
-    }
-
-    // if the running class was loaded directly (through eclipse) rather than through a
-    // jar then this would be needed
-    if (hiveJar == null) {
-      hiveJar = this.get(ConfVars.HIVEJAR.varname);
-    }
-
-    if (auxJars == null) {
-      auxJars = this.get(ConfVars.HIVEAUXJARS.varname);
-    }
-
-    if (getBoolVar(ConfVars.METASTORE_SCHEMA_VERIFICATION)) {
-      setBoolVar(ConfVars.METASTORE_AUTO_CREATE_SCHEMA, false);
-      setBoolVar(ConfVars.METASTORE_FIXED_DATASTORE, true);
-    }
-
-    if (getBoolVar(HiveConf.ConfVars.HIVECONFVALIDATION)) {
-      List<String> trimmed = new ArrayList<String>();
-      for (Map.Entry<String,String> entry : this) {
-        String key = entry.getKey();
-        if (key == null || !key.startsWith("hive.")) {
-          continue;
+        for (ConfVars confVar : ConfVars.values()) {
+            vars.put(confVar.varname, confVar);
         }
-        ConfVars var = HiveConf.getConfVars(key);
-        if (var == null) {
-          var = HiveConf.getConfVars(key.trim());
-          if (var != null) {
-            trimmed.add(key);
-          }
+    }
+
+    /**
+     * Metastore related options that the db is initialized against. When a conf
+     * var in this is list is changed, the metastore instance for the CLI will
+     * be recreated so that the change will take effect.
+     */
+    public static final HiveConf.ConfVars[] metaVars = {
+            HiveConf.ConfVars.METASTOREWAREHOUSE,
+            HiveConf.ConfVars.METASTOREURIS,
+            HiveConf.ConfVars.METASTORETHRIFTCONNECTIONRETRIES,
+            HiveConf.ConfVars.METASTORETHRIFTFAILURERETRIES,
+            HiveConf.ConfVars.METASTORE_CLIENT_CONNECT_RETRY_DELAY,
+            HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT,
+            HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_LIFETIME,
+            HiveConf.ConfVars.METASTOREPWD,
+            HiveConf.ConfVars.METASTORECONNECTURLHOOK,
+            HiveConf.ConfVars.METASTORECONNECTURLKEY,
+            HiveConf.ConfVars.METASTORESERVERMINTHREADS,
+            HiveConf.ConfVars.METASTORESERVERMAXTHREADS,
+            HiveConf.ConfVars.METASTORE_TCP_KEEP_ALIVE,
+            HiveConf.ConfVars.METASTORE_INT_ORIGINAL,
+            HiveConf.ConfVars.METASTORE_INT_ARCHIVED,
+            HiveConf.ConfVars.METASTORE_INT_EXTRACTED,
+            HiveConf.ConfVars.METASTORE_KERBEROS_KEYTAB_FILE,
+            HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL,
+            HiveConf.ConfVars.METASTORE_USE_THRIFT_SASL,
+            HiveConf.ConfVars.METASTORE_CACHE_PINOBJTYPES,
+            HiveConf.ConfVars.METASTORE_CONNECTION_POOLING_TYPE,
+            HiveConf.ConfVars.METASTORE_VALIDATE_TABLES,
+            HiveConf.ConfVars.METASTORE_VALIDATE_COLUMNS,
+            HiveConf.ConfVars.METASTORE_VALIDATE_CONSTRAINTS,
+            HiveConf.ConfVars.METASTORE_STORE_MANAGER_TYPE,
+            HiveConf.ConfVars.METASTORE_AUTO_CREATE_SCHEMA,
+            HiveConf.ConfVars.METASTORE_AUTO_START_MECHANISM_MODE,
+            HiveConf.ConfVars.METASTORE_TRANSACTION_ISOLATION,
+            HiveConf.ConfVars.METASTORE_CACHE_LEVEL2,
+            HiveConf.ConfVars.METASTORE_CACHE_LEVEL2_TYPE,
+            HiveConf.ConfVars.METASTORE_IDENTIFIER_FACTORY,
+            HiveConf.ConfVars.METASTORE_PLUGIN_REGISTRY_BUNDLE_CHECK,
+            HiveConf.ConfVars.METASTORE_AUTHORIZATION_STORAGE_AUTH_CHECKS,
+            HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX,
+            HiveConf.ConfVars.METASTORE_EVENT_LISTENERS,
+            HiveConf.ConfVars.METASTORE_EVENT_CLEAN_FREQ,
+            HiveConf.ConfVars.METASTORE_EVENT_EXPIRY_DURATION,
+            HiveConf.ConfVars.METASTORE_FILTER_HOOK,
+            HiveConf.ConfVars.METASTORE_RAW_STORE_IMPL,
+            HiveConf.ConfVars.METASTORE_END_FUNCTION_LISTENERS,
+            HiveConf.ConfVars.METASTORE_PART_INHERIT_TBL_PROPS,
+            HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_TABLE_PARTITION_MAX,
+            HiveConf.ConfVars.METASTORE_INIT_HOOKS,
+            HiveConf.ConfVars.METASTORE_PRE_EVENT_LISTENERS,
+            HiveConf.ConfVars.HMSHANDLERATTEMPTS,
+            HiveConf.ConfVars.HMSHANDLERINTERVAL,
+            HiveConf.ConfVars.HMSHANDLERFORCERELOADCONF,
+            HiveConf.ConfVars.METASTORE_PARTITION_NAME_WHITELIST_PATTERN,
+            HiveConf.ConfVars.METASTORE_ORM_RETRIEVE_MAPNULLS_AS_EMPTY_STRINGS,
+            HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES,
+            HiveConf.ConfVars.USERS_IN_ADMIN_ROLE,
+            HiveConf.ConfVars.HIVE_AUTHORIZATION_MANAGER,
+            HiveConf.ConfVars.HIVE_TXN_MANAGER,
+            HiveConf.ConfVars.HIVE_TXN_TIMEOUT,
+            HiveConf.ConfVars.HIVE_TXN_MAX_OPEN_BATCH,
+            HiveConf.ConfVars.HIVE_METASTORE_STATS_NDV_DENSITY_FUNCTION,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_ENABLED,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_SIZE,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_PARTITIONS,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_FPP,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_VARIANCE,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_TTL,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_WRITER_WAIT,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_READER_WAIT,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_MAX_FULL,
+            HiveConf.ConfVars.METASTORE_AGGREGATE_STATS_CACHE_CLEAN_UNTIL
+    };
+
+    /**
+     * User configurable Metastore vars
+     */
+    public static final HiveConf.ConfVars[] metaConfVars = {
+            HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL,
+            HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL_DDL,
+            HiveConf.ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT
+    };
+
+    static {
+        for (ConfVars confVar : metaConfVars) {
+            metaConfs.put(confVar.varname, confVar);
         }
-        if (var == null) {
-          l4j.warn("HiveConf of name " + key + " does not exist");
-        } else if (!var.isType(entry.getValue())) {
-          l4j.warn("HiveConf " + var.varname + " expects " + var.typeString() + " type value");
+    }
+
+    /**
+     * dbVars are the parameters can be set per database. If these
+     * parameters are set as a database property, when switching to that
+     * database, the HiveConf variable will be changed. The change of these
+     * parameters will effectively change the DFS and MapReduce clusters
+     * for different databases.
+     */
+    public static final HiveConf.ConfVars[] dbVars = {
+            HiveConf.ConfVars.HADOOPBIN,
+            HiveConf.ConfVars.METASTOREWAREHOUSE,
+            HiveConf.ConfVars.SCRATCHDIR
+    };
+
+    /**
+     * ConfVars.
+     *
+     * These are the default configuration properties for Hive. Each HiveConf
+     * object is initialized as follows:
+     *
+     * 1) Hadoop configuration properties are applied.
+     * 2) ConfVar properties with non-null values are overlayed.
+     * 3) hive-site.xml properties are overlayed.
+     *
+     * WARNING: think twice before adding any Hadoop configuration properties
+     * with non-null values to this list as they will override any values defined
+     * in the underlying Hadoop configuration.
+     */
+    public static enum ConfVars {
+        // QL execution stuff
+        SCRIPTWRAPPER("hive.exec.script.wrapper", null, ""),
+        PLAN("hive.exec.plan", "", ""),
+        PLAN_SERIALIZATION("hive.plan.serialization.format", "kryo",
+                "Query plan format serialization between client and task nodes. \n" +
+                        "Two supported values are : kryo and javaXML. Kryo is default."),
+        STAGINGDIR("hive.exec.stagingdir", ".hive-staging",
+                "Directory name that will be created inside table locations in order to support HDFS encryption. " +
+                        "This is replaces ${hive.exec.scratchdir} for query results with the exception of read-only tables. " +
+                        "In all cases ${hive.exec.scratchdir} is still used for other temporary files, such as job plans."),
+        SCRATCHDIR("hive.exec.scratchdir", "/tmp/hive",
+                "HDFS root scratch dir for Hive jobs which gets created with write all (733) permission. " +
+                        "For each connecting user, an HDFS scratch dir: ${hive.exec.scratchdir}/<username> is created, " +
+                        "with ${hive.scratch.dir.permission}."),
+        LOCALSCRATCHDIR("hive.exec.local.scratchdir",
+                "${system:java.io.tmpdir}" + File.separator + "${system:user.name}",
+                "Local scratch space for Hive jobs"),
+        DOWNLOADED_RESOURCES_DIR("hive.downloaded.resources.dir",
+                "${system:java.io.tmpdir}" + File.separator + "${hive.session.id}_resources",
+                "Temporary local directory for added resources in the remote file system."),
+        SCRATCHDIRPERMISSION("hive.scratch.dir.permission", "700",
+                "The permission for the user specific scratch directories that get created."),
+        SUBMITVIACHILD("hive.exec.submitviachild", false, ""),
+        SUBMITLOCALTASKVIACHILD("hive.exec.submit.local.task.via.child", true,
+                "Determines whether local tasks (typically mapjoin hashtable generation phase) runs in \n" +
+                        "separate JVM (true recommended) or not. \n" +
+                        "Avoids the overhead of spawning new JVM, but can lead to out-of-memory issues."),
+        SCRIPTERRORLIMIT("hive.exec.script.maxerrsize", 100000,
+                "Maximum number of bytes a script is allowed to emit to standard error (per map-reduce task). \n" +
+                        "This prevents runaway scripts from filling logs partitions to capacity"),
+        ALLOWPARTIALCONSUMP("hive.exec.script.allow.partial.consumption", false,
+                "When enabled, this option allows a user script to exit successfully without consuming \n" +
+                        "all the data from the standard input."),
+        STREAMREPORTERPERFIX("stream.stderr.reporter.prefix", "reporter:",
+                "Streaming jobs that log to standard error with this prefix can log counter or status information."),
+        STREAMREPORTERENABLED("stream.stderr.reporter.enabled", true,
+                "Enable consumption of status and counter messages for streaming jobs."),
+        COMPRESSRESULT("hive.exec.compress.output", false,
+                "This controls whether the final outputs of a query (to a local/HDFS file or a Hive table) is compressed. \n" +
+                        "The compression codec and other options are determined from Hadoop config variables mapred.output.compress*"),
+        COMPRESSINTERMEDIATE("hive.exec.compress.intermediate", false,
+                "This controls whether intermediate files produced by Hive between multiple map-reduce jobs are compressed. \n" +
+                        "The compression codec and other options are determined from Hadoop config variables mapred.output.compress*"),
+        COMPRESSINTERMEDIATECODEC("hive.intermediate.compression.codec", "", ""),
+        COMPRESSINTERMEDIATETYPE("hive.intermediate.compression.type", "", ""),
+        BYTESPERREDUCER("hive.exec.reducers.bytes.per.reducer", (long) (256 * 1000 * 1000),
+                "size per reducer.The default is 256Mb, i.e if the input size is 1G, it will use 4 reducers."),
+        MAXREDUCERS("hive.exec.reducers.max", 1009,
+                "max number of reducers will be used. If the one specified in the configuration parameter mapred.reduce.tasks is\n" +
+                        "negative, Hive will use this one as the max number of reducers when automatically determine number of reducers."),
+        PREEXECHOOKS("hive.exec.pre.hooks", "",
+                "Comma-separated list of pre-execution hooks to be invoked for each statement. \n" +
+                        "A pre-execution hook is specified as the name of a Java class which implements the \n" +
+                        "org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext interface."),
+        POSTEXECHOOKS("hive.exec.post.hooks", "",
+                "Comma-separated list of post-execution hooks to be invoked for each statement. \n" +
+                        "A post-execution hook is specified as the name of a Java class which implements the \n" +
+                        "org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext interface."),
+        ONFAILUREHOOKS("hive.exec.failure.hooks", "",
+                "Comma-separated list of on-failure hooks to be invoked for each statement. \n" +
+                        "An on-failure hook is specified as the name of Java class which implements the \n" +
+                        "org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext interface."),
+        QUERYREDACTORHOOKS("hive.exec.query.redactor.hooks", "",
+                "Comma-separated list of hooks to be invoked for each query which can \n" +
+                        "tranform the query before it's placed in the job.xml file. Must be a Java class which \n" +
+                        "extends from the org.apache.hadoop.hive.ql.hooks.Redactor abstract class."),
+        CLIENTSTATSPUBLISHERS("hive.client.stats.publishers", "",
+                "Comma-separated list of statistics publishers to be invoked on counters on each job. \n" +
+                        "A client stats publisher is specified as the name of a Java class which implements the \n" +
+                        "org.apache.hadoop.hive.ql.stats.ClientStatsPublisher interface."),
+        EXECPARALLEL("hive.exec.parallel", false, "Whether to execute jobs in parallel"),
+        EXECPARALLETHREADNUMBER("hive.exec.parallel.thread.number", 8,
+                "How many jobs at most can be executed in parallel"),
+        HIVESPECULATIVEEXECREDUCERS("hive.mapred.reduce.tasks.speculative.execution", true,
+                "Whether speculative execution for reducers should be turned on. "),
+        HIVECOUNTERSPULLINTERVAL("hive.exec.counters.pull.interval", 1000L,
+                "The interval with which to poll the JobTracker for the counters the running job. \n" +
+                        "The smaller it is the more load there will be on the jobtracker, the higher it is the less granular the caught will be."),
+        DYNAMICPARTITIONING("hive.exec.dynamic.partition", true,
+                "Whether or not to allow dynamic partitions in DML/DDL."),
+        DYNAMICPARTITIONINGMODE("hive.exec.dynamic.partition.mode", "strict",
+                "In strict mode, the user must specify at least one static partition\n" +
+                        "in case the user accidentally overwrites all partitions.\n" +
+                        "In nonstrict mode all partitions are allowed to be dynamic."),
+        DYNAMICPARTITIONMAXPARTS("hive.exec.max.dynamic.partitions", 1000,
+                "Maximum number of dynamic partitions allowed to be created in total."),
+        DYNAMICPARTITIONMAXPARTSPERNODE("hive.exec.max.dynamic.partitions.pernode", 100,
+                "Maximum number of dynamic partitions allowed to be created in each mapper/reducer node."),
+        MAXCREATEDFILES("hive.exec.max.created.files", 100000L,
+                "Maximum number of HDFS files created by all mappers/reducers in a MapReduce job."),
+        DEFAULTPARTITIONNAME("hive.exec.default.partition.name", "__HIVE_DEFAULT_PARTITION__",
+                "The default partition name in case the dynamic partition column value is null/empty string or any other values that cannot be escaped. \n" +
+                        "This value must not contain any special character used in HDFS URI (e.g., ':', '%', '/' etc). \n" +
+                        "The user has to be aware that the dynamic partition value should not contain this value to avoid confusions."),
+        DEFAULT_ZOOKEEPER_PARTITION_NAME("hive.lockmgr.zookeeper.default.partition.name", "__HIVE_DEFAULT_ZOOKEEPER_PARTITION__", ""),
+
+        // Whether to show a link to the most failed task + debugging tips
+        SHOW_JOB_FAIL_DEBUG_INFO("hive.exec.show.job.failure.debug.info", true,
+                "If a job fails, whether to provide a link in the CLI to the task with the\n" +
+                        "most failures, along with debugging hints if applicable."),
+        JOB_DEBUG_CAPTURE_STACKTRACES("hive.exec.job.debug.capture.stacktraces", true,
+                "Whether or not stack traces parsed from the task logs of a sampled failed task \n" +
+                        "for each failed job should be stored in the SessionState"),
+        JOB_DEBUG_TIMEOUT("hive.exec.job.debug.timeout", 30000, ""),
+        TASKLOG_DEBUG_TIMEOUT("hive.exec.tasklog.debug.timeout", 20000, ""),
+        OUTPUT_FILE_EXTENSION("hive.output.file.extension", null,
+                "String used as a file extension for output files. \n" +
+                        "If not set, defaults to the codec extension for text files (e.g. \".gz\"), or no extension otherwise."),
+
+        HIVE_IN_TEST("hive.in.test", false, "internal usage only, true in test mode", true),
+
+        HIVE_IN_TEZ_TEST("hive.in.tez.test", false, "internal use only, true when in testing tez",
+                true),
+
+        LOCALMODEAUTO("hive.exec.mode.local.auto", false,
+                "Let Hive determine whether to run in local mode automatically"),
+        LOCALMODEMAXBYTES("hive.exec.mode.local.auto.inputbytes.max", 134217728L,
+                "When hive.exec.mode.local.auto is true, input bytes should less than this for local mode."),
+        LOCALMODEMAXINPUTFILES("hive.exec.mode.local.auto.input.files.max", 4,
+                "When hive.exec.mode.local.auto is true, the number of tasks should less than this for local mode."),
+
+        DROPIGNORESNONEXISTENT("hive.exec.drop.ignorenonexistent", true,
+                "Do not report an error if DROP TABLE/VIEW/Index/Function specifies a non-existent table/view/index/function"),
+
+        HIVEIGNOREMAPJOINHINT("hive.ignore.mapjoin.hint", true, "Ignore the mapjoin hint"),
+
+        HIVE_FILE_MAX_FOOTER("hive.file.max.footer", 100,
+                "maximum number of lines for footer user can define for a table file"),
+
+        HIVE_RESULTSET_USE_UNIQUE_COLUMN_NAMES("hive.resultset.use.unique.column.names", true,
+                "Make column names unique in the result set by qualifying column names with table alias if needed.\n" +
+                        "Table alias will be added to column names for queries of type \"select *\" or \n" +
+                        "if query explicitly uses table alias \"select r1.x..\"."),
+
+        // Hadoop Configuration Properties
+        // Properties with null values are ignored and exist only for the purpose of giving us
+        // a symbolic name to reference in the Hive source code. Properties with non-null
+        // values will override any values set in the underlying Hadoop configuration.
+        HADOOPBIN("hadoop.bin.path", findHadoopBinary(), "", true),
+        HIVE_FS_HAR_IMPL("fs.har.impl", "org.apache.hadoop.hive.shims.HiveHarFileSystem",
+                "The implementation for accessing Hadoop Archives. Note that this won't be applicable to Hadoop versions less than 0.20"),
+        HADOOPFS(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPFS"), null, "", true),
+        HADOOPMAPFILENAME(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPMAPFILENAME"), null, "", true),
+        HADOOPMAPREDINPUTDIR(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPMAPREDINPUTDIR"), null, "", true),
+        HADOOPMAPREDINPUTDIRRECURSIVE(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPMAPREDINPUTDIRRECURSIVE"), false, "", true),
+        MAPREDMAXSPLITSIZE(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMAXSPLITSIZE"), 256000000L, "", true),
+        MAPREDMINSPLITSIZE(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMINSPLITSIZE"), 1L, "", true),
+        MAPREDMINSPLITSIZEPERNODE(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMINSPLITSIZEPERNODE"), 1L, "", true),
+        MAPREDMINSPLITSIZEPERRACK(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDMINSPLITSIZEPERRACK"), 1L, "", true),
+        // The number of reduce tasks per job. Hadoop sets this value to 1 by default
+        // By setting this property to -1, Hive will automatically determine the correct
+        // number of reducers.
+        HADOOPNUMREDUCERS(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPNUMREDUCERS"), -1, "", true),
+        HADOOPJOBNAME(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPJOBNAME"), null, "", true),
+        HADOOPSPECULATIVEEXECREDUCERS(ShimLoader.getHadoopShims().getHadoopConfNames().get("HADOOPSPECULATIVEEXECREDUCERS"), true, "", true),
+        MAPREDSETUPCLEANUPNEEDED(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDSETUPCLEANUPNEEDED"), false, "", true),
+        MAPREDTASKCLEANUPNEEDED(ShimLoader.getHadoopShims().getHadoopConfNames().get("MAPREDTASKCLEANUPNEEDED"), false, "", true),
+
+        // Metastore stuff. Be sure to update HiveConf.metaVars when you add something here!
+        METASTOREWAREHOUSE("hive.metastore.warehouse.dir", "/user/hive/warehouse",
+                "location of default database for the warehouse"),
+        METASTOREURIS("hive.metastore.uris", "",
+                "Thrift URI for the remote metastore. Used by metastore client to connect to remote metastore."),
+
+        METASTORETHRIFTCONNECTIONRETRIES("hive.metastore.connect.retries", 3,
+                "Number of retries while opening a connection to metastore"),
+        METASTORETHRIFTFAILURERETRIES("hive.metastore.failure.retries", 1,
+                "Number of retries upon failure of Thrift metastore calls"),
+
+        METASTORE_CLIENT_CONNECT_RETRY_DELAY("hive.metastore.client.connect.retry.delay", "1s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Number of seconds for the client to wait between consecutive connection attempts"),
+        METASTORE_CLIENT_SOCKET_TIMEOUT("hive.metastore.client.socket.timeout", "600s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "MetaStore Client socket timeout in seconds"),
+        METASTORE_CLIENT_SOCKET_LIFETIME("hive.metastore.client.socket.lifetime", "0s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "MetaStore Client socket lifetime in seconds. After this time is exceeded, client\n" +
+                        "reconnects on the next MetaStore operation. A value of 0s means the connection\n" +
+                        "has an infinite lifetime."),
+        METASTOREPWD("javax.jdo.option.ConnectionPassword", "mine",
+                "password to use against metastore database"),
+        METASTORECONNECTURLHOOK("hive.metastore.ds.connection.url.hook", "",
+                "Name of the hook to use for retrieving the JDO connection URL. If empty, the value in javax.jdo.option.ConnectionURL is used"),
+        METASTOREMULTITHREADED("javax.jdo.option.Multithreaded", true,
+                "Set this to true if multiple threads access metastore through JDO concurrently."),
+        METASTORECONNECTURLKEY("javax.jdo.option.ConnectionURL",
+                "jdbc:derby:;databaseName=metastore_db;create=true",
+                "JDBC connect string for a JDBC metastore"),
+        HMSHANDLERATTEMPTS("hive.hmshandler.retry.attempts", 10,
+                "The number of times to retry a HMSHandler call if there were a connection error."),
+        HMSHANDLERINTERVAL("hive.hmshandler.retry.interval", "2000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS), "The time between HMSHandler retry attempts on failure."),
+        HMSHANDLERFORCERELOADCONF("hive.hmshandler.force.reload.conf", false,
+                "Whether to force reloading of the HMSHandler configuration (including\n" +
+                        "the connection URL, before the next metastore query that accesses the\n" +
+                        "datastore. Once reloaded, this value is reset to false. Used for\n" +
+                        "testing only."),
+        METASTORESERVERMAXMESSAGESIZE("hive.metastore.server.max.message.size", 100 * 1024 * 1024,
+                "Maximum message size in bytes a HMS will accept."),
+        METASTORESERVERMINTHREADS("hive.metastore.server.min.threads", 200,
+                "Minimum number of worker threads in the Thrift server's pool."),
+        METASTORESERVERMAXTHREADS("hive.metastore.server.max.threads", 1000,
+                "Maximum number of worker threads in the Thrift server's pool."),
+        METASTORE_TCP_KEEP_ALIVE("hive.metastore.server.tcp.keepalive", true,
+                "Whether to enable TCP keepalive for the metastore server. Keepalive will prevent accumulation of half-open connections."),
+
+        METASTORE_INT_ORIGINAL("hive.metastore.archive.intermediate.original",
+                "_INTERMEDIATE_ORIGINAL",
+                "Intermediate dir suffixes used for archiving. Not important what they\n" +
+                        "are, as long as collisions are avoided"),
+        METASTORE_INT_ARCHIVED("hive.metastore.archive.intermediate.archived",
+                "_INTERMEDIATE_ARCHIVED", ""),
+        METASTORE_INT_EXTRACTED("hive.metastore.archive.intermediate.extracted",
+                "_INTERMEDIATE_EXTRACTED", ""),
+        METASTORE_KERBEROS_KEYTAB_FILE("hive.metastore.kerberos.keytab.file", "",
+                "The path to the Kerberos Keytab file containing the metastore Thrift server's service principal."),
+        METASTORE_KERBEROS_PRINCIPAL("hive.metastore.kerberos.principal",
+                "hive-metastore/_HOST@EXAMPLE.COM",
+                "The service principal for the metastore Thrift server. \n" +
+                        "The special string _HOST will be replaced automatically with the correct host name."),
+        METASTORE_USE_THRIFT_SASL("hive.metastore.sasl.enabled", false,
+                "If true, the metastore Thrift interface will be secured with SASL. Clients must authenticate with Kerberos."),
+        METASTORE_USE_THRIFT_FRAMED_TRANSPORT("hive.metastore.thrift.framed.transport.enabled", false,
+                "If true, the metastore Thrift interface will use TFramedTransport. When false (default) a standard TTransport is used."),
+        METASTORE_USE_THRIFT_COMPACT_PROTOCOL("hive.metastore.thrift.compact.protocol.enabled", false,
+                "If true, the metastore Thrift interface will use TCompactProtocol. When false (default) TBinaryProtocol will be used.\n" +
+                        "Setting it to true will break compatibility with older clients running TBinaryProtocol."),
+        METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_CLS("hive.cluster.delegation.token.store.class",
+                "org.apache.hadoop.hive.thrift.MemoryTokenStore",
+                "The delegation token store implementation. Set to org.apache.hadoop.hive.thrift.ZooKeeperTokenStore for load-balanced cluster."),
+        METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_ZK_CONNECTSTR(
+                "hive.cluster.delegation.token.store.zookeeper.connectString", "",
+                "The ZooKeeper token store connect string. You can re-use the configuration value\n" +
+                        "set in hive.zookeeper.quorum, by leaving this parameter unset."),
+        METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_ZK_ZNODE(
+                "hive.cluster.delegation.token.store.zookeeper.znode", "/hivedelegation",
+                "The root path for token store data. Note that this is used by both HiveServer2 and\n" +
+                        "MetaStore to store delegation Token. One directory gets created for each of them.\n" +
+                        "The final directory names would have the servername appended to it (HIVESERVER2,\n" +
+                        "METASTORE)."),
+        METASTORE_CLUSTER_DELEGATION_TOKEN_STORE_ZK_ACL(
+                "hive.cluster.delegation.token.store.zookeeper.acl", "",
+                "ACL for token store entries. Comma separated list of ACL entries. For example:\n" +
+                        "sasl:hive/host1@MY.DOMAIN:cdrwa,sasl:hive/host2@MY.DOMAIN:cdrwa\n" +
+                        "Defaults to all permissions for the hiveserver2/metastore process user."),
+        METASTORE_CACHE_PINOBJTYPES("hive.metastore.cache.pinobjtypes", "Table,StorageDescriptor,SerDeInfo,Partition,Database,Type,FieldSchema,Order",
+                "List of comma separated metastore object types that should be pinned in the cache"),
+        METASTORE_CONNECTION_POOLING_TYPE("datanucleus.connectionPoolingType", "BONECP",
+                "Specify connection pool library for datanucleus"),
+        METASTORE_VALIDATE_TABLES("datanucleus.validateTables", false,
+                "validates existing schema against code. turn this on if you want to verify existing schema"),
+        METASTORE_VALIDATE_COLUMNS("datanucleus.validateColumns", false,
+                "validates existing schema against code. turn this on if you want to verify existing schema"),
+        METASTORE_VALIDATE_CONSTRAINTS("datanucleus.validateConstraints", false,
+                "validates existing schema against code. turn this on if you want to verify existing schema"),
+        METASTORE_STORE_MANAGER_TYPE("datanucleus.storeManagerType", "rdbms", "metadata store type"),
+        METASTORE_AUTO_CREATE_SCHEMA("datanucleus.autoCreateSchema", true,
+                "creates necessary schema on a startup if one doesn't exist. set this to false, after creating it once"),
+        METASTORE_FIXED_DATASTORE("datanucleus.fixedDatastore", false, ""),
+        METASTORE_SCHEMA_VERIFICATION("hive.metastore.schema.verification", false,
+                "Enforce metastore schema version consistency.\n" +
+                        "True: Verify that version information stored in metastore matches with one from Hive jars.  Also disable automatic\n" +
+                        "      schema migration attempt. Users are required to manually migrate schema after Hive upgrade which ensures\n" +
+                        "      proper metastore schema migration. (Default)\n" +
+                        "False: Warn if the version information stored in metastore doesn't match with one from in Hive jars."),
+        METASTORE_SCHEMA_VERIFICATION_RECORD_VERSION("hive.metastore.schema.verification.record.version", true,
+                "When true the current MS version is recorded in the VERSION table. If this is disabled and verification is\n" +
+                        " enabled the MS will be unusable."),
+        METASTORE_AUTO_START_MECHANISM_MODE("datanucleus.autoStartMechanismMode", "checked",
+                "throw exception if metadata tables are incorrect"),
+        METASTORE_TRANSACTION_ISOLATION("datanucleus.transactionIsolation", "read-committed",
+                "Default transaction isolation level for identity generation."),
+        METASTORE_CACHE_LEVEL2("datanucleus.cache.level2", false,
+                "Use a level 2 cache. Turn this off if metadata is changed independently of Hive metastore server"),
+        METASTORE_CACHE_LEVEL2_TYPE("datanucleus.cache.level2.type", "none", ""),
+        METASTORE_IDENTIFIER_FACTORY("datanucleus.identifierFactory", "datanucleus1",
+                "Name of the identifier factory to use when generating table/column names etc. \n" +
+                        "'datanucleus1' is used for backward compatibility with DataNucleus v1"),
+        METASTORE_USE_LEGACY_VALUE_STRATEGY("datanucleus.rdbms.useLegacyNativeValueStrategy", true, ""),
+        METASTORE_PLUGIN_REGISTRY_BUNDLE_CHECK("datanucleus.plugin.pluginRegistryBundleCheck", "LOG",
+                "Defines what happens when plugin bundles are found and are duplicated [EXCEPTION|LOG|NONE]"),
+        METASTORE_BATCH_RETRIEVE_MAX("hive.metastore.batch.retrieve.max", 300,
+                "Maximum number of objects (tables/partitions) can be retrieved from metastore in one batch. \n" +
+                        "The higher the number, the less the number of round trips is needed to the Hive metastore server, \n" +
+                        "but it may also cause higher memory requirement at the client side."),
+        METASTORE_BATCH_RETRIEVE_TABLE_PARTITION_MAX(
+                "hive.metastore.batch.retrieve.table.partition.max", 1000,
+                "Maximum number of table partitions that metastore internally retrieves in one batch."),
+
+        METASTORE_INIT_HOOKS("hive.metastore.init.hooks", "",
+                "A comma separated list of hooks to be invoked at the beginning of HMSHandler initialization. \n" +
+                        "An init hook is specified as the name of Java class which extends org.apache.hadoop.hive.metastore.MetaStoreInitListener."),
+        METASTORE_PRE_EVENT_LISTENERS("hive.metastore.pre.event.listeners", "",
+                "List of comma separated listeners for metastore events."),
+        METASTORE_EVENT_LISTENERS("hive.metastore.event.listeners", "", ""),
+        METASTORE_EVENT_DB_LISTENER_TTL("hive.metastore.event.db.listener.timetolive", "86400s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "time after which events will be removed from the database listener queue"),
+        METASTORE_AUTHORIZATION_STORAGE_AUTH_CHECKS("hive.metastore.authorization.storage.checks", false,
+                "Should the metastore do authorization checks against the underlying storage (usually hdfs) \n" +
+                        "for operations like drop-partition (disallow the drop-partition if the user in\n" +
+                        "question doesn't have permissions to delete the corresponding directory\n" +
+                        "on the storage)."),
+        METASTORE_EVENT_CLEAN_FREQ("hive.metastore.event.clean.freq", "0s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Frequency at which timer task runs to purge expired events in metastore."),
+        METASTORE_EVENT_EXPIRY_DURATION("hive.metastore.event.expiry.duration", "0s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Duration after which events expire from events table"),
+        METASTORE_EXECUTE_SET_UGI("hive.metastore.execute.setugi", true,
+                "In unsecure mode, setting this property to true will cause the metastore to execute DFS operations using \n" +
+                        "the client's reported user and group permissions. Note that this property must be set on \n" +
+                        "both the client and server sides. Further note that its best effort. \n" +
+                        "If client sets its to true and server sets it to false, client setting will be ignored."),
+        METASTORE_PARTITION_NAME_WHITELIST_PATTERN("hive.metastore.partition.name.whitelist.pattern", "",
+                "Partition names will be checked against this regex pattern and rejected if not matched."),
+
+        METASTORE_INTEGER_JDO_PUSHDOWN("hive.metastore.integral.jdo.pushdown", false,
+                "Allow JDO query pushdown for integral partition columns in metastore. Off by default. This\n" +
+                        "improves metastore perf for integral columns, especially if there's a large number of partitions.\n" +
+                        "However, it doesn't work correctly with integral values that are not normalized (e.g. have\n" +
+                        "leading zeroes, like 0012). If metastore direct SQL is enabled and works, this optimization\n" +
+                        "is also irrelevant."),
+        METASTORE_TRY_DIRECT_SQL("hive.metastore.try.direct.sql", true,
+                "Whether the Hive metastore should try to use direct SQL queries instead of the\n" +
+                        "DataNucleus for certain read paths. This can improve metastore performance when\n" +
+                        "fetching many partitions or column statistics by orders of magnitude; however, it\n" +
+                        "is not guaranteed to work on all RDBMS-es and all versions. In case of SQL failures,\n" +
+                        "the metastore will fall back to the DataNucleus, so it's safe even if SQL doesn't\n" +
+                        "work for all queries on your datastore. If all SQL queries fail (for example, your\n" +
+                        "metastore is backed by MongoDB), you might want to disable this to save the\n" +
+                        "try-and-fall-back cost."),
+        METASTORE_DIRECT_SQL_PARTITION_BATCH_SIZE("hive.metastore.direct.sql.batch.size", 0,
+                "Batch size for partition and other object retrieval from the underlying DB in direct\n" +
+                        "SQL. For some DBs like Oracle and MSSQL, there are hardcoded or perf-based limitations\n" +
+                        "that necessitate this. For DBs that can handle the queries, this isn't necessary and\n" +
+                        "may impede performance. -1 means no batching, 0 means automatic batching."),
+        METASTORE_TRY_DIRECT_SQL_DDL("hive.metastore.try.direct.sql.ddl", true,
+                "Same as hive.metastore.try.direct.sql, for read statements within a transaction that\n" +
+                        "modifies metastore data. Due to non-standard behavior in Postgres, if a direct SQL\n" +
+                        "select query has incorrect syntax or something similar inside a transaction, the\n" +
+                        "entire transaction will fail and fall-back to DataNucleus will not be possible. You\n" +
+                        "should disable the usage of direct SQL inside transactions if that happens in your case."),
+        METASTORE_ORM_RETRIEVE_MAPNULLS_AS_EMPTY_STRINGS("hive.metastore.orm.retrieveMapNullsAsEmptyStrings", false,
+                "Thrift does not support nulls in maps, so any nulls present in maps retrieved from ORM must " +
+                        "either be pruned or converted to empty strings. Some backing dbs such as Oracle persist empty strings " +
+                        "as nulls, so we should set this parameter if we wish to reverse that behaviour. For others, " +
+                        "pruning is the correct behaviour"),
+        METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES(
+                "hive.metastore.disallow.incompatible.col.type.changes", false,
+                "If true (default is false), ALTER TABLE operations which change the type of a\n" +
+                        "column (say STRING) to an incompatible type (say MAP) are disallowed.\n" +
+                        "RCFile default SerDe (ColumnarSerDe) serializes the values in such a way that the\n" +
+                        "datatypes can be converted from string to any type. The map is also serialized as\n" +
+                        "a string, which can be read as a string as well. However, with any binary\n" +
+                        "serialization, this is not true. Blocking the ALTER TABLE prevents ClassCastExceptions\n" +
+                        "when subsequently trying to access old partitions.\n" +
+                        "\n" +
+                        "Primitive types like INT, STRING, BIGINT, etc., are compatible with each other and are\n" +
+                        "not blocked.\n" +
+                        "\n" +
+                        "See HIVE-4409 for more details."),
+
+        NEWTABLEDEFAULTPARA("hive.table.parameters.default", "",
+                "Default property values for newly created tables"),
+        DDL_CTL_PARAMETERS_WHITELIST("hive.ddl.createtablelike.properties.whitelist", "",
+                "Table Properties to copy over when executing a Create Table Like."),
+        METASTORE_RAW_STORE_IMPL("hive.metastore.rawstore.impl", "org.apache.hadoop.hive.metastore.ObjectStore",
+                "Name of the class that implements org.apache.hadoop.hive.metastore.rawstore interface. \n" +
+                        "This class is used to store and retrieval of raw metadata objects such as table, database"),
+        METASTORE_CONNECTION_DRIVER("javax.jdo.option.ConnectionDriverName", "org.apache.derby.jdbc.EmbeddedDriver",
+                "Driver class name for a JDBC metastore"),
+        METASTORE_MANAGER_FACTORY_CLASS("javax.jdo.PersistenceManagerFactoryClass",
+                "org.datanucleus.api.jdo.JDOPersistenceManagerFactory",
+                "class implementing the jdo persistence"),
+        METASTORE_EXPRESSION_PROXY_CLASS("hive.metastore.expression.proxy",
+                "org.apache.hadoop.hive.ql.optimizer.ppr.PartitionExpressionForMetastore", ""),
+        METASTORE_DETACH_ALL_ON_COMMIT("javax.jdo.option.DetachAllOnCommit", true,
+                "Detaches all objects from session so that they can be used after transaction is committed"),
+        METASTORE_NON_TRANSACTIONAL_READ("javax.jdo.option.NonTransactionalRead", true,
+                "Reads outside of transactions"),
+        METASTORE_CONNECTION_USER_NAME("javax.jdo.option.ConnectionUserName", "APP",
+                "Username to use against metastore database"),
+        METASTORE_END_FUNCTION_LISTENERS("hive.metastore.end.function.listeners", "",
+                "List of comma separated listeners for the end of metastore functions."),
+        METASTORE_PART_INHERIT_TBL_PROPS("hive.metastore.partition.inherit.table.properties", "",
+                "List of comma separated keys occurring in table properties which will get inherited to newly created partitions. \n" +
+                        "* implies all the keys will get inherited."),
+        METASTORE_FILTER_HOOK("hive.metastore.filter.hook", "org.apache.hadoop.hive.metastore.DefaultMetaStoreFilterHookImpl",
+                "Metastore hook class for filtering the metadata read results. If hive.security.authorization.manager"
+                        + "is set to instance of HiveAuthorizerFactory, then this value is ignored."),
+        FIRE_EVENTS_FOR_DML("hive.metastore.dml.events", false, "If true, the metastore will be asked" +
+                " to fire events for DML operations"),
+        METASTORE_CLIENT_DROP_PARTITIONS_WITH_EXPRESSIONS("hive.metastore.client.drop.partitions.using.expressions", true,
+                "Choose whether dropping partitions with HCatClient pushes the partition-predicate to the metastore, " +
+                        "or drops partitions iteratively"),
+
+        METASTORE_AGGREGATE_STATS_CACHE_ENABLED("hive.metastore.aggregate.stats.cache.enabled", true,
+                "Whether aggregate stats caching is enabled or not."),
+        METASTORE_AGGREGATE_STATS_CACHE_SIZE("hive.metastore.aggregate.stats.cache.size", 10000,
+                "Maximum number of aggregate stats nodes that we will place in the metastore aggregate stats cache."),
+        METASTORE_AGGREGATE_STATS_CACHE_MAX_PARTITIONS("hive.metastore.aggregate.stats.cache.max.partitions", 10000,
+                "Maximum number of partitions that are aggregated per cache node."),
+        METASTORE_AGGREGATE_STATS_CACHE_FPP("hive.metastore.aggregate.stats.cache.fpp", (float) 0.01,
+                "Maximum false positive probability for the Bloom Filter used in each aggregate stats cache node (default 1%)."),
+        METASTORE_AGGREGATE_STATS_CACHE_MAX_VARIANCE("hive.metastore.aggregate.stats.cache.max.variance", (float) 0.01,
+                "Maximum tolerable variance in number of partitions between a cached node and our request (default 1%)."),
+        METASTORE_AGGREGATE_STATS_CACHE_TTL("hive.metastore.aggregate.stats.cache.ttl", "600s", new TimeValidator(TimeUnit.SECONDS),
+                "Number of seconds for a cached node to be active in the cache before they become stale."),
+        METASTORE_AGGREGATE_STATS_CACHE_MAX_WRITER_WAIT("hive.metastore.aggregate.stats.cache.max.writer.wait", "5000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Number of milliseconds a writer will wait to acquire the writelock before giving up."),
+        METASTORE_AGGREGATE_STATS_CACHE_MAX_READER_WAIT("hive.metastore.aggregate.stats.cache.max.reader.wait", "1000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Number of milliseconds a reader will wait to acquire the readlock before giving up."),
+        METASTORE_AGGREGATE_STATS_CACHE_MAX_FULL("hive.metastore.aggregate.stats.cache.max.full", (float) 0.9,
+                "Maximum cache full % after which the cache cleaner thread kicks in."),
+        METASTORE_AGGREGATE_STATS_CACHE_CLEAN_UNTIL("hive.metastore.aggregate.stats.cache.clean.until", (float) 0.8,
+                "The cleaner thread cleans until cache reaches this % full size."),
+
+        // Parameters for exporting metadata on table drop (requires the use of the)
+        // org.apache.hadoop.hive.ql.parse.MetaDataExportListener preevent listener
+        METADATA_EXPORT_LOCATION("hive.metadata.export.location", "",
+                "When used in conjunction with the org.apache.hadoop.hive.ql.parse.MetaDataExportListener pre event listener, \n" +
+                        "it is the location to which the metadata will be exported. The default is an empty string, which results in the \n" +
+                        "metadata being exported to the current user's home directory on HDFS."),
+        MOVE_EXPORTED_METADATA_TO_TRASH("hive.metadata.move.exported.metadata.to.trash", true,
+                "When used in conjunction with the org.apache.hadoop.hive.ql.parse.MetaDataExportListener pre event listener, \n" +
+                        "this setting determines if the metadata that is exported will subsequently be moved to the user's trash directory \n" +
+                        "alongside the dropped table data. This ensures that the metadata will be cleaned up along with the dropped table data."),
+
+        // CLI
+        CLIIGNOREERRORS("hive.cli.errors.ignore", false, ""),
+        CLIPRINTCURRENTDB("hive.cli.print.current.db", false,
+                "Whether to include the current database in the Hive prompt."),
+        CLIPROMPT("hive.cli.prompt", "hive",
+                "Command line prompt configuration value. Other hiveconf can be used in this configuration value. \n" +
+                        "Variable substitution will only be invoked at the Hive CLI startup."),
+        CLIPRETTYOUTPUTNUMCOLS("hive.cli.pretty.output.num.cols", -1,
+                "The number of columns to use when formatting output generated by the DESCRIBE PRETTY table_name command.\n" +
+                        "If the value of this property is -1, then Hive will use the auto-detected terminal width."),
+
+        HIVE_METASTORE_FS_HANDLER_CLS("hive.metastore.fs.handler.class", "org.apache.hadoop.hive.metastore.HiveMetaStoreFsImpl", ""),
+
+        // Things we log in the jobconf
+
+        // session identifier
+        HIVESESSIONID("hive.session.id", "", ""),
+        // whether session is running in silent mode or not
+        HIVESESSIONSILENT("hive.session.silent", false, ""),
+
+        HIVE_SESSION_HISTORY_ENABLED("hive.session.history.enabled", false,
+                "Whether to log Hive query, query plan, runtime statistics etc."),
+
+        HIVEQUERYSTRING("hive.query.string", "",
+                "Query being executed (might be multiple per a session)"),
+
+        HIVEQUERYID("hive.query.id", "",
+                "ID for query being executed (might be multiple per a session)"),
+
+        HIVEJOBNAMELENGTH("hive.jobname.length", 50, "max jobname length"),
+
+        // hive jar
+        HIVEJAR("hive.jar.path", "",
+                "The location of hive_cli.jar that is used when submitting jobs in a separate jvm."),
+        HIVEAUXJARS("hive.aux.jars.path", "",
+                "The location of the plugin jars that contain implementations of user defined functions and serdes."),
+
+        // reloadable jars
+        HIVERELOADABLEJARS("hive.reloadable.aux.jars.path", "",
+                "Jars can be renewed by executing reload command. And these jars can be "
+                        + "used as the auxiliary classes like creating a UDF or SerDe."),
+
+        // hive added files and jars
+        HIVEADDEDFILES("hive.added.files.path", "", "This an internal parameter."),
+        HIVEADDEDJARS("hive.added.jars.path", "", "This an internal parameter."),
+        HIVEADDEDARCHIVES("hive.added.archives.path", "", "This an internal parameter."),
+
+        HIVE_CURRENT_DATABASE("hive.current.database", "", "Database name used by current session. Internal usage only.", true),
+
+        // for hive script operator
+        HIVES_AUTO_PROGRESS_TIMEOUT("hive.auto.progress.timeout", "0s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "How long to run autoprogressor for the script/UDTF operators.\n" +
+                        "Set to 0 for forever."),
+        HIVESCRIPTAUTOPROGRESS("hive.script.auto.progress", false,
+                "Whether Hive Transform/Map/Reduce Clause should automatically send progress information to TaskTracker \n" +
+                        "to avoid the task getting killed because of inactivity.  Hive sends progress information when the script is \n" +
+                        "outputting to stderr.  This option removes the need of periodically producing stderr messages, \n" +
+                        "but users should be cautious because this may prevent infinite loops in the scripts to be killed by TaskTracker."),
+        HIVESCRIPTIDENVVAR("hive.script.operator.id.env.var", "HIVE_SCRIPT_OPERATOR_ID",
+                "Name of the environment variable that holds the unique script operator ID in the user's \n" +
+                        "transform function (the custom mapper/reducer that the user has specified in the query)"),
+        HIVESCRIPTTRUNCATEENV("hive.script.operator.truncate.env", false,
+                "Truncate each environment variable for external script in scripts operator to 20KB (to fit system limits)"),
+        HIVESCRIPT_ENV_BLACKLIST("hive.script.operator.env.blacklist",
+                "hive.txn.valid.txns,hive.script.operator.env.blacklist",
+                "Comma separated list of keys from the configuration file not to convert to environment " +
+                        "variables when envoking the script operator"),
+        HIVEMAPREDMODE("hive.mapred.mode", "nonstrict",
+                "The mode in which the Hive operations are being performed. \n" +
+                        "In strict mode, some risky queries are not allowed to run. They include:\n" +
+                        "  Cartesian Product.\n" +
+                        "  No partition being picked up for a query.\n" +
+                        "  Comparing bigints and strings.\n" +
+                        "  Comparing bigints and doubles.\n" +
+                        "  Orderby without limit."),
+        HIVEALIAS("hive.alias", "", ""),
+        HIVEMAPSIDEAGGREGATE("hive.map.aggr", true, "Whether to use map-side aggregation in Hive Group By queries"),
+        HIVEGROUPBYSKEW("hive.groupby.skewindata", false, "Whether there is skew in data to optimize group by queries"),
+        HIVEJOINEMITINTERVAL("hive.join.emit.interval", 1000,
+                "How many rows in the right-most join operand Hive should buffer before emitting the join result."),
+        HIVEJOINCACHESIZE("hive.join.cache.size", 25000,
+                "How many rows in the joining tables (except the streaming table) should be cached in memory."),
+
+        // CBO related
+        HIVE_CBO_ENABLED("hive.cbo.enable", true, "Flag to control enabling Cost Based Optimizations using Calcite framework."),
+        HIVE_CBO_RETPATH_HIVEOP("hive.cbo.returnpath.hiveop", false, "Flag to control calcite plan to hive operator conversion"),
+        HIVE_CBO_EXTENDED_COST_MODEL("hive.cbo.costmodel.extended", false, "Flag to control enabling the extended cost model based on"
+                + "CPU, IO and cardinality. Otherwise, the cost model is based on cardinality."),
+        HIVE_CBO_COST_MODEL_CPU("hive.cbo.costmodel.cpu", "0.000001", "Default cost of a comparison"),
+        HIVE_CBO_COST_MODEL_NET("hive.cbo.costmodel.network", "150.0", "Default cost of a transfering a byte over network;"
+                + " expressed as multiple of CPU cost"),
+        HIVE_CBO_COST_MODEL_LFS_WRITE("hive.cbo.costmodel.local.fs.write", "4.0", "Default cost of writing a byte to local FS;"
+                + " expressed as multiple of NETWORK cost"),
+        HIVE_CBO_COST_MODEL_LFS_READ("hive.cbo.costmodel.local.fs.read", "4.0", "Default cost of reading a byte from local FS;"
+                + " expressed as multiple of NETWORK cost"),
+        HIVE_CBO_COST_MODEL_HDFS_WRITE("hive.cbo.costmodel.hdfs.write", "10.0", "Default cost of writing a byte to HDFS;"
+                + " expressed as multiple of Local FS write cost"),
+        HIVE_CBO_COST_MODEL_HDFS_READ("hive.cbo.costmodel.hdfs.read", "1.5", "Default cost of reading a byte from HDFS;"
+                + " expressed as multiple of Local FS read cost"),
+
+
+        // hive.mapjoin.bucket.cache.size has been replaced by hive.smbjoin.cache.row,
+        // need to remove by hive .13. Also, do not change default (see SMB operator)
+        HIVEMAPJOINBUCKETCACHESIZE("hive.mapjoin.bucket.cache.size", 100, ""),
+
+        HIVEMAPJOINUSEOPTIMIZEDTABLE("hive.mapjoin.optimized.hashtable", true,
+                "Whether Hive should use memory-optimized hash table for MapJoin. Only works on Tez,\n" +
+                        "because memory-optimized hashtable cannot be serialized."),
+        HIVEUSEHYBRIDGRACEHASHJOIN("hive.mapjoin.hybridgrace.hashtable", true, "Whether to use hybrid" +
+                "grace hash join as the join method for mapjoin. Tez only."),
+        HIVEHYBRIDGRACEHASHJOINMEMCHECKFREQ("hive.mapjoin.hybridgrace.memcheckfrequency", 1024, "For " +
+                "hybrid grace hash join, how often (how many rows apart) we check if memory is full. " +
+                "This number should be power of 2."),
+        HIVEHYBRIDGRACEHASHJOINMINWBSIZE("hive.mapjoin.hybridgrace.minwbsize", 524288, "For hybrid grace" +
+                " hash join, the minimum write buffer size used by optimized hashtable. Default is 512 KB."),
+        HIVEHYBRIDGRACEHASHJOINMINNUMPARTITIONS("hive.mapjoin.hybridgrace.minnumpartitions", 16, "For" +
+                " hybrid grace hash join, the minimum number of partitions to create."),
+        HIVEHASHTABLEWBSIZE("hive.mapjoin.optimized.hashtable.wbsize", 10 * 1024 * 1024,
+                "Optimized hashtable (see hive.mapjoin.optimized.hashtable) uses a chain of buffers to\n" +
+                        "store data. This is one buffer size. HT may be slightly faster if this is larger, but for small\n" +
+                        "joins unnecessary memory will be allocated and then trimmed."),
+
+        HIVESMBJOINCACHEROWS("hive.smbjoin.cache.rows", 10000,
+                "How many rows with the same key value should be cached in memory per smb joined table."),
+        HIVEGROUPBYMAPINTERVAL("hive.groupby.mapaggr.checkinterval", 100000,
+                "Number of rows after which size of the grouping keys/aggregation classes is performed"),
+        HIVEMAPAGGRHASHMEMORY("hive.map.aggr.hash.percentmemory", (float) 0.5,
+                "Portion of total memory to be used by map-side group aggregation hash table"),
+        HIVEMAPJOINFOLLOWEDBYMAPAGGRHASHMEMORY("hive.mapjoin.followby.map.aggr.hash.percentmemory", (float) 0.3,
+                "Portion of total memory to be used by map-side group aggregation hash table, when this group by is followed by map join"),
+        HIVEMAPAGGRMEMORYTHRESHOLD("hive.map.aggr.hash.force.flush.memory.threshold", (float) 0.9,
+                "The max memory to be used by map-side group aggregation hash table.\n" +
+                        "If the memory usage is higher than this number, force to flush data"),
+        HIVEMAPAGGRHASHMINREDUCTION("hive.map.aggr.hash.min.reduction", (float) 0.5,
+                "Hash aggregation will be turned off if the ratio between hash  table size and input rows is bigger than this number. \n" +
+                        "Set to 1 to make sure hash aggregation is never turned off."),
+        HIVEMULTIGROUPBYSINGLEREDUCER("hive.multigroupby.singlereducer", true,
+                "Whether to optimize multi group by query to generate single M/R  job plan. If the multi group by query has \n" +
+                        "common group by keys, it will be optimized to generate single M/R job."),
+        HIVE_MAP_GROUPBY_SORT("hive.map.groupby.sorted", false,
+                "If the bucketing/sorting properties of the table exactly match the grouping key, whether to perform \n" +
+                        "the group by in the mapper by using BucketizedHiveInputFormat. The only downside to this\n" +
+                        "is that it limits the number of mappers to the number of files."),
+        HIVE_MAP_GROUPBY_SORT_TESTMODE("hive.map.groupby.sorted.testmode", false,
+                "If the bucketing/sorting properties of the table exactly match the grouping key, whether to perform \n" +
+                        "the group by in the mapper by using BucketizedHiveInputFormat. If the test mode is set, the plan\n" +
+                        "is not converted, but a query property is set to denote the same."),
+        HIVE_GROUPBY_ORDERBY_POSITION_ALIAS("hive.groupby.orderby.position.alias", false,
+                "Whether to enable using Column Position Alias in Group By or Order By"),
+        HIVE_NEW_JOB_GROUPING_SET_CARDINALITY("hive.new.job.grouping.set.cardinality", 30,
+                "Whether a new map-reduce job should be launched for grouping sets/rollups/cubes.\n" +
+                        "For a query like: select a, b, c, count(1) from T group by a, b, c with rollup;\n" +
+                        "4 rows are created per row: (a, b, c), (a, b, null), (a, null, null), (null, null, null).\n" +
+                        "This can lead to explosion across map-reduce boundary if the cardinality of T is very high,\n" +
+                        "and map-side aggregation does not do a very good job. \n" +
+                        "\n" +
+                        "This parameter decides if Hive should add an additional map-reduce job. If the grouping set\n" +
+                        "cardinality (4 in the example above), is more than this value, a new MR job is added under the\n" +
+                        "assumption that the original group by will reduce the data size."),
+
+        // Max filesize used to do a single copy (after that, distcp is used)
+        HIVE_EXEC_COPYFILE_MAXSIZE("hive.exec.copyfile.maxsize", 32L * 1024 * 1024 /*32M*/,
+                "Maximum file size (in Mb) that Hive uses to do single HDFS copies between directories." +
+                        "Distributed copies (distcp) will be used instead for bigger files so that copies can be done faster."),
+
+        // for hive udtf operator
+        HIVEUDTFAUTOPROGRESS("hive.udtf.auto.progress", false,
+                "Whether Hive should automatically send progress information to TaskTracker \n" +
+                        "when using UDTF's to prevent the task getting killed because of inactivity.  Users should be cautious \n" +
+                        "because this may prevent TaskTracker from killing tasks with infinite loops."),
+
+        HIVEDEFAULTFILEFORMAT("hive.default.fileformat", "TextFile", new StringSet("TextFile", "SequenceFile", "RCfile", "ORC"),
+                "Default file format for CREATE TABLE statement. Users can explicitly override it by CREATE TABLE ... STORED AS [FORMAT]"),
+        HIVEDEFAULTMANAGEDFILEFORMAT("hive.default.fileformat.managed", "none",
+                new StringSet("none", "TextFile", "SequenceFile", "RCfile", "ORC"),
+                "Default file format for CREATE TABLE statement applied to managed tables only. External tables will be \n" +
+                        "created with format specified by hive.default.fileformat. Leaving this null will result in using hive.default.fileformat \n" +
+                        "for all tables."),
+        HIVEQUERYRESULTFILEFORMAT("hive.query.result.fileformat", "TextFile", new StringSet("TextFile", "SequenceFile", "RCfile"),
+                "Default file format for storing result of the query."),
+        HIVECHECKFILEFORMAT("hive.fileformat.check", true, "Whether to check file format or not when loading data files"),
+
+        // default serde for rcfile
+        HIVEDEFAULTRCFILESERDE("hive.default.rcfile.serde",
+                "org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe",
+                "The default SerDe Hive will use for the RCFile format"),
+
+        HIVEDEFAULTSERDE("hive.default.serde",
+                "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                "The default SerDe Hive will use for storage formats that do not specify a SerDe."),
+
+        SERDESUSINGMETASTOREFORSCHEMA("hive.serdes.using.metastore.for.schema",
+                "org.apache.hadoop.hive.ql.io.orc.OrcSerde,org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe," +
+                        "org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe,org.apache.hadoop.hive.serde2.dynamic_type.DynamicSerDe," +
+                        "org.apache.hadoop.hive.serde2.MetadataTypedColumnsetSerDe,org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe," +
+                        "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe,org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe",
+                "SerDes retriving schema from metastore. This an internal parameter. Check with the hive dev. team"),
+
+        HIVEHISTORYFILELOC("hive.querylog.location",
+                "${system:java.io.tmpdir}" + File.separator + "${system:user.name}",
+                "Location of Hive run time structured log file"),
+
+        HIVE_LOG_INCREMENTAL_PLAN_PROGRESS("hive.querylog.enable.plan.progress", true,
+                "Whether to log the plan's progress every time a job's progress is checked.\n" +
+                        "These logs are written to the location specified by hive.querylog.location"),
+
+        HIVE_LOG_INCREMENTAL_PLAN_PROGRESS_INTERVAL("hive.querylog.plan.progress.interval", "60000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "The interval to wait between logging the plan's progress.\n" +
+                        "If there is a whole number percentage change in the progress of the mappers or the reducers,\n" +
+                        "the progress is logged regardless of this value.\n" +
+                        "The actual interval will be the ceiling of (this value divided by the value of\n" +
+                        "hive.exec.counters.pull.interval) multiplied by the value of hive.exec.counters.pull.interval\n" +
+                        "I.e. if it is not divide evenly by the value of hive.exec.counters.pull.interval it will be\n" +
+                        "logged less frequently than specified.\n" +
+                        "This only has an effect if hive.querylog.enable.plan.progress is set to true."),
+
+        HIVESCRIPTSERDE("hive.script.serde", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                "The default SerDe for transmitting input data to and reading output data from the user scripts. "),
+        HIVESCRIPTRECORDREADER("hive.script.recordreader",
+                "org.apache.hadoop.hive.ql.exec.TextRecordReader",
+                "The default record reader for reading data from the user scripts. "),
+        HIVESCRIPTRECORDWRITER("hive.script.recordwriter",
+                "org.apache.hadoop.hive.ql.exec.TextRecordWriter",
+                "The default record writer for writing data to the user scripts. "),
+        HIVESCRIPTESCAPE("hive.transform.escape.input", false,
+                "This adds an option to escape special chars (newlines, carriage returns and\n" +
+                        "tabs) when they are passed to the user script. This is useful if the Hive tables\n" +
+                        "can contain data that contains special characters."),
+        HIVEBINARYRECORDMAX("hive.binary.record.max.length", 1000,
+                "Read from a binary stream and treat each hive.binary.record.max.length bytes as a record. \n" +
+                        "The last record before the end of stream can have less than hive.binary.record.max.length bytes"),
+
+        // HWI
+        HIVEHWILISTENHOST("hive.hwi.listen.host", "0.0.0.0", "This is the host address the Hive Web Interface will listen on"),
+        HIVEHWILISTENPORT("hive.hwi.listen.port", "9999", "This is the port the Hive Web Interface will listen on"),
+        HIVEHWIWARFILE("hive.hwi.war.file", "${env:HWI_WAR_FILE}",
+                "This sets the path to the HWI war file, relative to ${HIVE_HOME}. "),
+
+        HIVEHADOOPMAXMEM("hive.mapred.local.mem", 0, "mapper/reducer memory in local mode"),
+
+        //small table file size
+        HIVESMALLTABLESFILESIZE("hive.mapjoin.smalltable.filesize", 25000000L,
+                "The threshold for the input file size of the small tables; if the file size is smaller \n" +
+                        "than this threshold, it will try to convert the common join into map join"),
+
+        HIVESAMPLERANDOMNUM("hive.sample.seednumber", 0,
+                "A number used to percentage sampling. By changing this number, user will change the subsets of data sampled."),
+
+        // test mode in hive mode
+        HIVETESTMODE("hive.test.mode", false,
+                "Whether Hive is running in test mode. If yes, it turns on sampling and prefixes the output tablename.",
+                false),
+        HIVETESTMODEPREFIX("hive.test.mode.prefix", "test_",
+                "In test mode, specfies prefixes for the output table", false),
+        HIVETESTMODESAMPLEFREQ("hive.test.mode.samplefreq", 32,
+                "In test mode, specfies sampling frequency for table, which is not bucketed,\n" +
+                        "For example, the following query:\n" +
+                        "  INSERT OVERWRITE TABLE dest SELECT col1 from src\n" +
+                        "would be converted to\n" +
+                        "  INSERT OVERWRITE TABLE test_dest\n" +
+                        "  SELECT col1 from src TABLESAMPLE (BUCKET 1 out of 32 on rand(1))", false),
+        HIVETESTMODENOSAMPLE("hive.test.mode.nosamplelist", "",
+                "In test mode, specifies comma separated table names which would not apply sampling", false),
+        HIVETESTMODEDUMMYSTATAGGR("hive.test.dummystats.aggregator", "", "internal variable for test", false),
+        HIVETESTMODEDUMMYSTATPUB("hive.test.dummystats.publisher", "", "internal variable for test", false),
+        HIVETESTCURRENTTIMESTAMP("hive.test.currenttimestamp", null, "current timestamp for test", false),
+
+        HIVEMERGEMAPFILES("hive.merge.mapfiles", true,
+                "Merge small files at the end of a map-only job"),
+        HIVEMERGEMAPREDFILES("hive.merge.mapredfiles", false,
+                "Merge small files at the end of a map-reduce job"),
+        HIVEMERGETEZFILES("hive.merge.tezfiles", false, "Merge small files at the end of a Tez DAG"),
+        HIVEMERGESPARKFILES("hive.merge.sparkfiles", false, "Merge small files at the end of a Spark DAG Transformation"),
+        HIVEMERGEMAPFILESSIZE("hive.merge.size.per.task", (long) (256 * 1000 * 1000),
+                "Size of merged files at the end of the job"),
+        HIVEMERGEMAPFILESAVGSIZE("hive.merge.smallfiles.avgsize", (long) (16 * 1000 * 1000),
+                "When the average output file size of a job is less than this number, Hive will start an additional \n" +
+                        "map-reduce job to merge the output files into bigger files. This is only done for map-only jobs \n" +
+                        "if hive.merge.mapfiles is true, and for map-reduce jobs if hive.merge.mapredfiles is true."),
+        HIVEMERGERCFILEBLOCKLEVEL("hive.merge.rcfile.block.level", true, ""),
+        HIVEMERGEORCFILESTRIPELEVEL("hive.merge.orcfile.stripe.level", true,
+                "When hive.merge.mapfiles, hive.merge.mapredfiles or hive.merge.tezfiles is enabled\n" +
+                        "while writing a table with ORC file format, enabling this config will do stripe-level\n" +
+                        "fast merge for small ORC files. Note that enabling this config will not honor the\n" +
+                        "padding tolerance config (hive.exec.orc.block.padding.tolerance)."),
+
+        HIVEUSEEXPLICITRCFILEHEADER("hive.exec.rcfile.use.explicit.header", true,
+                "If this is set the header for RCFiles will simply be RCF.  If this is not\n" +
+                        "set the header will be that borrowed from sequence files, e.g. SEQ- followed\n" +
+                        "by the input and output RCFile formats."),
+        HIVEUSERCFILESYNCCACHE("hive.exec.rcfile.use.sync.cache", true, ""),
+
+        HIVE_RCFILE_RECORD_INTERVAL("hive.io.rcfile.record.interval", Integer.MAX_VALUE, ""),
+        HIVE_RCFILE_COLUMN_NUMBER_CONF("hive.io.rcfile.column.number.conf", 0, ""),
+        HIVE_RCFILE_TOLERATE_CORRUPTIONS("hive.io.rcfile.tolerate.corruptions", false, ""),
+        HIVE_RCFILE_RECORD_BUFFER_SIZE("hive.io.rcfile.record.buffer.size", 4194304, ""),   // 4M
+
+        PARQUET_MEMORY_POOL_RATIO("parquet.memory.pool.ratio", 0.5f,
+                "Maximum fraction of heap that can be used by Parquet file writers in one task.\n" +
+                        "It is for avoiding OutOfMemory error in tasks. Work with Parquet 1.6.0 and above.\n" +
+                        "This config parameter is defined in Parquet, so that it does not start with 'hive.'."),
+        HIVE_PARQUET_TIMESTAMP_SKIP_CONVERSION("hive.parquet.timestamp.skip.conversion", true,
+                "Current Hive implementation of parquet stores timestamps to UTC, this flag allows skipping of the conversion" +
+                        "on reading parquet files from other tools"),
+        HIVE_INT_TIMESTAMP_CONVERSION_IN_SECONDS("hive.int.timestamp.conversion.in.seconds", false,
+                "Boolean/tinyint/smallint/int/bigint value is interpreted as milliseconds during the timestamp conversion.\n" +
+                        "Set this flag to true to interpret the value as seconds to be consistent with float/double."),
+        HIVE_ORC_FILE_MEMORY_POOL("hive.exec.orc.memory.pool", 0.5f,
+                "Maximum fraction of heap that can be used by ORC file writers"),
+        HIVE_ORC_WRITE_FORMAT("hive.exec.orc.write.format", null,
+                "Define the version of the file to write. Possible values are 0.11 and 0.12.\n" +
+                        "If this parameter is not defined, ORC will use the run length encoding (RLE)\n" +
+                        "introduced in Hive 0.12. Any value other than 0.11 results in the 0.12 encoding."),
+        HIVE_ORC_DEFAULT_STRIPE_SIZE("hive.exec.orc.default.stripe.size",
+                64L * 1024 * 1024,
+                "Define the default ORC stripe size, in bytes."),
+        HIVE_ORC_DEFAULT_BLOCK_SIZE("hive.exec.orc.default.block.size", 256L * 1024 * 1024,
+                "Define the default file system block size for ORC files."),
+
+        HIVE_ORC_DICTIONARY_KEY_SIZE_THRESHOLD("hive.exec.orc.dictionary.key.size.threshold", 0.8f,
+                "If the number of keys in a dictionary is greater than this fraction of the total number of\n" +
+                        "non-null rows, turn off dictionary encoding.  Use 1 to always use dictionary encoding."),
+        HIVE_ORC_DEFAULT_ROW_INDEX_STRIDE("hive.exec.orc.default.row.index.stride", 10000,
+                "Define the default ORC index stride in number of rows. (Stride is the number of rows\n" +
+                        "an index entry represents.)"),
+        HIVE_ORC_ROW_INDEX_STRIDE_DICTIONARY_CHECK("hive.orc.row.index.stride.dictionary.check", true,
+                "If enabled dictionary check will happen after first row index stride (default 10000 rows)\n" +
+                        "else dictionary check will happen before writing first stripe. In both cases, the decision\n" +
+                        "to use dictionary or not will be retained thereafter."),
+        HIVE_ORC_DEFAULT_BUFFER_SIZE("hive.exec.orc.default.buffer.size", 256 * 1024,
+                "Define the default ORC buffer size, in bytes."),
+        HIVE_ORC_DEFAULT_BLOCK_PADDING("hive.exec.orc.default.block.padding", true,
+                "Define the default block padding, which pads stripes to the HDFS block boundaries."),
+        HIVE_ORC_BLOCK_PADDING_TOLERANCE("hive.exec.orc.block.padding.tolerance", 0.05f,
+                "Define the tolerance for block padding as a decimal fraction of stripe size (for\n" +
+                        "example, the default value 0.05 is 5% of the stripe size). For the defaults of 64Mb\n" +
+                        "ORC stripe and 256Mb HDFS blocks, the default block padding tolerance of 5% will\n" +
+                        "reserve a maximum of 3.2Mb for padding within the 256Mb block. In that case, if the\n" +
+                        "available size within the block is more than 3.2Mb, a new smaller stripe will be\n" +
+                        "inserted to fit within that space. This will make sure that no stripe written will\n" +
+                        "cross block boundaries and cause remote reads within a node local task."),
+        HIVE_ORC_DEFAULT_COMPRESS("hive.exec.orc.default.compress", "ZLIB", "Define the default compression codec for ORC file"),
+
+        HIVE_ORC_ENCODING_STRATEGY("hive.exec.orc.encoding.strategy", "SPEED", new StringSet("SPEED", "COMPRESSION"),
+                "Define the encoding strategy to use while writing data. Changing this will\n" +
+                        "only affect the light weight encoding for integers. This flag will not\n" +
+                        "change the compression level of higher level compression codec (like ZLIB)."),
+
+        HIVE_ORC_COMPRESSION_STRATEGY("hive.exec.orc.compression.strategy", "SPEED", new StringSet("SPEED", "COMPRESSION"),
+                "Define the compression strategy to use while writing data. \n" +
+                        "This changes the compression level of higher level compression codec (like ZLIB)."),
+
+        HIVE_ORC_SPLIT_STRATEGY("hive.exec.orc.split.strategy", "HYBRID", new StringSet("HYBRID", "BI", "ETL"),
+                "This is not a user level config. BI strategy is used when the requirement is to spend less time in split generation" +
+                        " as opposed to query execution (split generation does not read or cache file footers)." +
+                        " ETL strategy is used when spending little more time in split generation is acceptable" +
+                        " (split generation reads and caches file footers). HYBRID chooses between the above strategies" +
+                        " based on heuristics."),
+
+        HIVE_ORC_INCLUDE_FILE_FOOTER_IN_SPLITS("hive.orc.splits.include.file.footer", false,
+                "If turned on splits generated by orc will include metadata about the stripes in the file. This\n" +
+                        "data is read remotely (from the client or HS2 machine) and sent to all the tasks."),
+        HIVE_ORC_CACHE_STRIPE_DETAILS_SIZE("hive.orc.cache.stripe.details.size", 10000,
+                "Cache size for keeping meta info about orc splits cached in the client."),
+        HIVE_ORC_COMPUTE_SPLITS_NUM_THREADS("hive.orc.compute.splits.num.threads", 10,
+                "How many threads orc should use to create splits in parallel."),
+        HIVE_ORC_SKIP_CORRUPT_DATA("hive.exec.orc.skip.corrupt.data", false,
+                "If ORC reader encounters corrupt data, this value will be used to determine\n" +
+                        "whether to skip the corrupt data or throw exception. The default behavior is to throw exception."),
+
+        HIVE_ORC_ZEROCOPY("hive.exec.orc.zerocopy", false,
+                "Use zerocopy reads with ORC. (This requires Hadoop 2.3 or later.)"),
+
+        HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL("hive.lazysimple.extended_boolean_literal", false,
+                "LazySimpleSerde uses this property to determine if it treats 'T', 't', 'F', 'f',\n" +
+                        "'1', and '0' as extened, legal boolean literal, in addition to 'TRUE' and 'FALSE'.\n" +
+                        "The default is false, which means only 'TRUE' and 'FALSE' are treated as legal\n" +
+                        "boolean literal."),
+
+        HIVESKEWJOIN("hive.optimize.skewjoin", false,
+                "Whether to enable skew join optimization. \n" +
+                        "The algorithm is as follows: At runtime, detect the keys with a large skew. Instead of\n" +
+                        "processing those keys, store them temporarily in an HDFS directory. In a follow-up map-reduce\n" +
+                        "job, process those skewed keys. The same key need not be skewed for all the tables, and so,\n" +
+                        "the follow-up map-reduce job (for the skewed keys) would be much faster, since it would be a\n" +
+                        "map-join."),
+        HIVECONVERTJOIN("hive.auto.convert.join", true,
+                "Whether Hive enables the optimization about converting common join into mapjoin based on the input file size"),
+        HIVECONVERTJOINNOCONDITIONALTASK("hive.auto.convert.join.noconditionaltask", true,
+                "Whether Hive enables the optimization about converting common join into mapjoin based on the input file size. \n" +
+                        "If this parameter is on, and the sum of size for n-1 of the tables/partitions for a n-way join is smaller than the\n" +
+                        "specified size, the join is directly converted to a mapjoin (there is no conditional task)."),
+
+        HIVECONVERTJOINNOCONDITIONALTASKTHRESHOLD("hive.auto.convert.join.noconditionaltask.size",
+                10000000L,
+                "If hive.auto.convert.join.noconditionaltask is off, this parameter does not take affect. \n" +
+                        "However, if it is on, and the sum of size for n-1 of the tables/partitions for a n-way join is smaller than this size, \n" +
+                        "the join is directly converted to a mapjoin(there is no conditional task). The default is 10MB"),
+        HIVECONVERTJOINUSENONSTAGED("hive.auto.convert.join.use.nonstaged", false,
+                "For conditional joins, if input stream from a small alias can be directly applied to join operator without \n" +
+                        "filtering or projection, the alias need not to be pre-staged in distributed cache via mapred local task.\n" +
+                        "Currently, this is not working with vectorization or tez execution engine."),
+        HIVESKEWJOINKEY("hive.skewjoin.key", 100000,
+                "Determine if we get a skew key in join. If we see more than the specified number of rows with the same key in join operator,\n" +
+                        "we think the key as a skew join key. "),
+        HIVESKEWJOINMAPJOINNUMMAPTASK("hive.skewjoin.mapjoin.map.tasks", 10000,
+                "Determine the number of map task used in the follow up map join job for a skew join.\n" +
+                        "It should be used together with hive.skewjoin.mapjoin.min.split to perform a fine grained control."),
+        HIVESKEWJOINMAPJOINMINSPLIT("hive.skewjoin.mapjoin.min.split", 33554432L,
+                "Determine the number of map task at most used in the follow up map join job for a skew join by specifying \n" +
+                        "the minimum split size. It should be used together with hive.skewjoin.mapjoin.map.tasks to perform a fine grained control."),
+
+        HIVESENDHEARTBEAT("hive.heartbeat.interval", 1000,
+                "Send a heartbeat after this interval - used by mapjoin and filter operators"),
+        HIVELIMITMAXROWSIZE("hive.limit.row.max.size", 100000L,
+                "When trying a smaller subset of data for simple LIMIT, how much size we need to guarantee each row to have at least."),
+        HIVELIMITOPTLIMITFILE("hive.limit.optimize.limit.file", 10,
+                "When trying a smaller subset of data for simple LIMIT, maximum number of files we can sample."),
+        HIVELIMITOPTENABLE("hive.limit.optimize.enable", false,
+                "Whether to enable to optimization to trying a smaller subset of data for simple LIMIT first."),
+        HIVELIMITOPTMAXFETCH("hive.limit.optimize.fetch.max", 50000,
+                "Maximum number of rows allowed for a smaller subset of data for simple LIMIT, if it is a fetch query. \n" +
+                        "Insert queries are not restricted by this limit."),
+        HIVELIMITPUSHDOWNMEMORYUSAGE("hive.limit.pushdown.memory.usage", -1f,
+                "The max memory to be used for hash in RS operator for top K selection."),
+        HIVELIMITTABLESCANPARTITION("hive.limit.query.max.table.partition", -1,
+                "This controls how many partitions can be scanned for each partitioned table.\n" +
+                        "The default value \"-1\" means no limit."),
+
+        HIVEHASHTABLEKEYCOUNTADJUSTMENT("hive.hashtable.key.count.adjustment", 1.0f,
+                "Adjustment to mapjoin hashtable size derived from table and column statistics; the estimate" +
+                        " of the number of keys is divided by this value. If the value is 0, statistics are not used" +
+                        "and hive.hashtable.initialCapacity is used instead."),
+        HIVEHASHTABLETHRESHOLD("hive.hashtable.initialCapacity", 100000, "Initial capacity of " +
+                "mapjoin hashtable if statistics are absent, or if hive.hashtable.stats.key.estimate.adjustment is set to 0"),
+        HIVEHASHTABLELOADFACTOR("hive.hashtable.loadfactor", (float) 0.75, ""),
+        HIVEHASHTABLEFOLLOWBYGBYMAXMEMORYUSAGE("hive.mapjoin.followby.gby.localtask.max.memory.usage", (float) 0.55,
+                "This number means how much memory the local task can take to hold the key/value into an in-memory hash table \n" +
+                        "when this map join is followed by a group by. If the local task's memory usage is more than this number, \n" +
+                        "the local task will abort by itself. It means the data of the small table is too large to be held in memory."),
+        HIVEHASHTABLEMAXMEMORYUSAGE("hive.mapjoin.localtask.max.memory.usage", (float) 0.90,
+                "This number means how much memory the local task can take to hold the key/value into an in-memory hash table. \n" +
+                        "If the local task's memory usage is more than this number, the local task will abort by itself. \n" +
+                        "It means the data of the small table is too large to be held in memory."),
+        HIVEHASHTABLESCALE("hive.mapjoin.check.memory.rows", (long) 100000,
+                "The number means after how many rows processed it needs to check the memory usage"),
+
+        HIVEDEBUGLOCALTASK("hive.debug.localtask", false, ""),
+
+        HIVEINPUTFORMAT("hive.input.format", "org.apache.hadoop.hive.ql.io.CombineHiveInputFormat",
+                "The default input format. Set this to HiveInputFormat if you encounter problems with CombineHiveInputFormat."),
+        HIVETEZINPUTFORMAT("hive.tez.input.format", "org.apache.hadoop.hive.ql.io.HiveInputFormat",
+                "The default input format for tez. Tez groups splits in the AM."),
+
+        HIVETEZCONTAINERSIZE("hive.tez.container.size", -1,
+                "By default Tez will spawn containers of the size of a mapper. This can be used to overwrite."),
+        HIVETEZCPUVCORES("hive.tez.cpu.vcores", -1,
+                "By default Tez will ask for however many cpus map-reduce is configured to use per container.\n" +
+                        "This can be used to overwrite."),
+        HIVETEZJAVAOPTS("hive.tez.java.opts", null,
+                "By default Tez will use the Java options from map tasks. This can be used to overwrite."),
+        HIVETEZLOGLEVEL("hive.tez.log.level", "INFO",
+                "The log level to use for tasks executing as part of the DAG.\n" +
+                        "Used only if hive.tez.java.opts is used to configure Java options."),
+
+        HIVEENFORCEBUCKETING("hive.enforce.bucketing", false,
+                "Whether bucketing is enforced. If true, while inserting into the table, bucketing is enforced."),
+        HIVEENFORCESORTING("hive.enforce.sorting", false,
+                "Whether sorting is enforced. If true, while inserting into the table, sorting is enforced."),
+        HIVEOPTIMIZEBUCKETINGSORTING("hive.optimize.bucketingsorting", true,
+                "If hive.enforce.bucketing or hive.enforce.sorting is true, don't create a reducer for enforcing \n" +
+                        "bucketing/sorting for queries of the form: \n" +
+                        "insert overwrite table T2 select * from T1;\n" +
+                        "where T1 and T2 are bucketed/sorted by the same keys into the same number of buckets."),
+        HIVEPARTITIONER("hive.mapred.partitioner", "org.apache.hadoop.hive.ql.io.DefaultHivePartitioner", ""),
+        HIVEENFORCESORTMERGEBUCKETMAPJOIN("hive.enforce.sortmergebucketmapjoin", false,
+                "If the user asked for sort-merge bucketed map-side join, and it cannot be performed, should the query fail or not ?"),
+        HIVEENFORCEBUCKETMAPJOIN("hive.enforce.bucketmapjoin", false,
+                "If the user asked for bucketed map-side join, and it cannot be performed, \n" +
+                        "should the query fail or not ? For example, if the buckets in the tables being joined are\n" +
+                        "not a multiple of each other, bucketed map-side join cannot be performed, and the\n" +
+                        "query will fail if hive.enforce.bucketmapjoin is set to true."),
+
+        HIVE_AUTO_SORTMERGE_JOIN("hive.auto.convert.sortmerge.join", false,
+                "Will the join be automatically converted to a sort-merge join, if the joined tables pass the criteria for sort-merge join."),
+        HIVE_AUTO_SORTMERGE_JOIN_BIGTABLE_SELECTOR(
+                "hive.auto.convert.sortmerge.join.bigtable.selection.policy",
+                "org.apache.hadoop.hive.ql.optimizer.AvgPartitionSizeBasedBigTableSelectorForAutoSMJ",
+                "The policy to choose the big table for automatic conversion to sort-merge join. \n" +
+                        "By default, the table with the largest partitions is assigned the big table. All policies are:\n" +
+                        ". based on position of the table - the leftmost table is selected\n" +
+                        "org.apache.hadoop.hive.ql.optimizer.LeftmostBigTableSMJ.\n" +
+                        ". based on total size (all the partitions selected in the query) of the table \n" +
+                        "org.apache.hadoop.hive.ql.optimizer.TableSizeBasedBigTableSelectorForAutoSMJ.\n" +
+                        ". based on average size (all the partitions selected in the query) of the table \n" +
+                        "org.apache.hadoop.hive.ql.optimizer.AvgPartitionSizeBasedBigTableSelectorForAutoSMJ.\n" +
+                        "New policies can be added in future."),
+        HIVE_AUTO_SORTMERGE_JOIN_TOMAPJOIN(
+                "hive.auto.convert.sortmerge.join.to.mapjoin", false,
+                "If hive.auto.convert.sortmerge.join is set to true, and a join was converted to a sort-merge join, \n" +
+                        "this parameter decides whether each table should be tried as a big table, and effectively a map-join should be\n" +
+                        "tried. That would create a conditional task with n+1 children for a n-way join (1 child for each table as the\n" +
+                        "big table), and the backup task will be the sort-merge join. In some cases, a map-join would be faster than a\n" +
+                        "sort-merge join, if there is no advantage of having the output bucketed and sorted. For example, if a very big sorted\n" +
+                        "and bucketed table with few files (say 10 files) are being joined with a very small sorter and bucketed table\n" +
+                        "with few files (10 files), the sort-merge join will only use 10 mappers, and a simple map-only join might be faster\n" +
+                        "if the complete small table can fit in memory, and a map-join can be performed."),
+
+        HIVESCRIPTOPERATORTRUST("hive.exec.script.trust", false, ""),
+        HIVEROWOFFSET("hive.exec.rowoffset", false,
+                "Whether to provide the row offset virtual column"),
+
+        HIVE_COMBINE_INPUT_FORMAT_SUPPORTS_SPLITTABLE("hive.hadoop.supports.splittable.combineinputformat", false, ""),
+
+        // Optimizer
+        HIVEOPTINDEXFILTER("hive.optimize.index.filter", false,
+                "Whether to enable automatic use of indexes"),
+        HIVEINDEXAUTOUPDATE("hive.optimize.index.autoupdate", false,
+                "Whether to update stale indexes automatically"),
+        HIVEOPTPPD("hive.optimize.ppd", true,
+                "Whether to enable predicate pushdown"),
+        HIVEPPDRECOGNIZETRANSITIVITY("hive.ppd.recognizetransivity", true,
+                "Whether to transitively replicate predicate filters over equijoin conditions."),
+        HIVEPPDREMOVEDUPLICATEFILTERS("hive.ppd.remove.duplicatefilters", true,
+                "Whether to push predicates down into storage handlers.  Ignored when hive.optimize.ppd is false."),
+        // Constant propagation optimizer
+        HIVEOPTCONSTANTPROPAGATION("hive.optimize.constant.propagation", true, "Whether to enable constant propagation optimizer"),
+        HIVEIDENTITYPROJECTREMOVER("hive.optimize.remove.identity.project", true, "Removes identity project from operator tree"),
+        HIVEMETADATAONLYQUERIES("hive.optimize.metadataonly", true, ""),
+        HIVENULLSCANOPTIMIZE("hive.optimize.null.scan", true, "Dont scan relations which are guaranteed to not generate any rows"),
+        HIVEOPTPPD_STORAGE("hive.optimize.ppd.storage", true,
+                "Whether to push predicates down to storage handlers"),
+        HIVEOPTGROUPBY("hive.optimize.groupby", true,
+                "Whether to enable the bucketed group by from bucketed partitions/tables."),
+        HIVEOPTBUCKETMAPJOIN("hive.optimize.bucketmapjoin", false,
+                "Whether to try bucket mapjoin"),
+        HIVEOPTSORTMERGEBUCKETMAPJOIN("hive.optimize.bucketmapjoin.sortedmerge", false,
+                "Whether to try sorted bucket merge map join"),
+        HIVEOPTREDUCEDEDUPLICATION("hive.optimize.reducededuplication", true,
+                "Remove extra map-reduce jobs if the data is already clustered by the same key which needs to be used again. \n" +
+                        "This should always be set to true. Since it is a new feature, it has been made configurable."),
+        HIVEOPTREDUCEDEDUPLICATIONMINREDUCER("hive.optimize.reducededuplication.min.reducer", 4,
+                "Reduce deduplication merges two RSs by moving key/parts/reducer-num of the child RS to parent RS. \n" +
+                        "That means if reducer-num of the child RS is fixed (order by or forced bucketing) and small, it can make very slow, single MR.\n" +
+                        "The optimization will be automatically disabled if number of reducers would be less than specified value."),
+
+        HIVEOPTSORTDYNAMICPARTITION("hive.optimize.sort.dynamic.partition", false,
+                "When enabled dynamic partitioning column will be globally sorted.\n" +
+                        "This way we can keep only one record writer open for each partition value\n" +
+                        "in the reducer thereby reducing the memory pressure on reducers."),
+
+        HIVESAMPLINGFORORDERBY("hive.optimize.sampling.orderby", false, "Uses sampling on order-by clause for parallel execution."),
+        HIVESAMPLINGNUMBERFORORDERBY("hive.optimize.sampling.orderby.number", 1000, "Total number of samples to be obtained."),
+        HIVESAMPLINGPERCENTFORORDERBY("hive.optimize.sampling.orderby.percent", 0.1f, new RatioValidator(),
+                "Probability with which a row will be chosen."),
+        HIVEOPTIMIZEDISTINCTREWRITE("hive.optimize.distinct.rewrite", true, "When applicable this "
+                + "optimization rewrites distinct aggregates from a single stage to multi-stage "
+                + "aggregation. This may not be optimal in all cases. Ideally, whether to trigger it or "
+                + "not should be cost based decision. Until Hive formalizes cost model for this, this is config driven."),
+        // whether to optimize union followed by select followed by filesink
+        // It creates sub-directories in the final output, so should not be turned on in systems
+        // where MAPREDUCE-1501 is not present
+        HIVE_OPTIMIZE_UNION_REMOVE("hive.optimize.union.remove", false,
+                "Whether to remove the union and push the operators between union and the filesink above union. \n" +
+                        "This avoids an extra scan of the output by union. This is independently useful for union\n" +
+                        "queries, and specially useful when hive.optimize.skewjoin.compiletime is set to true, since an\n" +
+                        "extra union is inserted.\n" +
+                        "\n" +
+                        "The merge is triggered if either of hive.merge.mapfiles or hive.merge.mapredfiles is set to true.\n" +
+                        "If the user has set hive.merge.mapfiles to true and hive.merge.mapredfiles to false, the idea was the\n" +
+                        "number of reducers are few, so the number of files anyway are small. However, with this optimization,\n" +
+                        "we are increasing the number of files possibly by a big margin. So, we merge aggressively."),
+        HIVEOPTCORRELATION("hive.optimize.correlation", false, "exploit intra-query correlations."),
+
+        HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES("hive.mapred.supports.subdirectories", false,
+                "Whether the version of Hadoop which is running supports sub-directories for tables/partitions. \n" +
+                        "Many Hive optimizations can be applied if the Hadoop version supports sub-directories for\n" +
+                        "tables/partitions. It was added by MAPREDUCE-1501"),
+
+        HIVE_OPTIMIZE_SKEWJOIN_COMPILETIME("hive.optimize.skewjoin.compiletime", false,
+                "Whether to create a separate plan for skewed keys for the tables in the join.\n" +
+                        "This is based on the skewed keys stored in the metadata. At compile time, the plan is broken\n" +
+                        "into different joins: one for the skewed keys, and the other for the remaining keys. And then,\n" +
+                        "a union is performed for the 2 joins generated above. So unless the same skewed key is present\n" +
+                        "in both the joined tables, the join for the skewed key will be performed as a map-side join.\n" +
+                        "\n" +
+                        "The main difference between this parameter and hive.optimize.skewjoin is that this parameter\n" +
+                        "uses the skew information stored in the metastore to optimize the plan at compile time itself.\n" +
+                        "If there is no skew information in the metadata, this parameter will not have any affect.\n" +
+                        "Both hive.optimize.skewjoin.compiletime and hive.optimize.skewjoin should be set to true.\n" +
+                        "Ideally, hive.optimize.skewjoin should be renamed as hive.optimize.skewjoin.runtime, but not doing\n" +
+                        "so for backward compatibility.\n" +
+                        "\n" +
+                        "If the skew information is correctly stored in the metadata, hive.optimize.skewjoin.compiletime\n" +
+                        "would change the query plan to take care of it, and hive.optimize.skewjoin will be a no-op."),
+
+        // Indexes
+        HIVEOPTINDEXFILTER_COMPACT_MINSIZE("hive.optimize.index.filter.compact.minsize", (long) 5 * 1024 * 1024 * 1024,
+                "Minimum size (in bytes) of the inputs on which a compact index is automatically used."), // 5G
+        HIVEOPTINDEXFILTER_COMPACT_MAXSIZE("hive.optimize.index.filter.compact.maxsize", (long) -1,
+                "Maximum size (in bytes) of the inputs on which a compact index is automatically used.  A negative number is equivalent to infinity."), // infinity
+        HIVE_INDEX_COMPACT_QUERY_MAX_ENTRIES("hive.index.compact.query.max.entries", (long) 10000000,
+                "The maximum number of index entries to read during a query that uses the compact index. Negative value is equivalent to infinity."), // 10M
+        HIVE_INDEX_COMPACT_QUERY_MAX_SIZE("hive.index.compact.query.max.size", (long) 10 * 1024 * 1024 * 1024,
+                "The maximum number of bytes that a query using the compact index can read. Negative value is equivalent to infinity."), // 10G
+        HIVE_INDEX_COMPACT_BINARY_SEARCH("hive.index.compact.binary.search", true,
+                "Whether or not to use a binary search to find the entries in an index table that match the filter, where possible"),
+
+        // Statistics
+        HIVESTATSAUTOGATHER("hive.stats.autogather", true,
+                "A flag to gather statistics automatically during the INSERT OVERWRITE command."),
+        HIVESTATSDBCLASS("hive.stats.dbclass", "fs", new PatternSet("jdbc(:.*)", "hbase", "counter", "custom", "fs"),
+                "The storage that stores temporary Hive statistics. In filesystem based statistics collection ('fs'), \n" +
+                        "each task writes statistics it has collected in a file on the filesystem, which will be aggregated \n" +
+                        "after the job has finished. Supported values are fs (filesystem), jdbc:database (where database \n" +
+                        "can be derby, mysql, etc.), hbase, counter, and custom as defined in StatsSetupConst.java."), // StatsSetupConst.StatDB
+        HIVESTATSJDBCDRIVER("hive.stats.jdbcdriver",
+                "org.apache.derby.jdbc.EmbeddedDriver",
+                "The JDBC driver for the database that stores temporary Hive statistics."),
+        HIVESTATSDBCONNECTIONSTRING("hive.stats.dbconnectionstring",
+                "jdbc:derby:;databaseName=TempStatsStore;create=true",
+                "The default connection string for the database that stores temporary Hive statistics."), // automatically create database
+        HIVE_STATS_DEFAULT_PUBLISHER("hive.stats.default.publisher", "",
+                "The Java class (implementing the StatsPublisher interface) that is used by default if hive.stats.dbclass is custom type."),
+        HIVE_STATS_DEFAULT_AGGREGATOR("hive.stats.default.aggregator", "",
+                "The Java class (implementing the StatsAggregator interface) that is used by default if hive.stats.dbclass is custom type."),
+        HIVE_STATS_JDBC_TIMEOUT("hive.stats.jdbc.timeout", "30s", new TimeValidator(TimeUnit.SECONDS),
+                "Timeout value used by JDBC connection and statements."),
+        HIVE_STATS_ATOMIC("hive.stats.atomic", false,
+                "whether to update metastore stats only if all stats are available"),
+        HIVE_STATS_RETRIES_MAX("hive.stats.retries.max", 0,
+                "Maximum number of retries when stats publisher/aggregator got an exception updating intermediate database. \n" +
+                        "Default is no tries on failures."),
+        HIVE_STATS_RETRIES_WAIT("hive.stats.retries.wait", "3000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "The base waiting window before the next retry. The actual wait time is calculated by " +
+                        "baseWindow * failures baseWindow * (failure + 1) * (random number between [0.0,1.0])."),
+        HIVE_STATS_COLLECT_RAWDATASIZE("hive.stats.collect.rawdatasize", true,
+                "should the raw data size be collected when analyzing tables"),
+        CLIENT_STATS_COUNTERS("hive.client.stats.counters", "",
+                "Subset of counters that should be of interest for hive.client.stats.publishers (when one wants to limit their publishing). \n" +
+                        "Non-display names should be used"),
+        //Subset of counters that should be of interest for hive.client.stats.publishers (when one wants to limit their publishing). Non-display names should be used".
+        HIVE_STATS_RELIABLE("hive.stats.reliable", false,
+                "Whether queries will fail because stats cannot be collected completely accurately. \n" +
+                        "If this is set to true, reading/writing from/into a partition may fail because the stats\n" +
+                        "could not be computed accurately."),
+        HIVE_STATS_COLLECT_PART_LEVEL_STATS("hive.analyze.stmt.collect.partlevel.stats", true,
+                "analyze table T compute statistics for columns. Queries like these should compute partition"
+                        + "level stats for partitioned table even when no part spec is specified."),
+        HIVE_STATS_GATHER_NUM_THREADS("hive.stats.gather.num.threads", 10,
+                "Number of threads used by partialscan/noscan analyze command for partitioned tables.\n" +
+                        "This is applicable only for file formats that implement StatsProvidingRecordReader (like ORC)."),
+        // Collect table access keys information for operators that can benefit from bucketing
+        HIVE_STATS_COLLECT_TABLEKEYS("hive.stats.collect.tablekeys", false,
+                "Whether join and group by keys on tables are derived and maintained in the QueryPlan.\n" +
+                        "This is useful to identify how tables are accessed and to determine if they should be bucketed."),
+        // Collect column access information
+        HIVE_STATS_COLLECT_SCANCOLS("hive.stats.collect.scancols", false,
+                "Whether column accesses are tracked in the QueryPlan.\n" +
+                        "This is useful to identify how tables are accessed and to determine if there are wasted columns that can be trimmed."),
+        // standard error allowed for ndv estimates. A lower value indicates higher accuracy and a
+        // higher compute cost.
+        HIVE_STATS_NDV_ERROR("hive.stats.ndv.error", (float) 20.0,
+                "Standard error expressed in percentage. Provides a tradeoff between accuracy and compute cost. \n" +
+                        "A lower value for error indicates higher accuracy and a higher compute cost."),
+        HIVE_METASTORE_STATS_NDV_DENSITY_FUNCTION("hive.metastore.stats.ndv.densityfunction", false,
+                "Whether to use density function to estimate the NDV for the whole table based on the NDV of partitions"),
+        HIVE_STATS_KEY_PREFIX_MAX_LENGTH("hive.stats.key.prefix.max.length", 150,
+                "Determines if when the prefix of the key used for intermediate stats collection\n" +
+                        "exceeds a certain length, a hash of the key is used instead.  If the value < 0 then hashing"),
+        HIVE_STATS_KEY_PREFIX_RESERVE_LENGTH("hive.stats.key.prefix.reserve.length", 24,
+                "Reserved length for postfix of stats key. Currently only meaningful for counter type which should\n" +
+                        "keep length of full stats key smaller than max length configured by hive.stats.key.prefix.max.length.\n" +
+                        "For counter type, it should be bigger than the length of LB spec if exists."),
+        HIVE_STATS_KEY_PREFIX("hive.stats.key.prefix", "", "", true), // internal usage only
+        // if length of variable length data type cannot be determined this length will be used.
+        HIVE_STATS_MAX_VARIABLE_LENGTH("hive.stats.max.variable.length", 100,
+                "To estimate the size of data flowing through operators in Hive/Tez(for reducer estimation etc.),\n" +
+                        "average row size is multiplied with the total number of rows coming out of each operator.\n" +
+                        "Average row size is computed from average column size of all columns in the row. In the absence\n" +
+                        "of column statistics, for variable length columns (like string, bytes etc.), this value will be\n" +
+                        "used. For fixed length columns their corresponding Java equivalent sizes are used\n" +
+                        "(float - 4 bytes, double - 8 bytes etc.)."),
+        // if number of elements in list cannot be determined, this value will be used
+        HIVE_STATS_LIST_NUM_ENTRIES("hive.stats.list.num.entries", 10,
+                "To estimate the size of data flowing through operators in Hive/Tez(for reducer estimation etc.),\n" +
+                        "average row size is multiplied with the total number of rows coming out of each operator.\n" +
+                        "Average row size is computed from average column size of all columns in the row. In the absence\n" +
+                        "of column statistics and for variable length complex columns like list, the average number of\n" +
+                        "entries/values can be specified using this config."),
+        // if number of elements in map cannot be determined, this value will be used
+        HIVE_STATS_MAP_NUM_ENTRIES("hive.stats.map.num.entries", 10,
+                "To estimate the size of data flowing through operators in Hive/Tez(for reducer estimation etc.),\n" +
+                        "average row size is multiplied with the total number of rows coming out of each operator.\n" +
+                        "Average row size is computed from average column size of all columns in the row. In the absence\n" +
+                        "of column statistics and for variable length complex columns like map, the average number of\n" +
+                        "entries/values can be specified using this config."),
+        // statistics annotation fetches stats for each partition, which can be expensive. turning
+        // this off will result in basic sizes being fetched from namenode instead
+        HIVE_STATS_FETCH_PARTITION_STATS("hive.stats.fetch.partition.stats", true,
+                "Annotation of operator tree with statistics information requires partition level basic\n" +
+                        "statistics like number of rows, data size and file size. Partition statistics are fetched from\n" +
+                        "metastore. Fetching partition statistics for each needed partition can be expensive when the\n" +
+                        "number of partitions is high. This flag can be used to disable fetching of partition statistics\n" +
+                        "from metastore. When this flag is disabled, Hive will make calls to filesystem to get file sizes\n" +
+                        "and will estimate the number of rows from row schema."),
+        // statistics annotation fetches column statistics for all required columns which can
+        // be very expensive sometimes
+        HIVE_STATS_FETCH_COLUMN_STATS("hive.stats.fetch.column.stats", false,
+                "Annotation of operator tree with statistics information requires column statistics.\n" +
+                        "Column statistics are fetched from metastore. Fetching column statistics for each needed column\n" +
+                        "can be expensive when the number of columns is high. This flag can be used to disable fetching\n" +
+                        "of column statistics from metastore."),
+        // in the absence of column statistics, the estimated number of rows/data size that will
+        // be emitted from join operator will depend on this factor
+        HIVE_STATS_JOIN_FACTOR("hive.stats.join.factor", (float) 1.1,
+                "Hive/Tez optimizer estimates the data size flowing through each of the operators. JOIN operator\n" +
+                        "uses column statistics to estimate the number of rows flowing out of it and hence the data size.\n" +
+                        "In the absence of column statistics, this factor determines the amount of rows that flows out\n" +
+                        "of JOIN operator."),
+        // in the absence of uncompressed/raw data size, total file size will be used for statistics
+        // annotation. But the file may be compressed, encoded and serialized which may be lesser in size
+        // than the actual uncompressed/raw data size. This factor will be multiplied to file size to estimate
+        // the raw data size.
+        HIVE_STATS_DESERIALIZATION_FACTOR("hive.stats.deserialization.factor", (float) 1.0,
+                "Hive/Tez optimizer estimates the data size flowing through each of the operators. In the absence\n" +
+                        "of basic statistics like number of rows and data size, file size is used to estimate the number\n" +
+                        "of rows and data size. Since files in tables/partitions are serialized (and optionally\n" +
+                        "compressed) the estimates of number of rows and data size cannot be reliably determined.\n" +
+                        "This factor is multiplied with the file size to account for serialization and compression."),
+
+        // Concurrency
+        HIVE_SUPPORT_CONCURRENCY("hive.support.concurrency", false,
+                "Whether Hive supports concurrency control or not. \n" +
+                        "A ZooKeeper instance must be up and running when using zookeeper Hive lock manager "),
+        HIVE_LOCK_MANAGER("hive.lock.manager", "org.apache.hadoop.hive.ql.lockmgr.zookeeper.ZooKeeperHiveLockManager", ""),
+        HIVE_LOCK_NUMRETRIES("hive.lock.numretries", 100,
+                "The number of times you want to try to get all the locks"),
+        HIVE_UNLOCK_NUMRETRIES("hive.unlock.numretries", 10,
+                "The number of times you want to retry to do one unlock"),
+        HIVE_LOCK_SLEEP_BETWEEN_RETRIES("hive.lock.sleep.between.retries", "60s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "The sleep time between various retries"),
+        HIVE_LOCK_MAPRED_ONLY("hive.lock.mapred.only.operation", false,
+                "This param is to control whether or not only do lock on queries\n" +
+                        "that need to execute at least one mapred job."),
+
+        // Zookeeper related configs
+        HIVE_ZOOKEEPER_QUORUM("hive.zookeeper.quorum", "",
+                "List of ZooKeeper servers to talk to. This is needed for: \n" +
+                        "1. Read/write locks - when hive.lock.manager is set to \n" +
+                        "org.apache.hadoop.hive.ql.lockmgr.zookeeper.ZooKeeperHiveLockManager, \n" +
+                        "2. When HiveServer2 supports service discovery via Zookeeper.\n" +
+                        "3. For delegation token storage if zookeeper store is used, if\n" +
+                        "hive.cluster.delegation.token.store.zookeeper.connectString is not set"),
+
+        HIVE_ZOOKEEPER_CLIENT_PORT("hive.zookeeper.client.port", "2181",
+                "The port of ZooKeeper servers to talk to.\n" +
+                        "If the list of Zookeeper servers specified in hive.zookeeper.quorum\n" +
+                        "does not contain port numbers, this value is used."),
+        HIVE_ZOOKEEPER_SESSION_TIMEOUT("hive.zookeeper.session.timeout", "1200000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "ZooKeeper client's session timeout (in milliseconds). The client is disconnected, and as a result, all locks released, \n" +
+                        "if a heartbeat is not sent in the timeout."),
+        HIVE_ZOOKEEPER_NAMESPACE("hive.zookeeper.namespace", "hive_zookeeper_namespace",
+                "The parent node under which all ZooKeeper nodes are created."),
+        HIVE_ZOOKEEPER_CLEAN_EXTRA_NODES("hive.zookeeper.clean.extra.nodes", false,
+                "Clean extra nodes at the end of the session."),
+        HIVE_ZOOKEEPER_CONNECTION_MAX_RETRIES("hive.zookeeper.connection.max.retries", 3,
+                "Max number of times to retry when connecting to the ZooKeeper server."),
+        HIVE_ZOOKEEPER_CONNECTION_BASESLEEPTIME("hive.zookeeper.connection.basesleeptime", "1000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Initial amount of time (in milliseconds) to wait between retries\n" +
+                        "when connecting to the ZooKeeper server when using ExponentialBackoffRetry policy."),
+
+        // Transactions
+        HIVE_TXN_MANAGER("hive.txn.manager",
+                "org.apache.hadoop.hive.ql.lockmgr.DummyTxnManager",
+                "Set to org.apache.hadoop.hive.ql.lockmgr.DbTxnManager as part of turning on Hive\n" +
+                        "transactions, which also requires appropriate settings for hive.compactor.initiator.on,\n" +
+                        "hive.compactor.worker.threads, hive.support.concurrency (true), hive.enforce.bucketing\n" +
+                        "(true), and hive.exec.dynamic.partition.mode (nonstrict).\n" +
+                        "The default DummyTxnManager replicates pre-Hive-0.13 behavior and provides\n" +
+                        "no transactions."),
+        HIVE_TXN_TIMEOUT("hive.txn.timeout", "300s", new TimeValidator(TimeUnit.SECONDS),
+                "time after which transactions are declared aborted if the client has not sent a heartbeat."),
+
+        HIVE_TXN_MAX_OPEN_BATCH("hive.txn.max.open.batch", 1000,
+                "Maximum number of transactions that can be fetched in one call to open_txns().\n" +
+                        "This controls how many transactions streaming agents such as Flume or Storm open\n" +
+                        "simultaneously. The streaming agent then writes that number of entries into a single\n" +
+                        "file (per Flume agent or Storm bolt). Thus increasing this value decreases the number\n" +
+                        "of delta files created by streaming agents. But it also increases the number of open\n" +
+                        "transactions that Hive has to track at any given time, which may negatively affect\n" +
+                        "read performance."),
+
+        HIVE_COMPACTOR_INITIATOR_ON("hive.compactor.initiator.on", false,
+                "Whether to run the initiator and cleaner threads on this metastore instance or not.\n" +
+                        "Set this to true on one instance of the Thrift metastore service as part of turning\n" +
+                        "on Hive transactions. For a complete list of parameters required for turning on\n" +
+                        "transactions, see hive.txn.manager."),
+
+        HIVE_COMPACTOR_WORKER_THREADS("hive.compactor.worker.threads", 0,
+                "How many compactor worker threads to run on this metastore instance. Set this to a\n" +
+                        "positive number on one or more instances of the Thrift metastore service as part of\n" +
+                        "turning on Hive transactions. For a complete list of parameters required for turning\n" +
+                        "on transactions, see hive.txn.manager.\n" +
+                        "Worker threads spawn MapReduce jobs to do compactions. They do not do the compactions\n" +
+                        "themselves. Increasing the number of worker threads will decrease the time it takes\n" +
+                        "tables or partitions to be compacted once they are determined to need compaction.\n" +
+                        "It will also increase the background load on the Hadoop cluster as more MapReduce jobs\n" +
+                        "will be running in the background."),
+
+        HIVE_COMPACTOR_WORKER_TIMEOUT("hive.compactor.worker.timeout", "86400s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Time in seconds after which a compaction job will be declared failed and the\n" +
+                        "compaction re-queued."),
+
+        HIVE_COMPACTOR_CHECK_INTERVAL("hive.compactor.check.interval", "300s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Time in seconds between checks to see if any tables or partitions need to be\n" +
+                        "compacted. This should be kept high because each check for compaction requires\n" +
+                        "many calls against the NameNode.\n" +
+                        "Decreasing this value will reduce the time it takes for compaction to be started\n" +
+                        "for a table or partition that requires compaction. However, checking if compaction\n" +
+                        "is needed requires several calls to the NameNode for each table or partition that\n" +
+                        "has had a transaction done on it since the last major compaction. So decreasing this\n" +
+                        "value will increase the load on the NameNode."),
+
+        HIVE_COMPACTOR_DELTA_NUM_THRESHOLD("hive.compactor.delta.num.threshold", 10,
+                "Number of delta directories in a table or partition that will trigger a minor\n" +
+                        "compaction."),
+
+        HIVE_COMPACTOR_DELTA_PCT_THRESHOLD("hive.compactor.delta.pct.threshold", 0.1f,
+                "Percentage (fractional) size of the delta files relative to the base that will trigger\n" +
+                        "a major compaction. (1.0 = 100%, so the default 0.1 = 10%.)"),
+
+        HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD("hive.compactor.abortedtxn.threshold", 1000,
+                "Number of aborted transactions involving a given table or partition that will trigger\n" +
+                        "a major compaction."),
+
+        HIVE_COMPACTOR_CLEANER_RUN_INTERVAL("hive.compactor.cleaner.run.interval", "5000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS), "Time between runs of the cleaner thread"),
+
+        // For HBase storage handler
+        HIVE_HBASE_WAL_ENABLED("hive.hbase.wal.enabled", true,
+                "Whether writes to HBase should be forced to the write-ahead log. \n" +
+                        "Disabling this improves HBase write performance at the risk of lost writes in case of a crash."),
+        HIVE_HBASE_GENERATE_HFILES("hive.hbase.generatehfiles", false,
+                "True when HBaseStorageHandler should generate hfiles instead of operate against the online table."),
+        HIVE_HBASE_SNAPSHOT_NAME("hive.hbase.snapshot.name", null, "The HBase table snapshot name to use."),
+        HIVE_HBASE_SNAPSHOT_RESTORE_DIR("hive.hbase.snapshot.restoredir", "/tmp", "The directory in which to " +
+                "restore the HBase table snapshot."),
+
+        // For har files
+        HIVEARCHIVEENABLED("hive.archive.enabled", false, "Whether archiving operations are permitted"),
+
+        HIVEOPTGBYUSINGINDEX("hive.optimize.index.groupby", false,
+                "Whether to enable optimization of group-by queries using Aggregate indexes."),
+
+        HIVEOUTERJOINSUPPORTSFILTERS("hive.outerjoin.supports.filters", true, ""),
+
+        HIVEFETCHTASKCONVERSION("hive.fetch.task.conversion", "more", new StringSet("none", "minimal", "more"),
+                "Some select queries can be converted to single FETCH task minimizing latency.\n" +
+                        "Currently the query should be single sourced not having any subquery and should not have\n" +
+                        "any aggregations or distincts (which incurs RS), lateral views and joins.\n" +
+                        "0. none : disable hive.fetch.task.conversion\n" +
+                        "1. minimal : SELECT STAR, FILTER on partition columns, LIMIT only\n" +
+                        "2. more    : SELECT, FILTER, LIMIT only (support TABLESAMPLE and virtual columns)"
+        ),
+        HIVEFETCHTASKCONVERSIONTHRESHOLD("hive.fetch.task.conversion.threshold", 1073741824L,
+                "Input threshold for applying hive.fetch.task.conversion. If target table is native, input length\n" +
+                        "is calculated by summation of file lengths. If it's not native, storage handler for the table\n" +
+                        "can optionally implement org.apache.hadoop.hive.ql.metadata.InputEstimator interface."),
+
+        HIVEFETCHTASKAGGR("hive.fetch.task.aggr", false,
+                "Aggregation queries with no group-by clause (for example, select count(*) from src) execute\n" +
+                        "final aggregations in single reduce task. If this is set true, Hive delegates final aggregation\n" +
+                        "stage to fetch task, possibly decreasing the query time."),
+
+        HIVEOPTIMIZEMETADATAQUERIES("hive.compute.query.using.stats", false,
+                "When set to true Hive will answer a few queries like count(1) purely using stats\n" +
+                        "stored in metastore. For basic stats collection turn on the config hive.stats.autogather to true.\n" +
+                        "For more advanced stats collection need to run analyze table queries."),
+
+        // Serde for FetchTask
+        HIVEFETCHOUTPUTSERDE("hive.fetch.output.serde", "org.apache.hadoop.hive.serde2.DelimitedJSONSerDe",
+                "The SerDe used by FetchTask to serialize the fetch output."),
+
+        HIVEEXPREVALUATIONCACHE("hive.cache.expr.evaluation", true,
+                "If true, the evaluation result of a deterministic expression referenced twice or more\n" +
+                        "will be cached.\n" +
+                        "For example, in a filter condition like '.. where key + 10 = 100 or key + 10 = 0'\n" +
+                        "the expression 'key + 10' will be evaluated/cached once and reused for the following\n" +
+                        "expression ('key + 10 = 0'). Currently, this is applied only to expressions in select\n" +
+                        "or filter operators."),
+
+        // Hive Variables
+        HIVEVARIABLESUBSTITUTE("hive.variable.substitute", true,
+                "This enables substitution using syntax like ${var} ${system:var} and ${env:var}."),
+        HIVEVARIABLESUBSTITUTEDEPTH("hive.variable.substitute.depth", 40,
+                "The maximum replacements the substitution engine will do."),
+
+        HIVECONFVALIDATION("hive.conf.validation", true,
+                "Enables type checking for registered Hive configurations"),
+
+        SEMANTIC_ANALYZER_HOOK("hive.semantic.analyzer.hook", "", ""),
+        HIVE_TEST_AUTHORIZATION_SQLSTD_HS2_MODE(
+                "hive.test.authz.sstd.hs2.mode", false, "test hs2 mode from .q tests", true),
+        HIVE_AUTHORIZATION_ENABLED("hive.security.authorization.enabled", false,
+                "enable or disable the Hive client authorization"),
+        HIVE_AUTHORIZATION_MANAGER("hive.security.authorization.manager",
+                "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider",
+                "The Hive client authorization manager class name. The user defined authorization class should implement \n" +
+                        "interface org.apache.hadoop.hive.ql.security.authorization.HiveAuthorizationProvider."),
+        HIVE_AUTHENTICATOR_MANAGER("hive.security.authenticator.manager",
+                "org.apache.hadoop.hive.ql.security.HadoopDefaultAuthenticator",
+                "hive client authenticator manager class name. The user defined authenticator should implement \n" +
+                        "interface org.apache.hadoop.hive.ql.security.HiveAuthenticationProvider."),
+        HIVE_METASTORE_AUTHORIZATION_MANAGER("hive.security.metastore.authorization.manager",
+                "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveMetastoreAuthorizationProvider",
+                "Names of authorization manager classes (comma separated) to be used in the metastore\n" +
+                        "for authorization. The user defined authorization class should implement interface\n" +
+                        "org.apache.hadoop.hive.ql.security.authorization.HiveMetastoreAuthorizationProvider.\n" +
+                        "All authorization manager classes have to successfully authorize the metastore API\n" +
+                        "call for the command execution to be allowed."),
+        HIVE_METASTORE_AUTHORIZATION_AUTH_READS("hive.security.metastore.authorization.auth.reads", true,
+                "If this is true, metastore authorizer authorizes read actions on database, table"),
+        HIVE_METASTORE_AUTHENTICATOR_MANAGER("hive.security.metastore.authenticator.manager",
+                "org.apache.hadoop.hive.ql.security.HadoopDefaultMetastoreAuthenticator",
+                "authenticator manager class name to be used in the metastore for authentication. \n" +
+                        "The user defined authenticator should implement interface org.apache.hadoop.hive.ql.security.HiveAuthenticationProvider."),
+        HIVE_MOVE_FILES_THREAD_COUNT("hive.mv.files.thread", 15, "Number of threads"
+                + " used to move files in move task. Set it to 0 to disable multi-threaded file moves. This parameter is also used by"
+                + " MSCK to check tables."),
+        HIVE_AUTHORIZATION_TABLE_USER_GRANTS("hive.security.authorization.createtable.user.grants", "",
+                "the privileges automatically granted to some users whenever a table gets created.\n" +
+                        "An example like \"userX,userY:select;userZ:create\" will grant select privilege to userX and userY,\n" +
+                        "and grant create privilege to userZ whenever a new table created."),
+        HIVE_AUTHORIZATION_TABLE_GROUP_GRANTS("hive.security.authorization.createtable.group.grants",
+                "",
+                "the privileges automatically granted to some groups whenever a table gets created.\n" +
+                        "An example like \"groupX,groupY:select;groupZ:create\" will grant select privilege to groupX and groupY,\n" +
+                        "and grant create privilege to groupZ whenever a new table created."),
+        HIVE_AUTHORIZATION_TABLE_ROLE_GRANTS("hive.security.authorization.createtable.role.grants", "",
+                "the privileges automatically granted to some roles whenever a table gets created.\n" +
+                        "An example like \"roleX,roleY:select;roleZ:create\" will grant select privilege to roleX and roleY,\n" +
+                        "and grant create privilege to roleZ whenever a new table created."),
+        HIVE_AUTHORIZATION_TABLE_OWNER_GRANTS("hive.security.authorization.createtable.owner.grants",
+                "",
+                "The privileges automatically granted to the owner whenever a table gets created.\n" +
+                        "An example like \"select,drop\" will grant select and drop privilege to the owner\n" +
+                        "of the table. Note that the default gives the creator of a table no access to the\n" +
+                        "table (but see HIVE-8067)."),
+        HIVE_AUTHORIZATION_TASK_FACTORY("hive.security.authorization.task.factory",
+                "org.apache.hadoop.hive.ql.parse.authorization.HiveAuthorizationTaskFactoryImpl",
+                "Authorization DDL task factory implementation"),
+
+        // if this is not set default value is set during config initialization
+        // Default value can't be set in this constructor as it would refer names in other ConfVars
+        // whose constructor would not have been called
+        HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST(
+                "hive.security.authorization.sqlstd.confwhitelist", "",
+                "List of comma separated Java regexes. Configurations parameters that match these\n" +
+                        "regexes can be modified by user when SQL standard authorization is enabled.\n" +
+                        "To get the default value, use the 'set <param>' command.\n" +
+                        "Note that the hive.conf.restricted.list checks are still enforced after the white list\n" +
+                        "check"),
+
+        HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST_APPEND(
+                "hive.security.authorization.sqlstd.confwhitelist.append", "",
+                "List of comma separated Java regexes, to be appended to list set in\n" +
+                        "hive.security.authorization.sqlstd.confwhitelist. Using this list instead\n" +
+                        "of updating the original list means that you can append to the defaults\n" +
+                        "set by SQL standard authorization instead of replacing it entirely."),
+
+        HIVE_CLI_PRINT_HEADER("hive.cli.print.header", false, "Whether to print the names of the columns in query output."),
+
+        HIVE_ERROR_ON_EMPTY_PARTITION("hive.error.on.empty.partition", false,
+                "Whether to throw an exception if dynamic partition insert generates empty results."),
+
+        HIVE_INDEX_COMPACT_FILE("hive.index.compact.file", "", "internal variable"),
+        HIVE_INDEX_BLOCKFILTER_FILE("hive.index.blockfilter.file", "", "internal variable"),
+        HIVE_INDEX_IGNORE_HDFS_LOC("hive.index.compact.file.ignore.hdfs", false,
+                "When true the HDFS location stored in the index file will be ignored at runtime.\n" +
+                        "If the data got moved or the name of the cluster got changed, the index data should still be usable."),
+
+        HIVE_EXIM_URI_SCHEME_WL("hive.exim.uri.scheme.whitelist", "hdfs,pfile",
+                "A comma separated list of acceptable URI schemes for import and export."),
+        // temporary variable for testing. This is added just to turn off this feature in case of a bug in
+        // deployment. It has not been documented in hive-default.xml intentionally, this should be removed
+        // once the feature is stable
+        HIVE_EXIM_RESTRICT_IMPORTS_INTO_REPLICATED_TABLES("hive.exim.strict.repl.tables", true,
+                "Parameter that determines if 'regular' (non-replication) export dumps can be\n" +
+                        "imported on to tables that are the target of replication. If this parameter is\n" +
+                        "set, regular imports will check if the destination table(if it exists) has a " +
+                        "'repl.last.id' set on it. If so, it will fail."),
+        HIVE_REPL_TASK_FACTORY("hive.repl.task.factory",
+                "org.apache.hive.hcatalog.api.repl.exim.EximReplicationTaskFactory",
+                "Parameter that can be used to override which ReplicationTaskFactory will be\n" +
+                        "used to instantiate ReplicationTask events. Override for third party repl plugins"),
+        HIVE_MAPPER_CANNOT_SPAN_MULTIPLE_PARTITIONS("hive.mapper.cannot.span.multiple.partitions", false, ""),
+        HIVE_REWORK_MAPREDWORK("hive.rework.mapredwork", false,
+                "should rework the mapred work or not.\n" +
+                        "This is first introduced by SymlinkTextInputFormat to replace symlink files with real paths at compile time."),
+        HIVE_CONCATENATE_CHECK_INDEX("hive.exec.concatenate.check.index", true,
+                "If this is set to true, Hive will throw error when doing\n" +
+                        "'alter table tbl_name [partSpec] concatenate' on a table/partition\n" +
+                        "that has indexes on it. The reason the user want to set this to true\n" +
+                        "is because it can help user to avoid handling all index drop, recreation,\n" +
+                        "rebuild work. This is very helpful for tables with thousands of partitions."),
+        HIVE_IO_EXCEPTION_HANDLERS("hive.io.exception.handlers", "",
+                "A list of io exception handler class names. This is used\n" +
+                        "to construct a list exception handlers to handle exceptions thrown\n" +
+                        "by record readers"),
+
+        // operation log configuration
+        HIVE_SERVER2_LOGGING_OPERATION_ENABLED("hive.server2.logging.operation.enabled", true,
+                "When true, HS2 will save operation logs and make them available for clients"),
+        HIVE_SERVER2_LOGGING_OPERATION_LOG_LOCATION("hive.server2.logging.operation.log.location",
+                "${system:java.io.tmpdir}" + File.separator + "${system:user.name}" + File.separator +
+                        "operation_logs",
+                "Top level directory where operation logs are stored if logging functionality is enabled"),
+        HIVE_SERVER2_LOGGING_OPERATION_LEVEL("hive.server2.logging.operation.level", "EXECUTION",
+                new StringSet("NONE", "EXECUTION", "PERFORMANCE", "VERBOSE"),
+                "HS2 operation logging mode available to clients to be set at session level.\n" +
+                        "For this to work, hive.server2.logging.operation.enabled should be set to true.\n" +
+                        "  NONE: Ignore any logging\n" +
+                        "  EXECUTION: Log completion of tasks\n" +
+                        "  PERFORMANCE: Execution + Performance logs \n" +
+                        "  VERBOSE: All logs"),
+        // logging configuration
+        HIVE_LOG4J_FILE("hive.log4j.file", "",
+                "Hive log4j configuration file.\n" +
+                        "If the property is not set, then logging will be initialized using hive-log4j.properties found on the classpath.\n" +
+                        "If the property is set, the value must be a valid URI (java.net.URI, e.g. \"file:///tmp/my-logging.properties\"), \n" +
+                        "which you can then extract a URL from and pass to PropertyConfigurator.configure(URL)."),
+        HIVE_EXEC_LOG4J_FILE("hive.exec.log4j.file", "",
+                "Hive log4j configuration file for execution mode(sub command).\n" +
+                        "If the property is not set, then logging will be initialized using hive-exec-log4j.properties found on the classpath.\n" +
+                        "If the property is set, the value must be a valid URI (java.net.URI, e.g. \"file:///tmp/my-logging.properties\"), \n" +
+                        "which you can then extract a URL from and pass to PropertyConfigurator.configure(URL)."),
+
+        HIVE_LOG_EXPLAIN_OUTPUT("hive.log.explain.output", false,
+                "Whether to log explain output for every query.\n" +
+                        "When enabled, will log EXPLAIN EXTENDED output for the query at INFO log4j log level."),
+        HIVE_EXPLAIN_USER("hive.explain.user", false,
+                "Whether to show explain result at user level.\n" +
+                        "When enabled, will log EXPLAIN output for the query at user level."),
+
+        // prefix used to auto generated column aliases (this should be started with '_')
+        HIVE_AUTOGEN_COLUMNALIAS_PREFIX_LABEL("hive.autogen.columnalias.prefix.label", "_c",
+                "String used as a prefix when auto generating column alias.\n" +
+                        "By default the prefix label will be appended with a column position number to form the column alias. \n" +
+                        "Auto generation would happen if an aggregate function is used in a select clause without an explicit alias."),
+        HIVE_AUTOGEN_COLUMNALIAS_PREFIX_INCLUDEFUNCNAME(
+                "hive.autogen.columnalias.prefix.includefuncname", false,
+                "Whether to include function name in the column alias auto generated by Hive."),
+
+        HIVE_PERF_LOGGER("hive.exec.perf.logger", "org.apache.hadoop.hive.ql.log.PerfLogger",
+                "The class responsible for logging client side performance metrics. \n" +
+                        "Must be a subclass of org.apache.hadoop.hive.ql.log.PerfLogger"),
+        HIVE_START_CLEANUP_SCRATCHDIR("hive.start.cleanup.scratchdir", false,
+                "To cleanup the Hive scratchdir when starting the Hive Server"),
+        HIVE_INSERT_INTO_MULTILEVEL_DIRS("hive.insert.into.multilevel.dirs", false,
+                "Where to insert into multilevel directories like\n" +
+                        "\"insert directory '/HIVEFT25686/chinna/' from table\""),
+        HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS("hive.warehouse.subdir.inherit.perms", true,
+                "Set this to false if the table directories should be created\n" +
+                        "with the permissions derived from dfs umask instead of\n" +
+                        "inheriting the permission of the warehouse or database directory."),
+        HIVE_INSERT_INTO_EXTERNAL_TABLES("hive.insert.into.external.tables", true,
+                "whether insert into external tables is allowed"),
+        HIVE_TEMPORARY_TABLE_STORAGE(
+                "hive.exec.temporary.table.storage", "default", new StringSet("memory",
+                "ssd", "default"), "Define the storage policy for temporary tables." +
+                "Choices between memory, ssd and default"),
+
+        HIVE_DRIVER_RUN_HOOKS("hive.exec.driver.run.hooks", "",
+                "A comma separated list of hooks which implement HiveDriverRunHook. Will be run at the beginning " +
+                        "and end of Driver.run, these will be run in the order specified."),
+        HIVE_DDL_OUTPUT_FORMAT("hive.ddl.output.format", null,
+                "The data format to use for DDL output.  One of \"text\" (for human\n" +
+                        "readable text) or \"json\" (for a json object)."),
+        HIVE_ENTITY_SEPARATOR("hive.entity.separator", "@",
+                "Separator used to construct names of tables and partitions. For example, dbname@tablename@partitionname"),
+        HIVE_CAPTURE_TRANSFORM_ENTITY("hive.entity.capture.transform", false,
+                "Compiler to capture transform URI referred in the query"),
+        HIVE_DISPLAY_PARTITION_COLUMNS_SEPARATELY("hive.display.partition.cols.separately", true,
+                "In older Hive version (0.10 and earlier) no distinction was made between\n" +
+                        "partition columns or non-partition columns while displaying columns in describe\n" +
+                        "table. From 0.12 onwards, they are displayed separately. This flag will let you\n" +
+                        "get old behavior, if desired. See, test-case in patch for HIVE-6689."),
+
+        HIVE_SSL_PROTOCOL_BLACKLIST("hive.ssl.protocol.blacklist", "SSLv2,SSLv3",
+                "SSL Versions to disable for all Hive Servers"),
+
+        // HiveServer2 specific configs
+        HIVE_SERVER2_MAX_START_ATTEMPTS("hive.server2.max.start.attempts", 30L, new RangeValidator(0L, null),
+                "Number of times HiveServer2 will attempt to start before exiting, sleeping 60 seconds " +
+                        "between retries. \n The default of 30 will keep trying for 30 minutes."),
+        HIVE_SERVER2_SUPPORT_DYNAMIC_SERVICE_DISCOVERY("hive.server2.support.dynamic.service.discovery", false,
+                "Whether HiveServer2 supports dynamic service discovery for its clients. " +
+                        "To support this, each instance of HiveServer2 currently uses ZooKeeper to register itself, " +
+                        "when it is brought up. JDBC/ODBC clients should use the ZooKeeper ensemble: " +
+                        "hive.zookeeper.quorum in their connection string."),
+        HIVE_SERVER2_ZOOKEEPER_NAMESPACE("hive.server2.zookeeper.namespace", "hiveserver2",
+                "The parent node in ZooKeeper used by HiveServer2 when supporting dynamic service discovery."),
+        // HiveServer2 global init file location
+        HIVE_SERVER2_GLOBAL_INIT_FILE_LOCATION("hive.server2.global.init.file.location", "${env:HIVE_CONF_DIR}",
+                "Either the location of a HS2 global init file or a directory containing a .hiverc file. If the \n" +
+                        "property is set, the value must be a valid path to an init file or directory where the init file is located."),
+        HIVE_SERVER2_TRANSPORT_MODE("hive.server2.transport.mode", "binary", new StringSet("binary", "http"),
+                "Transport mode of HiveServer2."),
+        HIVE_SERVER2_THRIFT_BIND_HOST("hive.server2.thrift.bind.host", "",
+                "Bind host on which to run the HiveServer2 Thrift service."),
+
+        // http (over thrift) transport settings
+        HIVE_SERVER2_THRIFT_HTTP_PORT("hive.server2.thrift.http.port", 10001,
+                "Port number of HiveServer2 Thrift interface when hive.server2.transport.mode is 'http'."),
+        HIVE_SERVER2_THRIFT_HTTP_PATH("hive.server2.thrift.http.path", "cliservice",
+                "Path component of URL endpoint when in HTTP mode."),
+        HIVE_SERVER2_THRIFT_MAX_MESSAGE_SIZE("hive.server2.thrift.max.message.size", 100 * 1024 * 1024,
+                "Maximum message size in bytes a HS2 server will accept."),
+        HIVE_SERVER2_THRIFT_HTTP_MAX_IDLE_TIME("hive.server2.thrift.http.max.idle.time", "1800s",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Maximum idle time for a connection on the server when in HTTP mode."),
+        HIVE_SERVER2_THRIFT_HTTP_WORKER_KEEPALIVE_TIME("hive.server2.thrift.http.worker.keepalive.time", "60s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Keepalive time for an idle http worker thread. When the number of workers exceeds min workers, " +
+                        "excessive threads are killed after this time interval."),
+
+        // Cookie based authentication
+        HIVE_SERVER2_THRIFT_HTTP_COOKIE_AUTH_ENABLED("hive.server2.thrift.http.cookie.auth.enabled", true,
+                "When true, HiveServer2 in HTTP transport mode, will use cookie based authentication mechanism."),
+        HIVE_SERVER2_THRIFT_HTTP_COOKIE_MAX_AGE("hive.server2.thrift.http.cookie.max.age", "86400s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Maximum age in seconds for server side cookie used by HS2 in HTTP mode."),
+        HIVE_SERVER2_THRIFT_HTTP_COOKIE_DOMAIN("hive.server2.thrift.http.cookie.domain", null,
+                "Domain for the HS2 generated cookies"),
+        HIVE_SERVER2_THRIFT_HTTP_COOKIE_PATH("hive.server2.thrift.http.cookie.path", null,
+                "Path for the HS2 generated cookies"),
+        HIVE_SERVER2_THRIFT_HTTP_COOKIE_IS_SECURE("hive.server2.thrift.http.cookie.is.secure", true,
+                "Secure attribute of the HS2 generated cookie."),
+        HIVE_SERVER2_THRIFT_HTTP_COOKIE_IS_HTTPONLY("hive.server2.thrift.http.cookie.is.httponly", true,
+                "HttpOnly attribute of the HS2 generated cookie."),
+
+        // binary transport settings
+        HIVE_SERVER2_THRIFT_PORT("hive.server2.thrift.port", 10000,
+                "Port number of HiveServer2 Thrift interface when hive.server2.transport.mode is 'binary'."),
+        HIVE_SERVER2_THRIFT_SASL_QOP("hive.server2.thrift.sasl.qop", "auth",
+                new StringSet("auth", "auth-int", "auth-conf"),
+                "Sasl QOP value; set it to one of following values to enable higher levels of\n" +
+                        "protection for HiveServer2 communication with clients.\n" +
+                        "Setting hadoop.rpc.protection to a higher level than HiveServer2 does not\n" +
+                        "make sense in most situations. HiveServer2 ignores hadoop.rpc.protection in favor\n" +
+                        "of hive.server2.thrift.sasl.qop.\n" +
+                        "  \"auth\" - authentication only (default)\n" +
+                        "  \"auth-int\" - authentication plus integrity protection\n" +
+                        "  \"auth-conf\" - authentication plus integrity and confidentiality protection\n" +
+                        "This is applicable only if HiveServer2 is configured to use Kerberos authentication."),
+        HIVE_SERVER2_THRIFT_MIN_WORKER_THREADS("hive.server2.thrift.min.worker.threads", 5,
+                "Minimum number of Thrift worker threads"),
+        HIVE_SERVER2_THRIFT_MAX_WORKER_THREADS("hive.server2.thrift.max.worker.threads", 500,
+                "Maximum number of Thrift worker threads"),
+        HIVE_SERVER2_THRIFT_LOGIN_BEBACKOFF_SLOT_LENGTH(
+                "hive.server2.thrift.exponential.backoff.slot.length", "100ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Binary exponential backoff slot time for Thrift clients during login to HiveServer2,\n" +
+                        "for retries until hitting Thrift client timeout"),
+        HIVE_SERVER2_THRIFT_LOGIN_TIMEOUT("hive.server2.thrift.login.timeout", "20s",
+                new TimeValidator(TimeUnit.SECONDS), "Timeout for Thrift clients during login to HiveServer2"),
+        HIVE_SERVER2_THRIFT_WORKER_KEEPALIVE_TIME("hive.server2.thrift.worker.keepalive.time", "60s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Keepalive time (in seconds) for an idle worker thread. When the number of workers exceeds min workers, " +
+                        "excessive threads are killed after this time interval."),
+        // Configuration for async thread pool in SessionManager
+        HIVE_SERVER2_ASYNC_EXEC_THREADS("hive.server2.async.exec.threads", 100,
+                "Number of threads in the async thread pool for HiveServer2"),
+        HIVE_SERVER2_ASYNC_EXEC_SHUTDOWN_TIMEOUT("hive.server2.async.exec.shutdown.timeout", "10s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "How long HiveServer2 shutdown will wait for async threads to terminate."),
+        HIVE_SERVER2_ASYNC_EXEC_WAIT_QUEUE_SIZE("hive.server2.async.exec.wait.queue.size", 100,
+                "Size of the wait queue for async thread pool in HiveServer2.\n" +
+                        "After hitting this limit, the async thread pool will reject new requests."),
+        HIVE_SERVER2_ASYNC_EXEC_KEEPALIVE_TIME("hive.server2.async.exec.keepalive.time", "10s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Time that an idle HiveServer2 async thread (from the thread pool) will wait for a new task\n" +
+                        "to arrive before terminating"),
+        HIVE_SERVER2_LONG_POLLING_TIMEOUT("hive.server2.long.polling.timeout", "5000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Time that HiveServer2 will wait before responding to asynchronous calls that use long polling"),
+
+        // HiveServer2 auth configuration
+        HIVE_SERVER2_AUTHENTICATION("hive.server2.authentication", "NONE",
+                new StringSet("NOSASL", "NONE", "LDAP", "KERBEROS", "PAM", "CUSTOM"),
+                "Client authentication types.\n" +
+                        "  NONE: no authentication check\n" +
+                        "  LDAP: LDAP/AD based authentication\n" +
+                        "  KERBEROS: Kerberos/GSSAPI authentication\n" +
+                        "  CUSTOM: Custom authentication provider\n" +
+                        "          (Use with property hive.server2.custom.authentication.class)\n" +
+                        "  PAM: Pluggable authentication module\n" +
+                        "  NOSASL:  Raw transport"),
+        HIVE_SERVER2_ALLOW_USER_SUBSTITUTION("hive.server2.allow.user.substitution", true,
+                "Allow alternate user to be specified as part of HiveServer2 open connection request."),
+        HIVE_SERVER2_KERBEROS_KEYTAB("hive.server2.authentication.kerberos.keytab", "",
+                "Kerberos keytab file for server principal"),
+        HIVE_SERVER2_KERBEROS_PRINCIPAL("hive.server2.authentication.kerberos.principal", "",
+                "Kerberos server principal"),
+        HIVE_SERVER2_SPNEGO_KEYTAB("hive.server2.authentication.spnego.keytab", "",
+                "keytab file for SPNego principal, optional,\n" +
+                        "typical value would look like /etc/security/keytabs/spnego.service.keytab,\n" +
+                        "This keytab would be used by HiveServer2 when Kerberos security is enabled and \n" +
+                        "HTTP transport mode is used.\n" +
+                        "This needs to be set only if SPNEGO is to be used in authentication.\n" +
+                        "SPNego authentication would be honored only if valid\n" +
+                        "  hive.server2.authentication.spnego.principal\n" +
+                        "and\n" +
+                        "  hive.server2.authentication.spnego.keytab\n" +
+                        "are specified."),
+        HIVE_SERVER2_SPNEGO_PRINCIPAL("hive.server2.authentication.spnego.principal", "",
+                "SPNego service principal, optional,\n" +
+                        "typical value would look like HTTP/_HOST@EXAMPLE.COM\n" +
+                        "SPNego service principal would be used by HiveServer2 when Kerberos security is enabled\n" +
+                        "and HTTP transport mode is used.\n" +
+                        "This needs to be set only if SPNEGO is to be used in authentication."),
+        HIVE_SERVER2_PLAIN_LDAP_URL("hive.server2.authentication.ldap.url", null,
+                "LDAP connection URL(s),\n" +
+                        "this value could contain URLs to mutiple LDAP servers instances for HA,\n" +
+                        "each LDAP URL is separated by a SPACE character. URLs are used in the \n" +
+                        " order specified until a connection is successful."),
+        HIVE_SERVER2_PLAIN_LDAP_BASEDN("hive.server2.authentication.ldap.baseDN", null, "LDAP base DN"),
+        HIVE_SERVER2_PLAIN_LDAP_DOMAIN("hive.server2.authentication.ldap.Domain", null, ""),
+        HIVE_SERVER2_CUSTOM_AUTHENTICATION_CLASS("hive.server2.custom.authentication.class", null,
+                "Custom authentication class. Used when property\n" +
+                        "'hive.server2.authentication' is set to 'CUSTOM'. Provided class\n" +
+                        "must be a proper implementation of the interface\n" +
+                        "org.apache.hive.service.auth.PasswdAuthenticationProvider. HiveServer2\n" +
+                        "will call its Authenticate(user, passed) method to authenticate requests.\n" +
+                        "The implementation may optionally implement Hadoop's\n" +
+                        "org.apache.hadoop.conf.Configurable class to grab Hive's Configuration object."),
+        HIVE_SERVER2_PAM_SERVICES("hive.server2.authentication.pam.services", null,
+                "List of the underlying pam services that should be used when auth type is PAM\n" +
+                        "A file with the same name must exist in /etc/pam.d"),
+
+        HIVE_SERVER2_ENABLE_DOAS("hive.server2.enable.doAs", true,
+                "Setting this property to true will have HiveServer2 execute\n" +
+                        "Hive operations as the user making the calls to it."),
+        HIVE_SERVER2_TABLE_TYPE_MAPPING("hive.server2.table.type.mapping", "CLASSIC", new StringSet("CLASSIC", "HIVE"),
+                "This setting reflects how HiveServer2 will report the table types for JDBC and other\n" +
+                        "client implementations that retrieve the available tables and supported table types\n" +
+                        "  HIVE : Exposes Hive's native table types like MANAGED_TABLE, EXTERNAL_TABLE, VIRTUAL_VIEW\n" +
+                        "  CLASSIC : More generic types like TABLE and VIEW"),
+        HIVE_SERVER2_SESSION_HOOK("hive.server2.session.hook", "", ""),
+        HIVE_SERVER2_USE_SSL("hive.server2.use.SSL", false,
+                "Set this to true for using SSL encryption in HiveServer2."),
+        HIVE_SERVER2_SSL_KEYSTORE_PATH("hive.server2.keystore.path", "",
+                "SSL certificate keystore location."),
+        HIVE_SERVER2_SSL_KEYSTORE_PASSWORD("hive.server2.keystore.password", "",
+                "SSL certificate keystore password."),
+        HIVE_SERVER2_MAP_FAIR_SCHEDULER_QUEUE("hive.server2.map.fair.scheduler.queue", true,
+                "If the YARN fair scheduler is configured and HiveServer2 is running in non-impersonation mode,\n" +
+                        "this setting determines the user for fair scheduler queue mapping.\n" +
+                        "If set to true (default), the logged-in user determines the fair scheduler queue\n" +
+                        "for submitted jobs, so that map reduce resource usage can be tracked by user.\n" +
+                        "If set to false, all Hive jobs go to the 'hive' user's queue."),
+        HIVE_SERVER2_BUILTIN_UDF_WHITELIST("hive.server2.builtin.udf.whitelist", "",
+                "Comma separated list of builtin udf names allowed in queries.\n" +
+                        "An empty whitelist allows all builtin udfs to be executed. " +
+                        " The udf black list takes precedence over udf white list"),
+        HIVE_SERVER2_BUILTIN_UDF_BLACKLIST("hive.server2.builtin.udf.blacklist", "",
+                "Comma separated list of udfs names. These udfs will not be allowed in queries." +
+                        " The udf black list takes precedence over udf white list"),
+
+        HIVE_SECURITY_COMMAND_WHITELIST("hive.security.command.whitelist", "set,reset,dfs,add,list,delete,reload,compile",
+                "Comma separated list of non-SQL Hive commands users are authorized to execute"),
+
+        HIVE_SERVER2_SESSION_CHECK_INTERVAL("hive.server2.session.check.interval", "6h",
+                new TimeValidator(TimeUnit.MILLISECONDS, 3000l, true, null, false),
+                "The check interval for session/operation timeout, which can be disabled by setting to zero or negative value."),
+        HIVE_SERVER2_IDLE_SESSION_TIMEOUT("hive.server2.idle.session.timeout", "7d",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Session will be closed when it's not accessed for this duration, which can be disabled by setting to zero or negative value."),
+        HIVE_SERVER2_IDLE_OPERATION_TIMEOUT("hive.server2.idle.operation.timeout", "5d",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Operation will be closed when it's not accessed for this duration of time, which can be disabled by setting to zero value.\n" +
+                        "  With positive value, it's checked for operations in terminal state only (FINISHED, CANCELED, CLOSED, ERROR).\n" +
+                        "  With negative value, it's checked for all of the operations regardless of state."),
+        HIVE_SERVER2_IDLE_SESSION_CHECK_OPERATION("hive.server2.idle.session.check.operation", true,
+                "Session will be considered to be idle only if there is no activity, and there is no pending operation.\n" +
+                        " This setting takes effect only if session idle timeout (hive.server2.idle.session.timeout) and checking\n" +
+                        "(hive.server2.session.check.interval) are enabled."),
+
+        HIVE_CONF_RESTRICTED_LIST("hive.conf.restricted.list",
+                "hive.security.authenticator.manager,hive.security.authorization.manager,hive.users.in.admin.role",
+                "Comma separated list of configuration options which are immutable at runtime"),
+
+        // If this is set all move tasks at the end of a multi-insert query will only begin once all
+        // outputs are ready
+        HIVE_MULTI_INSERT_MOVE_TASKS_SHARE_DEPENDENCIES(
+                "hive.multi.insert.move.tasks.share.dependencies", false,
+                "If this is set all move tasks for tables/partitions (not directories) at the end of a\n" +
+                        "multi-insert query will only begin once the dependencies for all these move tasks have been\n" +
+                        "met.\n" +
+                        "Advantages: If concurrency is enabled, the locks will only be released once the query has\n" +
+                        "            finished, so with this config enabled, the time when the table/partition is\n" +
+                        "            generated will be much closer to when the lock on it is released.\n" +
+                        "Disadvantages: If concurrency is not enabled, with this disabled, the tables/partitions which\n" +
+                        "               are produced by this query and finish earlier will be available for querying\n" +
+                        "               much earlier.  Since the locks are only released once the query finishes, this\n" +
+                        "               does not apply if concurrency is enabled."),
+
+        HIVE_INFER_BUCKET_SORT("hive.exec.infer.bucket.sort", false,
+                "If this is set, when writing partitions, the metadata will include the bucketing/sorting\n" +
+                        "properties with which the data was written if any (this will not overwrite the metadata\n" +
+                        "inherited from the table if the table is bucketed/sorted)"),
+
+        HIVE_INFER_BUCKET_SORT_NUM_BUCKETS_POWER_TWO(
+                "hive.exec.infer.bucket.sort.num.buckets.power.two", false,
+                "If this is set, when setting the number of reducers for the map reduce task which writes the\n" +
+                        "final output files, it will choose a number which is a power of two, unless the user specifies\n" +
+                        "the number of reducers to use using mapred.reduce.tasks.  The number of reducers\n" +
+                        "may be set to a power of two, only to be followed by a merge task meaning preventing\n" +
+                        "anything from being inferred.\n" +
+                        "With hive.exec.infer.bucket.sort set to true:\n" +
+                        "Advantages:  If this is not set, the number of buckets for partitions will seem arbitrary,\n" +
+                        "             which means that the number of mappers used for optimized joins, for example, will\n" +
+                        "             be very low.  With this set, since the number of buckets used for any partition is\n" +
+                        "             a power of two, the number of mappers used for optimized joins will be the least\n" +
+                        "             number of buckets used by any partition being joined.\n" +
+                        "Disadvantages: This may mean a much larger or much smaller number of reducers being used in the\n" +
+                        "               final map reduce job, e.g. if a job was originally going to take 257 reducers,\n" +
+                        "               it will now take 512 reducers, similarly if the max number of reducers is 511,\n" +
+                        "               and a job was going to use this many, it will now use 256 reducers."),
+
+        HIVEOPTLISTBUCKETING("hive.optimize.listbucketing", false,
+                "Enable list bucketing optimizer. Default value is false so that we disable it by default."),
+
+        // Allow TCP Keep alive socket option for for HiveServer or a maximum timeout for the socket.
+        SERVER_READ_SOCKET_TIMEOUT("hive.server.read.socket.timeout", "10s",
+                new TimeValidator(TimeUnit.SECONDS),
+                "Timeout for the HiveServer to close the connection if no response from the client. By default, 10 seconds."),
+        SERVER_TCP_KEEP_ALIVE("hive.server.tcp.keepalive", true,
+                "Whether to enable TCP keepalive for the Hive Server. Keepalive will prevent accumulation of half-open connections."),
+
+        HIVE_DECODE_PARTITION_NAME("hive.decode.partition.name", false,
+                "Whether to show the unquoted partition names in query results."),
+
+        HIVE_EXECUTION_ENGINE("hive.execution.engine", "mr", new StringSet("mr", "tez", "spark"),
+                "Chooses execution engine. Options are: mr (Map reduce, default), tez (hadoop 2 only), spark"),
+        HIVE_JAR_DIRECTORY("hive.jar.directory", null,
+                "This is the location hive in tez mode will look for to find a site wide \n" +
+                        "installed hive instance."),
+        HIVE_USER_INSTALL_DIR("hive.user.install.directory", "hdfs:///user/",
+                "If hive (in tez mode only) cannot find a usable hive jar in \"hive.jar.directory\", \n" +
+                        "it will upload the hive jar to \"hive.user.install.directory/user.name\"\n" +
+                        "and use it to run queries."),
+
+        // Vectorization enabled
+        HIVE_VECTORIZATION_ENABLED("hive.vectorized.execution.enabled", false,
+                "This flag should be set to true to enable vectorized mode of query execution.\n" +
+                        "The default value is false."),
+        HIVE_VECTORIZATION_REDUCE_ENABLED("hive.vectorized.execution.reduce.enabled", true,
+                "This flag should be set to true to enable vectorized mode of the reduce-side of query execution.\n" +
+                        "The default value is true."),
+        HIVE_VECTORIZATION_REDUCE_GROUPBY_ENABLED("hive.vectorized.execution.reduce.groupby.enabled", true,
+                "This flag should be set to true to enable vectorized mode of the reduce-side GROUP BY query execution.\n" +
+                        "The default value is true."),
+        HIVE_VECTORIZATION_MAPJOIN_NATIVE_ENABLED("hive.vectorized.execution.mapjoin.native.enabled", true,
+                "This flag should be set to true to enable native (i.e. non-pass through) vectorization\n" +
+                        "of queries using MapJoin.\n" +
+                        "The default value is true."),
+        HIVE_VECTORIZATION_MAPJOIN_NATIVE_MULTIKEY_ONLY_ENABLED("hive.vectorized.execution.mapjoin.native.multikey.only.enabled", false,
+                "This flag should be set to true to restrict use of native vector map join hash tables to\n" +
+                        "the MultiKey in queries using MapJoin.\n" +
+                        "The default value is false."),
+        HIVE_VECTORIZATION_MAPJOIN_NATIVE_MINMAX_ENABLED("hive.vectorized.execution.mapjoin.minmax.enabled", false,
+                "This flag should be set to true to enable vector map join hash tables to\n" +
+                        "use max / max filtering for integer join queries using MapJoin.\n" +
+                        "The default value is false."),
+        HIVE_VECTORIZATION_MAPJOIN_NATIVE_OVERFLOW_REPEATED_THRESHOLD("hive.vectorized.execution.mapjoin.overflow.repeated.threshold", -1,
+                "The number of small table rows for a match in vector map join hash tables\n" +
+                        "where we use the repeated field optimization in overflow vectorized row batch for join queries using MapJoin.\n" +
+                        "A value of -1 means do use the join result optimization.  Otherwise, threshold value can be 0 to maximum integer."),
+        HIVE_VECTORIZATION_MAPJOIN_NATIVE_FAST_HASHTABLE_ENABLED("hive.vectorized.execution.mapjoin.native.fast.hashtable.enabled", false,
+                "This flag should be set to true to enable use of native fast vector map join hash tables in\n" +
+                        "queries using MapJoin.\n" +
+                        "The default value is false."),
+        HIVE_VECTORIZATION_GROUPBY_CHECKINTERVAL("hive.vectorized.groupby.checkinterval", 100000,
+                "Number of entries added to the group by aggregation hash before a recomputation of average entry size is performed."),
+        HIVE_VECTORIZATION_GROUPBY_MAXENTRIES("hive.vectorized.groupby.maxentries", 1000000,
+                "Max number of entries in the vector group by aggregation hashtables. \n" +
+                        "Exceeding this will trigger a flush irrelevant of memory pressure condition."),
+        HIVE_VECTORIZATION_GROUPBY_FLUSH_PERCENT("hive.vectorized.groupby.flush.percent", (float) 0.1,
+                "Percent of entries in the group by aggregation hash flushed when the memory threshold is exceeded."),
+
+        HIVE_TYPE_CHECK_ON_INSERT("hive.typecheck.on.insert", true, "This property has been extended to control "
+                + "whether to check, convert, and normalize partition value to conform to its column type in "
+                + "partition operations including but not limited to insert, such as alter, describe etc."),
+
+        HIVE_HADOOP_CLASSPATH("hive.hadoop.classpath", null,
+                "For Windows OS, we need to pass HIVE_HADOOP_CLASSPATH Java parameter while starting HiveServer2 \n" +
+                        "using \"-hiveconf hive.hadoop.classpath=%HIVE_LIB%\"."),
+
+        HIVE_RPC_QUERY_PLAN("hive.rpc.query.plan", false,
+                "Whether to send the query plan via local resource or RPC"),
+        HIVE_AM_SPLIT_GENERATION("hive.compute.splits.in.am", true,
+                "Whether to generate the splits locally or in the AM (tez only)"),
+
+        HIVE_PREWARM_ENABLED("hive.prewarm.enabled", false, "Enables container prewarm for Tez (Hadoop 2 only)"),
+        HIVE_PREWARM_NUM_CONTAINERS("hive.prewarm.numcontainers", 10, "Controls the number of containers to prewarm for Tez (Hadoop 2 only)"),
+
+        HIVESTAGEIDREARRANGE("hive.stageid.rearrange", "none", new StringSet("none", "idonly", "traverse", "execution"), ""),
+        HIVEEXPLAINDEPENDENCYAPPENDTASKTYPES("hive.explain.dependency.append.tasktype", false, ""),
+
+        HIVECOUNTERGROUP("hive.counters.group.name", "HIVE",
+                "The name of counter group for internal Hive variables (CREATED_FILE, FATAL_ERROR, etc.)"),
+
+        HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
+                "A list of comma separated values corresponding to YARN queues of the same name.\n" +
+                        "When HiveServer2 is launched in Tez mode, this configuration needs to be set\n" +
+                        "for multiple Tez sessions to run in parallel on the cluster."),
+        HIVE_SERVER2_TEZ_SESSIONS_PER_DEFAULT_QUEUE("hive.server2.tez.sessions.per.default.queue", 1,
+                "A positive integer that determines the number of Tez sessions that should be\n" +
+                        "launched on each of the queues specified by \"hive.server2.tez.default.queues\".\n" +
+                        "Determines the parallelism on each queue."),
+        HIVE_SERVER2_TEZ_INITIALIZE_DEFAULT_SESSIONS("hive.server2.tez.initialize.default.sessions", false,
+                "This flag is used in HiveServer2 to enable a user to use HiveServer2 without\n" +
+                        "turning on Tez for HiveServer2. The user could potentially want to run queries\n" +
+                        "over Tez without the pool of sessions."),
+
+        HIVE_QUOTEDID_SUPPORT("hive.support.quoted.identifiers", "column",
+                new StringSet("none", "column"),
+                "Whether to use quoted identifier. 'none' or 'column' can be used. \n" +
+                        "  none: default(past) behavior. Implies only alphaNumeric and underscore are valid characters in identifiers.\n" +
+                        "  column: implies column names can contain any character."
+        ),
+        HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS("hive.support.sql11.reserved.keywords", true,
+                "This flag should be set to true to enable support for SQL2011 reserved keywords.\n" +
+                        "The default value is true."),
+        // role names are case-insensitive
+        USERS_IN_ADMIN_ROLE("hive.users.in.admin.role", "", false,
+                "Comma separated list of users who are in admin role for bootstrapping.\n" +
+                        "More users can be added in ADMIN role later."),
+
+        HIVE_COMPAT("hive.compat", HiveCompat.DEFAULT_COMPAT_LEVEL,
+                "Enable (configurable) deprecated behaviors by setting desired level of backward compatibility.\n" +
+                        "Setting to 0.12:\n" +
+                        "  Maintains division behavior: int / int = double"),
+        HIVE_CONVERT_JOIN_BUCKET_MAPJOIN_TEZ("hive.convert.join.bucket.mapjoin.tez", false,
+                "Whether joins can be automatically converted to bucket map joins in hive \n" +
+                        "when tez is used as the execution engine."),
+
+        HIVE_CHECK_CROSS_PRODUCT("hive.exec.check.crossproducts", true,
+                "Check if a plan contains a Cross Product. If there is one, output a warning to the Session's console."),
+        HIVE_LOCALIZE_RESOURCE_WAIT_INTERVAL("hive.localize.resource.wait.interval", "5000ms",
+                new TimeValidator(TimeUnit.MILLISECONDS),
+                "Time to wait for another thread to localize the same resource for hive-tez."),
+        HIVE_LOCALIZE_RESOURCE_NUM_WAIT_ATTEMPTS("hive.localize.resource.num.wait.attempts", 5,
+                "The number of attempts waiting for localizing a resource in hive-tez."),
+        TEZ_AUTO_REDUCER_PARALLELISM("hive.tez.auto.reducer.parallelism", false,
+                "Turn on Tez' auto reducer parallelism feature. When enabled, Hive will still estimate data sizes\n" +
+                        "and set parallelism estimates. Tez will sample source vertices' output sizes and adjust the estimates at runtime as\n" +
+                        "necessary."),
+        TEZ_MAX_PARTITION_FACTOR("hive.tez.max.partition.factor", 2f,
+                "When auto reducer parallelism is enabled this factor will be used to over-partition data in shuffle edges."),
+        TEZ_MIN_PARTITION_FACTOR("hive.tez.min.partition.factor", 0.25f,
+                "When auto reducer parallelism is enabled this factor will be used to put a lower limit to the number\n" +
+                        "of reducers that tez specifies."),
+        TEZ_DYNAMIC_PARTITION_PRUNING(
+                "hive.tez.dynamic.partition.pruning", true,
+                "When dynamic pruning is enabled, joins on partition keys will be processed by sending\n" +
+                        "events from the processing vertices to the Tez application master. These events will be\n" +
+                        "used to prune unnecessary partitions."),
+        TEZ_DYNAMIC_PARTITION_PRUNING_MAX_EVENT_SIZE("hive.tez.dynamic.partition.pruning.max.event.size", 1 * 1024 * 1024L,
+                "Maximum size of events sent by processors in dynamic pruning. If this size is crossed no pruning will take place."),
+        TEZ_DYNAMIC_PARTITION_PRUNING_MAX_DATA_SIZE("hive.tez.dynamic.partition.pruning.max.data.size", 100 * 1024 * 1024L,
+                "Maximum total data size of events in dynamic pruning."),
+        TEZ_SMB_NUMBER_WAVES(
+                "hive.tez.smb.number.waves",
+                (float) 0.5,
+                "The number of waves in which to run the SMB join. Account for cluster being occupied. Ideally should be 1 wave."),
+        TEZ_EXEC_SUMMARY(
+                "hive.tez.exec.print.summary",
+                false,
+                "Display breakdown of execution steps, for every query executed by the shell."),
+        TEZ_EXEC_INPLACE_PROGRESS(
+                "hive.tez.exec.inplace.progress",
+                true,
+                "Updates tez job execution progress in-place in the terminal."),
+        SPARK_CLIENT_FUTURE_TIMEOUT("hive.spark.client.future.timeout",
+                "60s", new TimeValidator(TimeUnit.SECONDS),
+                "Timeout for requests from Hive client to remote Spark driver."),
+        SPARK_JOB_MONITOR_TIMEOUT("hive.spark.job.monitor.timeout",
+                "60s", new TimeValidator(TimeUnit.SECONDS),
+                "Timeout for job monitor to get Spark job state."),
+        SPARK_RPC_CLIENT_CONNECT_TIMEOUT("hive.spark.client.connect.timeout",
+                "1000ms", new TimeValidator(TimeUnit.MILLISECONDS),
+                "Timeout for remote Spark driver in connecting back to Hive client."),
+        SPARK_RPC_CLIENT_HANDSHAKE_TIMEOUT("hive.spark.client.server.connect.timeout",
+                "90000ms", new TimeValidator(TimeUnit.MILLISECONDS),
+                "Timeout for handshake between Hive client and remote Spark driver.  Checked by both processes."),
+        SPARK_RPC_SECRET_RANDOM_BITS("hive.spark.client.secret.bits", "256",
+                "Number of bits of randomness in the generated secret for communication between Hive client and remote Spark driver. " +
+                        "Rounded down to the nearest multiple of 8."),
+        SPARK_RPC_MAX_THREADS("hive.spark.client.rpc.threads", 8,
+                "Maximum number of threads for remote Spark driver's RPC event loop."),
+        SPARK_RPC_MAX_MESSAGE_SIZE("hive.spark.client.rpc.max.size", 50 * 1024 * 1024,
+                "Maximum message size in bytes for communication between Hive client and remote Spark driver. Default is 50MB."),
+        SPARK_RPC_CHANNEL_LOG_LEVEL("hive.spark.client.channel.log.level", null,
+                "Channel logging level for remote Spark driver.  One of {DEBUG, ERROR, INFO, TRACE, WARN}."),
+        SPARK_RPC_SASL_MECHANISM("hive.spark.client.rpc.sasl.mechanisms", "DIGEST-MD5",
+                "Name of the SASL mechanism to use for authentication."),
+        NWAYJOINREORDER("hive.reorder.nway.joins", true,
+                "Runs reordering of tables within single n-way join (i.e.: picks streamtable)"),
+        HIVE_LOG_N_RECORDS("hive.log.every.n.records", 0L, new RangeValidator(0L, null),
+                "If value is greater than 0 logs in fixed intervals of size n rather than exponentially.");
+
+        public final String varname;
+        private final String defaultExpr;
+
+        public final String defaultStrVal;
+        public final int defaultIntVal;
+        public final long defaultLongVal;
+        public final float defaultFloatVal;
+        public final boolean defaultBoolVal;
+
+        private final Class<?> valClass;
+        private final VarType valType;
+
+        private final Validator validator;
+
+        private final String description;
+
+        private final boolean excluded;
+        private final boolean caseSensitive;
+
+        ConfVars(String varname, Object defaultVal, String description) {
+            this(varname, defaultVal, null, description, true, false);
         }
-      }
-      for (String key : trimmed) {
-        set(key.trim(), getRaw(key));
-        unset(key);
-      }
-    }
 
-    setupSQLStdAuthWhiteList();
-
-    // setup list of conf vars that are not allowed to change runtime
-    setupRestrictList();
-
-  }
-
-  /**
-   * If the config whitelist param for sql standard authorization is not set, set it up here.
-   */
-  private void setupSQLStdAuthWhiteList() {
-    String whiteListParamsStr = getVar(ConfVars.HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST);
-    if (whiteListParamsStr == null || whiteListParamsStr.trim().isEmpty()) {
-      // set the default configs in whitelist
-      whiteListParamsStr = getSQLStdAuthDefaultWhiteListPattern();
-    }
-    setVar(ConfVars.HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST, whiteListParamsStr);
-  }
-
-  private static String getSQLStdAuthDefaultWhiteListPattern() {
-    // create the default white list from list of safe config params
-    // and regex list
-    String confVarPatternStr = Joiner.on("|").join(convertVarsToRegex(sqlStdAuthSafeVarNames));
-    String regexPatternStr = Joiner.on("|").join(sqlStdAuthSafeVarNameRegexes);
-    return regexPatternStr + "|" + confVarPatternStr;
-  }
-
-  /**
-   * @param paramList  list of parameter strings
-   * @return list of parameter strings with "." replaced by "\."
-   */
-  private static String[] convertVarsToRegex(String[] paramList) {
-    String[] regexes = new String[paramList.length];
-    for(int i=0; i<paramList.length; i++) {
-      regexes[i] = paramList[i].replace(".", "\\." );
-    }
-    return regexes;
-  }
-
-  /**
-   * Default list of modifiable config parameters for sql standard authorization
-   * For internal use only.
-   */
-  private static final String [] sqlStdAuthSafeVarNames = new String [] {
-    ConfVars.BYTESPERREDUCER.varname,
-    ConfVars.CLIENT_STATS_COUNTERS.varname,
-    ConfVars.DEFAULTPARTITIONNAME.varname,
-    ConfVars.DROPIGNORESNONEXISTENT.varname,
-    ConfVars.HIVECOUNTERGROUP.varname,
-    ConfVars.HIVEDEFAULTMANAGEDFILEFORMAT.varname,
-    ConfVars.HIVEENFORCEBUCKETING.varname,
-    ConfVars.HIVEENFORCEBUCKETMAPJOIN.varname,
-    ConfVars.HIVEENFORCESORTING.varname,
-    ConfVars.HIVEENFORCESORTMERGEBUCKETMAPJOIN.varname,
-    ConfVars.HIVEEXPREVALUATIONCACHE.varname,
-    ConfVars.HIVEHASHTABLELOADFACTOR.varname,
-    ConfVars.HIVEHASHTABLETHRESHOLD.varname,
-    ConfVars.HIVEIGNOREMAPJOINHINT.varname,
-    ConfVars.HIVELIMITMAXROWSIZE.varname,
-    ConfVars.HIVEMAPREDMODE.varname,
-    ConfVars.HIVEMAPSIDEAGGREGATE.varname,
-    ConfVars.HIVEOPTIMIZEMETADATAQUERIES.varname,
-    ConfVars.HIVEROWOFFSET.varname,
-    ConfVars.HIVEVARIABLESUBSTITUTE.varname,
-    ConfVars.HIVEVARIABLESUBSTITUTEDEPTH.varname,
-    ConfVars.HIVE_AUTOGEN_COLUMNALIAS_PREFIX_INCLUDEFUNCNAME.varname,
-    ConfVars.HIVE_AUTOGEN_COLUMNALIAS_PREFIX_LABEL.varname,
-    ConfVars.HIVE_CHECK_CROSS_PRODUCT.varname,
-    ConfVars.HIVE_COMPAT.varname,
-    ConfVars.HIVE_CONCATENATE_CHECK_INDEX.varname,
-    ConfVars.HIVE_DISPLAY_PARTITION_COLUMNS_SEPARATELY.varname,
-    ConfVars.HIVE_ERROR_ON_EMPTY_PARTITION.varname,
-    ConfVars.HIVE_EXECUTION_ENGINE.varname,
-    ConfVars.HIVE_EXIM_URI_SCHEME_WL.varname,
-    ConfVars.HIVE_FILE_MAX_FOOTER.varname,
-    ConfVars.HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES.varname,
-    ConfVars.HIVE_INSERT_INTO_MULTILEVEL_DIRS.varname,
-    ConfVars.HIVE_LOCALIZE_RESOURCE_NUM_WAIT_ATTEMPTS.varname,
-    ConfVars.HIVE_MULTI_INSERT_MOVE_TASKS_SHARE_DEPENDENCIES.varname,
-    ConfVars.HIVE_QUOTEDID_SUPPORT.varname,
-    ConfVars.HIVE_RESULTSET_USE_UNIQUE_COLUMN_NAMES.varname,
-    ConfVars.HIVE_STATS_COLLECT_PART_LEVEL_STATS.varname,
-    ConfVars.HIVE_SERVER2_LOGGING_OPERATION_LEVEL.varname,
-    ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS.varname,
-    ConfVars.JOB_DEBUG_CAPTURE_STACKTRACES.varname,
-    ConfVars.JOB_DEBUG_TIMEOUT.varname,
-    ConfVars.MAXCREATEDFILES.varname,
-    ConfVars.MAXREDUCERS.varname,
-    ConfVars.NWAYJOINREORDER.varname,
-    ConfVars.OUTPUT_FILE_EXTENSION.varname,
-    ConfVars.SHOW_JOB_FAIL_DEBUG_INFO.varname,
-    ConfVars.TASKLOG_DEBUG_TIMEOUT.varname,
-  };
-
-  /**
-   * Default list of regexes for config parameters that are modifiable with
-   * sql standard authorization enabled
-   */
-  static final String [] sqlStdAuthSafeVarNameRegexes = new String [] {
-    "hive\\.auto\\..*",
-    "hive\\.cbo\\..*",
-    "hive\\.convert\\..*",
-    "hive\\.exec\\.dynamic\\.partition.*",
-    "hive\\.exec\\..*\\.dynamic\\.partitions\\..*",
-    "hive\\.exec\\.compress\\..*",
-    "hive\\.exec\\.infer\\..*",
-    "hive\\.exec\\.mode.local\\..*",
-    "hive\\.exec\\.orc\\..*",
-    "hive\\.exec\\.parallel.*",
-    "hive\\.explain\\..*",
-    "hive\\.fetch.task\\..*",
-    "hive\\.groupby\\..*",
-    "hive\\.hbase\\..*",
-    "hive\\.index\\..*",
-    "hive\\.index\\..*",
-    "hive\\.intermediate\\..*",
-    "hive\\.join\\..*",
-    "hive\\.limit\\..*",
-    "hive\\.log\\..*",
-    "hive\\.mapjoin\\..*",
-    "hive\\.merge\\..*",
-    "hive\\.optimize\\..*",
-    "hive\\.orc\\..*",
-    "hive\\.outerjoin\\..*",
-    "hive\\.parquet\\..*",
-    "hive\\.ppd\\..*",
-    "hive\\.prewarm\\..*",
-    "hive\\.server2\\.proxy\\.user",
-    "hive\\.skewjoin\\..*",
-    "hive\\.smbjoin\\..*",
-    "hive\\.stats\\..*",
-    "hive\\.tez\\..*",
-    "hive\\.vectorized\\..*",
-    "mapred\\.map\\..*",
-    "mapred\\.reduce\\..*",
-    "mapred\\.output\\.compression\\.codec",
-    "mapred\\.job\\.queuename",
-    "mapred\\.output\\.compression\\.type",
-    "mapred\\.min\\.split\\.size",
-    "mapreduce\\.job\\.reduce\\.slowstart\\.completedmaps",
-    "mapreduce\\.job\\.queuename",
-    "mapreduce\\.job\\.tags",
-    "mapreduce\\.input\\.fileinputformat\\.split\\.minsize",
-    "mapreduce\\.map\\..*",
-    "mapreduce\\.reduce\\..*",
-    "mapreduce\\.output\\.fileoutputformat\\.compress\\.codec",
-    "mapreduce\\.output\\.fileoutputformat\\.compress\\.type",
-    "tez\\.am\\..*",
-    "tez\\.task\\..*",
-    "tez\\.runtime\\..*",
-    "tez.queue.name",
-
-  };
-
-
-
-  /**
-   * Apply system properties to this object if the property name is defined in ConfVars
-   * and the value is non-null and not an empty string.
-   */
-  private void applySystemProperties() {
-    Map<String, String> systemProperties = getConfSystemProperties();
-    for (Entry<String, String> systemProperty : systemProperties.entrySet()) {
-      this.set(systemProperty.getKey(), systemProperty.getValue());
-    }
-  }
-
-  /**
-   * This method returns a mapping from config variable name to its value for all config variables
-   * which have been set using System properties
-   */
-  public static Map<String, String> getConfSystemProperties() {
-    Map<String, String> systemProperties = new HashMap<String, String>();
-
-    for (ConfVars oneVar : ConfVars.values()) {
-      if (System.getProperty(oneVar.varname) != null) {
-        if (System.getProperty(oneVar.varname).length() > 0) {
-          systemProperties.put(oneVar.varname, System.getProperty(oneVar.varname));
+        ConfVars(String varname, Object defaultVal, String description, boolean excluded) {
+            this(varname, defaultVal, null, description, true, excluded);
         }
-      }
+
+        ConfVars(String varname, String defaultVal, boolean caseSensitive, String description) {
+            this(varname, defaultVal, null, description, caseSensitive, false);
+        }
+
+        ConfVars(String varname, Object defaultVal, Validator validator, String description) {
+            this(varname, defaultVal, validator, description, true, false);
+        }
+
+        ConfVars(String varname, Object defaultVal, Validator validator, String description, boolean caseSensitive, boolean excluded) {
+            this.varname = varname;
+            this.validator = validator;
+            this.description = description;
+            this.defaultExpr = defaultVal == null ? null : String.valueOf(defaultVal);
+            this.excluded = excluded;
+            this.caseSensitive = caseSensitive;
+            if (defaultVal == null || defaultVal instanceof String) {
+                this.valClass = String.class;
+                this.valType = VarType.STRING;
+                this.defaultStrVal = SystemVariables.substitute((String) defaultVal);
+                this.defaultIntVal = -1;
+                this.defaultLongVal = -1;
+                this.defaultFloatVal = -1;
+                this.defaultBoolVal = false;
+            } else if (defaultVal instanceof Integer) {
+                this.valClass = Integer.class;
+                this.valType = VarType.INT;
+                this.defaultStrVal = null;
+                this.defaultIntVal = (Integer) defaultVal;
+                this.defaultLongVal = -1;
+                this.defaultFloatVal = -1;
+                this.defaultBoolVal = false;
+            } else if (defaultVal instanceof Long) {
+                this.valClass = Long.class;
+                this.valType = VarType.LONG;
+                this.defaultStrVal = null;
+                this.defaultIntVal = -1;
+                this.defaultLongVal = (Long) defaultVal;
+                this.defaultFloatVal = -1;
+                this.defaultBoolVal = false;
+            } else if (defaultVal instanceof Float) {
+                this.valClass = Float.class;
+                this.valType = VarType.FLOAT;
+                this.defaultStrVal = null;
+                this.defaultIntVal = -1;
+                this.defaultLongVal = -1;
+                this.defaultFloatVal = (Float) defaultVal;
+                this.defaultBoolVal = false;
+            } else if (defaultVal instanceof Boolean) {
+                this.valClass = Boolean.class;
+                this.valType = VarType.BOOLEAN;
+                this.defaultStrVal = null;
+                this.defaultIntVal = -1;
+                this.defaultLongVal = -1;
+                this.defaultFloatVal = -1;
+                this.defaultBoolVal = (Boolean) defaultVal;
+            } else {
+                throw new IllegalArgumentException("Not supported type value " + defaultVal.getClass() +
+                        " for name " + varname);
+            }
+        }
+
+        public boolean isType(String value) {
+            return valType.isType(value);
+        }
+
+        public Validator getValidator() {
+            return validator;
+        }
+
+        public String validate(String value) {
+            return validator == null ? null : validator.validate(value);
+        }
+
+        public String validatorDescription() {
+            return validator == null ? null : validator.toDescription();
+        }
+
+        public String typeString() {
+            String type = valType.typeString();
+            if (valType == VarType.STRING && validator != null) {
+                if (validator instanceof TimeValidator) {
+                    type += "(TIME)";
+                }
+            }
+            return type;
+        }
+
+        public String getRawDescription() {
+            return description;
+        }
+
+        public String getDescription() {
+            String validator = validatorDescription();
+            if (validator != null) {
+                return validator + ".\n" + description;
+            }
+            return description;
+        }
+
+        public boolean isExcluded() {
+            return excluded;
+        }
+
+        public boolean isCaseSensitive() {
+            return caseSensitive;
+        }
+
+        @Override
+        public String toString() {
+            return varname;
+        }
+
+        private static String findHadoopBinary() {
+            String val = System.getenv("HADOOP_HOME");
+            // In Hadoop 1.X and Hadoop 2.X HADOOP_HOME is gone and replaced with HADOOP_PREFIX
+            if (val == null) {
+                val = System.getenv("HADOOP_PREFIX");
+            }
+            // and if all else fails we can at least try /usr/bin/hadoop
+            val = (val == null ? File.separator + "usr" : val)
+                    + File.separator + "bin" + File.separator + "hadoop";
+            // Launch hadoop command file on windows.
+            return val + (Shell.WINDOWS ? ".cmd" : "");
+        }
+
+        public String getDefaultValue() {
+            return valType.defaultValueString(this);
+        }
+
+        public String getDefaultExpr() {
+            return defaultExpr;
+        }
+
+        enum VarType {
+            STRING {
+                @Override
+                void checkType(String value) throws Exception {
+                }
+
+                @Override
+                String defaultValueString(ConfVars confVar) {
+                    return confVar.defaultStrVal;
+                }
+            },
+            INT {
+                @Override
+                void checkType(String value) throws Exception {
+                    Integer.valueOf(value);
+                }
+            },
+            LONG {
+                @Override
+                void checkType(String value) throws Exception {
+                    Long.valueOf(value);
+                }
+            },
+            FLOAT {
+                @Override
+                void checkType(String value) throws Exception {
+                    Float.valueOf(value);
+                }
+            },
+            BOOLEAN {
+                @Override
+                void checkType(String value) throws Exception {
+                    Boolean.valueOf(value);
+                }
+            };
+
+            boolean isType(String value) {
+                try {
+                    checkType(value);
+                } catch (Exception e) {
+                    return false;
+                }
+                return true;
+            }
+
+            String typeString() {
+                return name().toUpperCase();
+            }
+
+            String defaultValueString(ConfVars confVar) {
+                return confVar.defaultExpr;
+            }
+
+            abstract void checkType(String value) throws Exception;
+        }
     }
 
-    return systemProperties;
-  }
+    /**
+     * Writes the default ConfVars out to a byte array and returns an input
+     * stream wrapping that byte array.
+     *
+     * We need this in order to initialize the ConfVar properties
+     * in the underling Configuration object using the addResource(InputStream)
+     * method.
+     *
+     * It is important to use a LoopingByteArrayInputStream because it turns out
+     * addResource(InputStream) is broken since Configuration tries to read the
+     * entire contents of the same InputStream repeatedly without resetting it.
+     * LoopingByteArrayInputStream has special logic to handle this.
+     */
+    private static synchronized InputStream getConfVarInputStream() {
+        if (confVarByteArray == null) {
+            try {
+                // Create a Hadoop configuration without inheriting default settings.
+                Configuration conf = new Configuration(false);
 
-  /**
-   * Overlays ConfVar properties with non-null values
-   */
-  private static void applyDefaultNonNullConfVars(Configuration conf) {
-    for (ConfVars var : ConfVars.values()) {
-      String defaultValue = var.getDefaultValue();
-      if (defaultValue == null) {
-        // Don't override ConfVars with null values
-        continue;
-      }
-      conf.set(var.varname, defaultValue);
+                applyDefaultNonNullConfVars(conf);
+
+                ByteArrayOutputStream confVarBaos = new ByteArrayOutputStream();
+                conf.writeXml(confVarBaos);
+                confVarByteArray = confVarBaos.toByteArray();
+            } catch (Exception e) {
+                // We're pretty screwed if we can't load the default conf vars
+                throw new RuntimeException("Failed to initialize default Hive configuration variables!", e);
+            }
+        }
+        return new LoopingByteArrayInputStream(confVarByteArray);
     }
-  }
 
-  public Properties getChangedProperties() {
-    Properties ret = new Properties();
-    Properties newProp = getAllProperties();
-
-    for (Object one : newProp.keySet()) {
-      String oneProp = (String) one;
-      String oldValue = origProp.getProperty(oneProp);
-      if (!StringUtils.equals(oldValue, newProp.getProperty(oneProp))) {
-        ret.setProperty(oneProp, newProp.getProperty(oneProp));
-      }
+    public void verifyAndSet(String name, String value) throws IllegalArgumentException {
+        if (modWhiteListPattern != null) {
+            Matcher wlMatcher = modWhiteListPattern.matcher(name);
+            if (!wlMatcher.matches()) {
+                throw new IllegalArgumentException("Cannot modify " + name + " at runtime. "
+                        + "It is not in list of params that are allowed to be modified at runtime");
+            }
+        }
+        if (restrictList.contains(name)) {
+            throw new IllegalArgumentException("Cannot modify " + name + " at runtime. It is in the list"
+                    + "of parameters that can't be modified at runtime");
+        }
+        isSparkConfigUpdated = isSparkRelatedConfig(name);
+        set(name, value);
     }
-    return (ret);
-  }
 
-  public String getJar() {
-    return hiveJar;
-  }
+    /**
+     * check whether spark related property is updated, which includes spark configurations,
+     * RSC configurations and yarn configuration in Spark on YARN mode.
+     * @param name
+     * @return
+     */
+    private boolean isSparkRelatedConfig(String name) {
+        boolean result = false;
+        if (name.startsWith("spark")) { // Spark property.
+            result = true;
+        } else if (name.startsWith("yarn")) { // YARN property in Spark on YARN mode.
+            String sparkMaster = get("spark.master");
+            if (sparkMaster != null &&
+                    (sparkMaster.equals("yarn-client") || sparkMaster.equals("yarn-cluster"))) {
+                result = true;
+            }
+        } else if (name.startsWith("hive.spark")) { // Remote Spark Context property.
+            result = true;
+        }
 
-  /**
-   * @return the auxJars
-   */
-  public String getAuxJars() {
-    return auxJars;
-  }
-
-  /**
-   * @param auxJars the auxJars to set
-   */
-  public void setAuxJars(String auxJars) {
-    this.auxJars = auxJars;
-    setVar(this, ConfVars.HIVEAUXJARS, auxJars);
-  }
-
-  public URL getHiveDefaultLocation() {
-    return hiveDefaultURL;
-  }
-
-  public static void setHiveSiteLocation(URL location) {
-    hiveSiteURL = location;
-  }
-
-  public static URL getHiveSiteLocation() {
-    return hiveSiteURL;
-  }
-
-  public static URL getMetastoreSiteLocation() {
-    return hivemetastoreSiteUrl;
-  }
-
-  public static URL getHiveServer2SiteLocation() {
-    return hiveServer2SiteUrl;
-  }
-
-  /**
-   * @return the user name set in hadoop.job.ugi param or the current user from System
-   * @throws IOException
-   */
-  public String getUser() throws IOException {
-    try {
-      UserGroupInformation ugi = Utils.getUGI();
-      return ugi.getUserName();
-    } catch (LoginException le) {
-      throw new IOException(le);
+        return result;
     }
-  }
 
-  public static String getColumnInternalName(int pos) {
-    return "_col" + pos;
-  }
-
-  public static int getPositionFromInternalName(String internalName) {
-    Pattern internalPattern = Pattern.compile("_col([0-9]+)");
-    Matcher m = internalPattern.matcher(internalName);
-    if (!m.matches()){
-      return -1;
-    } else {
-      return Integer.parseInt(m.group(1));
+    public static int getIntVar(Configuration conf, ConfVars var) {
+        assert (var.valClass == Integer.class) : var.varname;
+        return conf.getInt(var.varname, var.defaultIntVal);
     }
-  }
 
-  /**
-   * Append comma separated list of config vars to the restrict List
-   * @param restrictListStr
-   */
-  public void addToRestrictList(String restrictListStr) {
-    if (restrictListStr == null) {
-      return;
+    public static void setIntVar(Configuration conf, ConfVars var, int val) {
+        assert (var.valClass == Integer.class) : var.varname;
+        conf.setInt(var.varname, val);
     }
-    String oldList = this.getVar(ConfVars.HIVE_CONF_RESTRICTED_LIST);
-    if (oldList == null || oldList.isEmpty()) {
-      this.setVar(ConfVars.HIVE_CONF_RESTRICTED_LIST, restrictListStr);
-    } else {
-      this.setVar(ConfVars.HIVE_CONF_RESTRICTED_LIST, oldList + "," + restrictListStr);
+
+    public int getIntVar(ConfVars var) {
+        return getIntVar(this, var);
     }
-    setupRestrictList();
-  }
 
-  /**
-   * Set white list of parameters that are allowed to be modified
-   *
-   * @param paramNameRegex
-   */
-  @LimitedPrivate(value = { "Currently only for use by HiveAuthorizer" })
-  public void setModifiableWhiteListRegex(String paramNameRegex) {
-    if (paramNameRegex == null) {
-      return;
+    public void setIntVar(ConfVars var, int val) {
+        setIntVar(this, var, val);
     }
-    modWhiteListPattern = Pattern.compile(paramNameRegex);
-  }
 
-  /**
-   * Add the HIVE_CONF_RESTRICTED_LIST values to restrictList,
-   * including HIVE_CONF_RESTRICTED_LIST itself
-   */
-  private void setupRestrictList() {
-    String restrictListStr = this.getVar(ConfVars.HIVE_CONF_RESTRICTED_LIST);
-    restrictList.clear();
-    if (restrictListStr != null) {
-      for (String entry : restrictListStr.split(",")) {
-        restrictList.add(entry.trim());
-      }
+    public static long getTimeVar(Configuration conf, ConfVars var, TimeUnit outUnit) {
+        return toTime(getVar(conf, var), getDefaultTimeUnit(var), outUnit);
     }
-    restrictList.add(ConfVars.HIVE_IN_TEST.varname);
-    restrictList.add(ConfVars.HIVE_CONF_RESTRICTED_LIST.varname);
-  }
 
-  public static boolean isLoadMetastoreConfig() {
-    return loadMetastoreConfig;
-  }
+    public static void setTimeVar(Configuration conf, ConfVars var, long time, TimeUnit timeunit) {
+        assert (var.valClass == String.class) : var.varname;
+        conf.set(var.varname, time + stringFor(timeunit));
+    }
 
-  public static void setLoadMetastoreConfig(boolean loadMetastoreConfig) {
-    HiveConf.loadMetastoreConfig = loadMetastoreConfig;
-  }
+    public long getTimeVar(ConfVars var, TimeUnit outUnit) {
+        return getTimeVar(this, var, outUnit);
+    }
 
-  public static boolean isLoadHiveServer2Config() {
-    return loadHiveServer2Config;
-  }
+    public void setTimeVar(ConfVars var, long time, TimeUnit outUnit) {
+        setTimeVar(this, var, time, outUnit);
+    }
 
-  public static void setLoadHiveServer2Config(boolean loadHiveServer2Config) {
-    HiveConf.loadHiveServer2Config = loadHiveServer2Config;
-  }
+    private static TimeUnit getDefaultTimeUnit(ConfVars var) {
+        TimeUnit inputUnit = null;
+        if (var.validator instanceof TimeValidator) {
+            inputUnit = ((TimeValidator) var.validator).getTimeUnit();
+        }
+        return inputUnit;
+    }
+
+    public static long toTime(String value, TimeUnit inputUnit, TimeUnit outUnit) {
+        String[] parsed = parseTime(value.trim());
+        return outUnit.convert(Long.valueOf(parsed[0].trim().trim()), unitFor(parsed[1].trim(), inputUnit));
+    }
+
+    private static String[] parseTime(String value) {
+        char[] chars = value.toCharArray();
+        int i = 0;
+        for (; i < chars.length && (chars[i] == '-' || Character.isDigit(chars[i])); i++) {
+        }
+        return new String[]{value.substring(0, i), value.substring(i)};
+    }
+
+    public static TimeUnit unitFor(String unit, TimeUnit defaultUnit) {
+        unit = unit.trim().toLowerCase();
+        if (unit.isEmpty() || unit.equals("l")) {
+            if (defaultUnit == null) {
+                throw new IllegalArgumentException("Time unit is not specified");
+            }
+            return defaultUnit;
+        } else if (unit.equals("d") || unit.startsWith("day")) {
+            return TimeUnit.DAYS;
+        } else if (unit.equals("h") || unit.startsWith("hour")) {
+            return TimeUnit.HOURS;
+        } else if (unit.equals("m") || unit.startsWith("min")) {
+            return TimeUnit.MINUTES;
+        } else if (unit.equals("s") || unit.startsWith("sec")) {
+            return TimeUnit.SECONDS;
+        } else if (unit.equals("ms") || unit.startsWith("msec")) {
+            return TimeUnit.MILLISECONDS;
+        } else if (unit.equals("us") || unit.startsWith("usec")) {
+            return TimeUnit.MICROSECONDS;
+        } else if (unit.equals("ns") || unit.startsWith("nsec")) {
+            return TimeUnit.NANOSECONDS;
+        }
+        throw new IllegalArgumentException("Invalid time unit " + unit);
+    }
+
+    public static String stringFor(TimeUnit timeunit) {
+        switch (timeunit) {
+            case DAYS:
+                return "day";
+            case HOURS:
+                return "hour";
+            case MINUTES:
+                return "min";
+            case SECONDS:
+                return "sec";
+            case MILLISECONDS:
+                return "msec";
+            case MICROSECONDS:
+                return "usec";
+            case NANOSECONDS:
+                return "nsec";
+        }
+        throw new IllegalArgumentException("Invalid timeunit " + timeunit);
+    }
+
+    public static long getLongVar(Configuration conf, ConfVars var) {
+        assert (var.valClass == Long.class) : var.varname;
+        return conf.getLong(var.varname, var.defaultLongVal);
+    }
+
+    public static long getLongVar(Configuration conf, ConfVars var, long defaultVal) {
+        return conf.getLong(var.varname, defaultVal);
+    }
+
+    public static void setLongVar(Configuration conf, ConfVars var, long val) {
+        assert (var.valClass == Long.class) : var.varname;
+        conf.setLong(var.varname, val);
+    }
+
+    public long getLongVar(ConfVars var) {
+        return getLongVar(this, var);
+    }
+
+    public void setLongVar(ConfVars var, long val) {
+        setLongVar(this, var, val);
+    }
+
+    public static float getFloatVar(Configuration conf, ConfVars var) {
+        assert (var.valClass == Float.class) : var.varname;
+        return conf.getFloat(var.varname, var.defaultFloatVal);
+    }
+
+    public static float getFloatVar(Configuration conf, ConfVars var, float defaultVal) {
+        return conf.getFloat(var.varname, defaultVal);
+    }
+
+    public static void setFloatVar(Configuration conf, ConfVars var, float val) {
+        assert (var.valClass == Float.class) : var.varname;
+        conf.setFloat(var.varname, val);
+    }
+
+    public float getFloatVar(ConfVars var) {
+        return getFloatVar(this, var);
+    }
+
+    public void setFloatVar(ConfVars var, float val) {
+        setFloatVar(this, var, val);
+    }
+
+    public static boolean getBoolVar(Configuration conf, ConfVars var) {
+        assert (var.valClass == Boolean.class) : var.varname;
+        return conf.getBoolean(var.varname, var.defaultBoolVal);
+    }
+
+    public static boolean getBoolVar(Configuration conf, ConfVars var, boolean defaultVal) {
+        return conf.getBoolean(var.varname, defaultVal);
+    }
+
+    public static void setBoolVar(Configuration conf, ConfVars var, boolean val) {
+        assert (var.valClass == Boolean.class) : var.varname;
+        conf.setBoolean(var.varname, val);
+    }
+
+    public boolean getBoolVar(ConfVars var) {
+        return getBoolVar(this, var);
+    }
+
+    public void setBoolVar(ConfVars var, boolean val) {
+        setBoolVar(this, var, val);
+    }
+
+    public static String getVar(Configuration conf, ConfVars var) {
+        assert (var.valClass == String.class) : var.varname;
+        return conf.get(var.varname, var.defaultStrVal);
+    }
+
+    public static String getVar(Configuration conf, ConfVars var, String defaultVal) {
+        return conf.get(var.varname, defaultVal);
+    }
+
+    public static void setVar(Configuration conf, ConfVars var, String val) {
+        assert (var.valClass == String.class) : var.varname;
+        conf.set(var.varname, val);
+    }
+
+    public static ConfVars getConfVars(String name) {
+        return vars.get(name);
+    }
+
+    public static ConfVars getMetaConf(String name) {
+        return metaConfs.get(name);
+    }
+
+    public String getVar(ConfVars var) {
+        return getVar(this, var);
+    }
+
+    public void setVar(ConfVars var, String val) {
+        setVar(this, var, val);
+    }
+
+    public void logVars(PrintStream ps) {
+        for (ConfVars one : ConfVars.values()) {
+            ps.println(one.varname + "=" + ((get(one.varname) != null) ? get(one.varname) : ""));
+        }
+    }
+
+    public HiveConf() {
+        super();
+        initialize(this.getClass());
+    }
+
+    public HiveConf(Class<?> cls) {
+        super();
+        initialize(cls);
+    }
+
+    public HiveConf(Configuration other, Class<?> cls) {
+        super(other);
+        initialize(cls);
+    }
+
+    /**
+     * Copy constructor
+     */
+    public HiveConf(HiveConf other) {
+        super(other);
+        hiveJar = other.hiveJar;
+        auxJars = other.auxJars;
+        origProp = (Properties) other.origProp.clone();
+        restrictList.addAll(other.restrictList);
+        modWhiteListPattern = other.modWhiteListPattern;
+    }
+
+    public Properties getAllProperties() {
+        return getProperties(this);
+    }
+
+    private static Properties getProperties(Configuration conf) {
+        Iterator<Map.Entry<String, String>> iter = conf.iterator();
+        Properties p = new Properties();
+        while (iter.hasNext()) {
+            Map.Entry<String, String> e = iter.next();
+            p.setProperty(e.getKey(), e.getValue());
+        }
+        return p;
+    }
+
+    private void initialize(Class<?> cls) {
+        hiveJar = (new JobConf(cls)).getJar();
+
+        // preserve the original configuration
+        origProp = getAllProperties();
+
+        // Overlay the ConfVars. Note that this ignores ConfVars with null values
+        addResource(getConfVarInputStream());
+
+        // Overlay hive-site.xml if it exists
+        if (hiveSiteURL != null) {
+            addResource(hiveSiteURL);
+        }
+
+        // if embedded metastore is to be used as per config so far
+        // then this is considered like the metastore server case
+        String msUri = this.getVar(HiveConf.ConfVars.METASTOREURIS);
+        if (HiveConfUtil.isEmbeddedMetaStore(msUri)) {
+            setLoadMetastoreConfig(true);
+        }
+
+        // load hivemetastore-site.xml if this is metastore and file exists
+        if (isLoadMetastoreConfig() && hivemetastoreSiteUrl != null) {
+            addResource(hivemetastoreSiteUrl);
+        }
+
+        // load hiveserver2-site.xml if this is hiveserver2 and file exists
+        // metastore can be embedded within hiveserver2, in such cases
+        // the conf params in hiveserver2-site.xml will override whats defined
+        // in hivemetastore-site.xml
+        if (isLoadHiveServer2Config() && hiveServer2SiteUrl != null) {
+            addResource(hiveServer2SiteUrl);
+        }
+
+        // Overlay the values of any system properties whose names appear in the list of ConfVars
+        applySystemProperties();
+
+        if ((this.get("hive.metastore.ds.retry.attempts") != null) ||
+                this.get("hive.metastore.ds.retry.interval") != null) {
+            l4j.warn("DEPRECATED: hive.metastore.ds.retry.* no longer has any effect.  " +
+                    "Use hive.hmshandler.retry.* instead");
+        }
+
+        // if the running class was loaded directly (through eclipse) rather than through a
+        // jar then this would be needed
+        if (hiveJar == null) {
+            hiveJar = this.get(ConfVars.HIVEJAR.varname);
+        }
+
+        if (auxJars == null) {
+            auxJars = this.get(ConfVars.HIVEAUXJARS.varname);
+        }
+
+        if (getBoolVar(ConfVars.METASTORE_SCHEMA_VERIFICATION)) {
+            setBoolVar(ConfVars.METASTORE_AUTO_CREATE_SCHEMA, false);
+            setBoolVar(ConfVars.METASTORE_FIXED_DATASTORE, true);
+        }
+
+        if (getBoolVar(HiveConf.ConfVars.HIVECONFVALIDATION)) {
+            List<String> trimmed = new ArrayList<String>();
+            for (Map.Entry<String, String> entry : this) {
+                String key = entry.getKey();
+                if (key == null || !key.startsWith("hive.")) {
+                    continue;
+                }
+                ConfVars var = HiveConf.getConfVars(key);
+                if (var == null) {
+                    var = HiveConf.getConfVars(key.trim());
+                    if (var != null) {
+                        trimmed.add(key);
+                    }
+                }
+                if (var == null) {
+                    l4j.warn("HiveConf of name " + key + " does not exist");
+                } else if (!var.isType(entry.getValue())) {
+                    l4j.warn("HiveConf " + var.varname + " expects " + var.typeString() + " type value");
+                }
+            }
+            for (String key : trimmed) {
+                set(key.trim(), getRaw(key));
+                unset(key);
+            }
+        }
+
+        setupSQLStdAuthWhiteList();
+
+        // setup list of conf vars that are not allowed to change runtime
+        setupRestrictList();
+
+    }
+
+    /**
+     * If the config whitelist param for sql standard authorization is not set, set it up here.
+     */
+    private void setupSQLStdAuthWhiteList() {
+        String whiteListParamsStr = getVar(ConfVars.HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST);
+        if (whiteListParamsStr == null || whiteListParamsStr.trim().isEmpty()) {
+            // set the default configs in whitelist
+            whiteListParamsStr = getSQLStdAuthDefaultWhiteListPattern();
+        }
+        setVar(ConfVars.HIVE_AUTHORIZATION_SQL_STD_AUTH_CONFIG_WHITELIST, whiteListParamsStr);
+    }
+
+    private static String getSQLStdAuthDefaultWhiteListPattern() {
+        // create the default white list from list of safe config params
+        // and regex list
+        String confVarPatternStr = Joiner.on("|").join(convertVarsToRegex(sqlStdAuthSafeVarNames));
+        String regexPatternStr = Joiner.on("|").join(sqlStdAuthSafeVarNameRegexes);
+        return regexPatternStr + "|" + confVarPatternStr;
+    }
+
+    /**
+     * @param paramList  list of parameter strings
+     * @return list of parameter strings with "." replaced by "\."
+     */
+    private static String[] convertVarsToRegex(String[] paramList) {
+        String[] regexes = new String[paramList.length];
+        for (int i = 0; i < paramList.length; i++) {
+            regexes[i] = paramList[i].replace(".", "\\.");
+        }
+        return regexes;
+    }
+
+    /**
+     * Default list of modifiable config parameters for sql standard authorization
+     * For internal use only.
+     */
+    private static final String[] sqlStdAuthSafeVarNames = new String[]{
+            ConfVars.BYTESPERREDUCER.varname,
+            ConfVars.CLIENT_STATS_COUNTERS.varname,
+            ConfVars.DEFAULTPARTITIONNAME.varname,
+            ConfVars.DROPIGNORESNONEXISTENT.varname,
+            ConfVars.HIVECOUNTERGROUP.varname,
+            ConfVars.HIVEDEFAULTMANAGEDFILEFORMAT.varname,
+            ConfVars.HIVEENFORCEBUCKETING.varname,
+            ConfVars.HIVEENFORCEBUCKETMAPJOIN.varname,
+            ConfVars.HIVEENFORCESORTING.varname,
+            ConfVars.HIVEENFORCESORTMERGEBUCKETMAPJOIN.varname,
+            ConfVars.HIVEEXPREVALUATIONCACHE.varname,
+            ConfVars.HIVEHASHTABLELOADFACTOR.varname,
+            ConfVars.HIVEHASHTABLETHRESHOLD.varname,
+            ConfVars.HIVEIGNOREMAPJOINHINT.varname,
+            ConfVars.HIVELIMITMAXROWSIZE.varname,
+            ConfVars.HIVEMAPREDMODE.varname,
+            ConfVars.HIVEMAPSIDEAGGREGATE.varname,
+            ConfVars.HIVEOPTIMIZEMETADATAQUERIES.varname,
+            ConfVars.HIVEROWOFFSET.varname,
+            ConfVars.HIVEVARIABLESUBSTITUTE.varname,
+            ConfVars.HIVEVARIABLESUBSTITUTEDEPTH.varname,
+            ConfVars.HIVE_AUTOGEN_COLUMNALIAS_PREFIX_INCLUDEFUNCNAME.varname,
+            ConfVars.HIVE_AUTOGEN_COLUMNALIAS_PREFIX_LABEL.varname,
+            ConfVars.HIVE_CHECK_CROSS_PRODUCT.varname,
+            ConfVars.HIVE_COMPAT.varname,
+            ConfVars.HIVE_CONCATENATE_CHECK_INDEX.varname,
+            ConfVars.HIVE_DISPLAY_PARTITION_COLUMNS_SEPARATELY.varname,
+            ConfVars.HIVE_ERROR_ON_EMPTY_PARTITION.varname,
+            ConfVars.HIVE_EXECUTION_ENGINE.varname,
+            ConfVars.HIVE_EXIM_URI_SCHEME_WL.varname,
+            ConfVars.HIVE_FILE_MAX_FOOTER.varname,
+            ConfVars.HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES.varname,
+            ConfVars.HIVE_INSERT_INTO_MULTILEVEL_DIRS.varname,
+            ConfVars.HIVE_LOCALIZE_RESOURCE_NUM_WAIT_ATTEMPTS.varname,
+            ConfVars.HIVE_MULTI_INSERT_MOVE_TASKS_SHARE_DEPENDENCIES.varname,
+            ConfVars.HIVE_QUOTEDID_SUPPORT.varname,
+            ConfVars.HIVE_RESULTSET_USE_UNIQUE_COLUMN_NAMES.varname,
+            ConfVars.HIVE_STATS_COLLECT_PART_LEVEL_STATS.varname,
+            ConfVars.HIVE_SERVER2_LOGGING_OPERATION_LEVEL.varname,
+            ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS.varname,
+            ConfVars.JOB_DEBUG_CAPTURE_STACKTRACES.varname,
+            ConfVars.JOB_DEBUG_TIMEOUT.varname,
+            ConfVars.MAXCREATEDFILES.varname,
+            ConfVars.MAXREDUCERS.varname,
+            ConfVars.NWAYJOINREORDER.varname,
+            ConfVars.OUTPUT_FILE_EXTENSION.varname,
+            ConfVars.SHOW_JOB_FAIL_DEBUG_INFO.varname,
+            ConfVars.TASKLOG_DEBUG_TIMEOUT.varname,
+    };
+
+    /**
+     * Default list of regexes for config parameters that are modifiable with
+     * sql standard authorization enabled
+     */
+    static final String[] sqlStdAuthSafeVarNameRegexes = new String[]{
+            "hive\\.auto\\..*",
+            "hive\\.cbo\\..*",
+            "hive\\.convert\\..*",
+            "hive\\.exec\\.dynamic\\.partition.*",
+            "hive\\.exec\\..*\\.dynamic\\.partitions\\..*",
+            "hive\\.exec\\.compress\\..*",
+            "hive\\.exec\\.infer\\..*",
+            "hive\\.exec\\.mode.local\\..*",
+            "hive\\.exec\\.orc\\..*",
+            "hive\\.exec\\.parallel.*",
+            "hive\\.explain\\..*",
+            "hive\\.fetch.task\\..*",
+            "hive\\.groupby\\..*",
+            "hive\\.hbase\\..*",
+            "hive\\.index\\..*",
+            "hive\\.index\\..*",
+            "hive\\.intermediate\\..*",
+            "hive\\.join\\..*",
+            "hive\\.limit\\..*",
+            "hive\\.log\\..*",
+            "hive\\.mapjoin\\..*",
+            "hive\\.merge\\..*",
+            "hive\\.optimize\\..*",
+            "hive\\.orc\\..*",
+            "hive\\.outerjoin\\..*",
+            "hive\\.parquet\\..*",
+            "hive\\.ppd\\..*",
+            "hive\\.prewarm\\..*",
+            "hive\\.server2\\.proxy\\.user",
+            "hive\\.skewjoin\\..*",
+            "hive\\.smbjoin\\..*",
+            "hive\\.stats\\..*",
+            "hive\\.tez\\..*",
+            "hive\\.vectorized\\..*",
+            "mapred\\.map\\..*",
+            "mapred\\.reduce\\..*",
+            "mapred\\.output\\.compression\\.codec",
+            "mapred\\.job\\.queuename",
+            "mapred\\.output\\.compression\\.type",
+            "mapred\\.min\\.split\\.size",
+            "mapreduce\\.job\\.reduce\\.slowstart\\.completedmaps",
+            "mapreduce\\.job\\.queuename",
+            "mapreduce\\.job\\.tags",
+            "mapreduce\\.input\\.fileinputformat\\.split\\.minsize",
+            "mapreduce\\.map\\..*",
+            "mapreduce\\.reduce\\..*",
+            "mapreduce\\.output\\.fileoutputformat\\.compress\\.codec",
+            "mapreduce\\.output\\.fileoutputformat\\.compress\\.type",
+            "tez\\.am\\..*",
+            "tez\\.task\\..*",
+            "tez\\.runtime\\..*",
+            "tez.queue.name",
+
+    };
+
+
+    /**
+     * Apply system properties to this object if the property name is defined in ConfVars
+     * and the value is non-null and not an empty string.
+     */
+    private void applySystemProperties() {
+        Map<String, String> systemProperties = getConfSystemProperties();
+        for (Entry<String, String> systemProperty : systemProperties.entrySet()) {
+            this.set(systemProperty.getKey(), systemProperty.getValue());
+        }
+    }
+
+    /**
+     * This method returns a mapping from config variable name to its value for all config variables
+     * which have been set using System properties
+     */
+    public static Map<String, String> getConfSystemProperties() {
+        Map<String, String> systemProperties = new HashMap<String, String>();
+
+        for (ConfVars oneVar : ConfVars.values()) {
+            if (System.getProperty(oneVar.varname) != null) {
+                if (System.getProperty(oneVar.varname).length() > 0) {
+                    systemProperties.put(oneVar.varname, System.getProperty(oneVar.varname));
+                }
+            }
+        }
+
+        return systemProperties;
+    }
+
+    /**
+     * Overlays ConfVar properties with non-null values
+     */
+    private static void applyDefaultNonNullConfVars(Configuration conf) {
+        for (ConfVars var : ConfVars.values()) {
+            String defaultValue = var.getDefaultValue();
+            if (defaultValue == null) {
+                // Don't override ConfVars with null values
+                continue;
+            }
+            conf.set(var.varname, defaultValue);
+        }
+    }
+
+    public Properties getChangedProperties() {
+        Properties ret = new Properties();
+        Properties newProp = getAllProperties();
+
+        for (Object one : newProp.keySet()) {
+            String oneProp = (String) one;
+            String oldValue = origProp.getProperty(oneProp);
+            if (!StringUtils.equals(oldValue, newProp.getProperty(oneProp))) {
+                ret.setProperty(oneProp, newProp.getProperty(oneProp));
+            }
+        }
+        return (ret);
+    }
+
+    public String getJar() {
+        return hiveJar;
+    }
+
+    /**
+     * @return the auxJars
+     */
+    public String getAuxJars() {
+        return auxJars;
+    }
+
+    /**
+     * @param auxJars the auxJars to set
+     */
+    public void setAuxJars(String auxJars) {
+        this.auxJars = auxJars;
+        setVar(this, ConfVars.HIVEAUXJARS, auxJars);
+    }
+
+    public URL getHiveDefaultLocation() {
+        return hiveDefaultURL;
+    }
+
+    public static void setHiveSiteLocation(URL location) {
+        hiveSiteURL = location;
+    }
+
+    public static URL getHiveSiteLocation() {
+        return hiveSiteURL;
+    }
+
+    public static URL getMetastoreSiteLocation() {
+        return hivemetastoreSiteUrl;
+    }
+
+    public static URL getHiveServer2SiteLocation() {
+        return hiveServer2SiteUrl;
+    }
+
+    /**
+     * @return the user name set in hadoop.job.ugi param or the current user from System
+     * @throws IOException
+     */
+    public String getUser() throws IOException {
+        try {
+            UserGroupInformation ugi = Utils.getUGI();
+            return ugi.getUserName();
+        } catch (LoginException le) {
+            throw new IOException(le);
+        }
+    }
+
+    public static String getColumnInternalName(int pos) {
+        return "_col" + pos;
+    }
+
+    public static int getPositionFromInternalName(String internalName) {
+        Pattern internalPattern = Pattern.compile("_col([0-9]+)");
+        Matcher m = internalPattern.matcher(internalName);
+        if (!m.matches()) {
+            return -1;
+        } else {
+            return Integer.parseInt(m.group(1));
+        }
+    }
+
+    /**
+     * Append comma separated list of config vars to the restrict List
+     * @param restrictListStr
+     */
+    public void addToRestrictList(String restrictListStr) {
+        if (restrictListStr == null) {
+            return;
+        }
+        String oldList = this.getVar(ConfVars.HIVE_CONF_RESTRICTED_LIST);
+        if (oldList == null || oldList.isEmpty()) {
+            this.setVar(ConfVars.HIVE_CONF_RESTRICTED_LIST, restrictListStr);
+        } else {
+            this.setVar(ConfVars.HIVE_CONF_RESTRICTED_LIST, oldList + "," + restrictListStr);
+        }
+        setupRestrictList();
+    }
+
+    /**
+     * Set white list of parameters that are allowed to be modified
+     *
+     * @param paramNameRegex
+     */
+    @LimitedPrivate(value = {"Currently only for use by HiveAuthorizer"})
+    public void setModifiableWhiteListRegex(String paramNameRegex) {
+        if (paramNameRegex == null) {
+            return;
+        }
+        modWhiteListPattern = Pattern.compile(paramNameRegex);
+    }
+
+    /**
+     * Add the HIVE_CONF_RESTRICTED_LIST values to restrictList,
+     * including HIVE_CONF_RESTRICTED_LIST itself
+     */
+    private void setupRestrictList() {
+        String restrictListStr = this.getVar(ConfVars.HIVE_CONF_RESTRICTED_LIST);
+        restrictList.clear();
+        if (restrictListStr != null) {
+            for (String entry : restrictListStr.split(",")) {
+                restrictList.add(entry.trim());
+            }
+        }
+        restrictList.add(ConfVars.HIVE_IN_TEST.varname);
+        restrictList.add(ConfVars.HIVE_CONF_RESTRICTED_LIST.varname);
+    }
+
+    public static boolean isLoadMetastoreConfig() {
+        return loadMetastoreConfig;
+    }
+
+    public static void setLoadMetastoreConfig(boolean loadMetastoreConfig) {
+        HiveConf.loadMetastoreConfig = loadMetastoreConfig;
+    }
+
+    public static boolean isLoadHiveServer2Config() {
+        return loadHiveServer2Config;
+    }
+
+    public static void setLoadHiveServer2Config(boolean loadHiveServer2Config) {
+        HiveConf.loadHiveServer2Config = loadHiveServer2Config;
+    }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.*;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -128,7 +130,7 @@ import com.google.common.collect.Sets;
  * This class has functions that implement meta data/DDL operations using calls
  * to the metastore.
  * It has a metastore client instance it uses to communicate with the metastore.
- *
+ * <p>
  * It is a thread local variable, and the instances is accessed using static
  * get methods in this class.
  */
@@ -136,3163 +138,3154 @@ import com.google.common.collect.Sets;
 @SuppressWarnings({"deprecation", "rawtypes"})
 public class Hive {
 
-  static final private Log LOG = LogFactory.getLog("hive.ql.metadata.Hive");
+    static final private Log LOG = LogFactory.getLog("hive.ql.metadata.Hive");
 
-  private HiveConf conf = null;
-  private IMetaStoreClient metaStoreClient;
-  private UserGroupInformation owner;
+    private HiveConf conf = null;
+    private IMetaStoreClient metaStoreClient;
+    private UserGroupInformation owner;
 
-  // metastore calls timing information
-  private final Map<String, Long> metaCallTimeMap = new HashMap<String, Long>();
+    // metastore calls timing information
+    private final Map<String, Long> metaCallTimeMap = new HashMap<String, Long>();
 
-  private static ThreadLocal<Hive> hiveDB = new ThreadLocal<Hive>() {
-    @Override
-    protected synchronized Hive initialValue() {
-      return null;
-    }
-
-    @Override
-    public synchronized void remove() {
-      if (this.get() != null) {
-        this.get().close();
-      }
-      super.remove();
-    }
-  };
-
-  // register all permanent functions. need improvement
-  static {
-    try {
-      reloadFunctions();
-    } catch (Exception e) {
-      LOG.warn("Failed to access metastore. This class should not accessed in runtime.",e);
-    }
-  }
-
-  public static void reloadFunctions() throws HiveException {
-    Hive db = Hive.get();
-    for (String dbName : db.getAllDatabases()) {
-      for (String functionName : db.getFunctions(dbName, "*")) {
-        Function function = db.getFunction(dbName, functionName);
-        try {
-	  FunctionRegistry.registerPermanentFunction(
-	      FunctionUtils.qualifyFunctionName(functionName, dbName), function.getClassName(),
-	      false, FunctionTask.toFunctionResource(function.getResourceUris()));
-        } catch (Exception e) {
-          LOG.warn("Failed to register persistent function " +
-              functionName + ":" + function.getClassName() + ". Ignore and continue.");
-        }
-      }
-    }
-  }
-
-  public static Hive get(Configuration c, Class<?> clazz) throws HiveException {
-    return get(c instanceof HiveConf ? (HiveConf)c : new HiveConf(c, clazz));
-  }
-
-  /**
-   * Gets hive object for the current thread. If one is not initialized then a
-   * new one is created If the new configuration is different in metadata conf
-   * vars then a new one is created.
-   *
-   * @param c
-   *          new Hive Configuration
-   * @return Hive object for current thread
-   * @throws HiveException
-   *
-   */
-  public static Hive get(HiveConf c) throws HiveException {
-    Hive db = hiveDB.get();
-    if (db == null ||
-        (db.metaStoreClient != null && !db.metaStoreClient.isCompatibleWith(c))) {
-      return get(c, true);
-    }
-    db.conf = c;
-    return db;
-  }
-
-  /**
-   * get a connection to metastore. see get(HiveConf) function for comments
-   *
-   * @param c
-   *          new conf
-   * @param needsRefresh
-   *          if true then creates a new one
-   * @return The connection to the metastore
-   * @throws HiveException
-   */
-  public static Hive get(HiveConf c, boolean needsRefresh) throws HiveException {
-    Hive db = hiveDB.get();
-    if (db == null || needsRefresh || !db.isCurrentUserOwner()) {
-      if (db != null) {
-        LOG.debug("Creating new db. db = " + db + ", needsRefresh = " + needsRefresh +
-          ", db.isCurrentUserOwner = " + db.isCurrentUserOwner());
-      }
-      closeCurrent();
-      c.set("fs.scheme.class", "dfs");
-      Hive newdb = new Hive(c);
-      hiveDB.set(newdb);
-      return newdb;
-    }
-    db.conf = c;
-    return db;
-  }
-
-  public static Hive get() throws HiveException {
-    Hive db = hiveDB.get();
-    if (db != null && !db.isCurrentUserOwner()) {
-      LOG.debug("Creating new db. db.isCurrentUserOwner = " + db.isCurrentUserOwner());
-      db.close();
-      db = null;
-    }
-    if (db == null) {
-      SessionState session = SessionState.get();
-      db = new Hive(session == null ? new HiveConf(Hive.class) : session.getConf());
-      hiveDB.set(db);
-    }
-    return db;
-  }
-
-  public static void set(Hive hive) {
-    hiveDB.set(hive);
-  }
-
-  public static void closeCurrent() {
-    hiveDB.remove();
-  }
-
-  /**
-   * Hive
-   *
-   * @param c
-   *
-   */
-  private Hive(HiveConf c) throws HiveException {
-    conf = c;
-  }
-
-
-  private boolean isCurrentUserOwner() throws HiveException {
-    try {
-      return owner == null || owner.equals(UserGroupInformation.getCurrentUser());
-    } catch(IOException e) {
-      throw new HiveException("Error getting current user: " + e.getMessage(), e);
-    }
-  }
-
-
-
-  /**
-   * closes the connection to metastore for the calling thread
-   */
-  private void close() {
-    LOG.debug("Closing current thread's connection to Hive Metastore.");
-    if (metaStoreClient != null) {
-      metaStoreClient.close();
-      metaStoreClient = null;
-    }
-  }
-
-  /**
-   * Create a database
-   * @param db
-   * @param ifNotExist if true, will ignore AlreadyExistsException exception
-   * @throws AlreadyExistsException
-   * @throws HiveException
-   */
-  public void createDatabase(Database db, boolean ifNotExist)
-      throws AlreadyExistsException, HiveException {
-    try {
-      getMSC().createDatabase(db);
-    } catch (AlreadyExistsException e) {
-      if (!ifNotExist) {
-        throw e;
-      }
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Create a Database. Raise an error if a database with the same name already exists.
-   * @param db
-   * @throws AlreadyExistsException
-   * @throws HiveException
-   */
-  public void createDatabase(Database db) throws AlreadyExistsException, HiveException {
-    createDatabase(db, false);
-  }
-
-  /**
-   * Drop a database.
-   * @param name
-   * @throws NoSuchObjectException
-   * @throws HiveException
-   * @see org.apache.hadoop.hive.metastore.HiveMetaStoreClient#dropDatabase(java.lang.String)
-   */
-  public void dropDatabase(String name) throws HiveException, NoSuchObjectException {
-    dropDatabase(name, true, false, false);
-  }
-
-  /**
-   * Drop a database
-   * @param name
-   * @param deleteData
-   * @param ignoreUnknownDb if true, will ignore NoSuchObjectException
-   * @throws HiveException
-   * @throws NoSuchObjectException
-   */
-  public void dropDatabase(String name, boolean deleteData, boolean ignoreUnknownDb)
-      throws HiveException, NoSuchObjectException {
-    dropDatabase(name, deleteData, ignoreUnknownDb, false);
-  }
-
-  /**
-   * Drop a database
-   * @param name
-   * @param deleteData
-   * @param ignoreUnknownDb if true, will ignore NoSuchObjectException
-   * @param cascade         if true, delete all tables on the DB if exists. Otherwise, the query
-   *                        will fail if table still exists.
-   * @throws HiveException
-   * @throws NoSuchObjectException
-   */
-  public void dropDatabase(String name, boolean deleteData, boolean ignoreUnknownDb, boolean cascade)
-      throws HiveException, NoSuchObjectException {
-    try {
-      getMSC().dropDatabase(name, deleteData, ignoreUnknownDb, cascade);
-    } catch (NoSuchObjectException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-
-  /**
-   * Creates a table metadata and the directory for the table data
-   *
-   * @param tableName
-   *          name of the table
-   * @param columns
-   *          list of fields of the table
-   * @param partCols
-   *          partition keys of the table
-   * @param fileInputFormat
-   *          Class of the input format of the table data file
-   * @param fileOutputFormat
-   *          Class of the output format of the table data file
-   * @throws HiveException
-   *           thrown if the args are invalid or if the metadata or the data
-   *           directory couldn't be created
-   */
-  public void createTable(String tableName, List<String> columns,
-      List<String> partCols, Class<? extends InputFormat> fileInputFormat,
-      Class<?> fileOutputFormat) throws HiveException {
-    this.createTable(tableName, columns, partCols, fileInputFormat,
-        fileOutputFormat, -1, null);
-  }
-
-  /**
-   * Creates a table metadata and the directory for the table data
-   *
-   * @param tableName
-   *          name of the table
-   * @param columns
-   *          list of fields of the table
-   * @param partCols
-   *          partition keys of the table
-   * @param fileInputFormat
-   *          Class of the input format of the table data file
-   * @param fileOutputFormat
-   *          Class of the output format of the table data file
-   * @param bucketCount
-   *          number of buckets that each partition (or the table itself) should
-   *          be divided into
-   * @throws HiveException
-   *           thrown if the args are invalid or if the metadata or the data
-   *           directory couldn't be created
-   */
-  public void createTable(String tableName, List<String> columns,
-      List<String> partCols, Class<? extends InputFormat> fileInputFormat,
-      Class<?> fileOutputFormat, int bucketCount, List<String> bucketCols)
-      throws HiveException {
-    createTable(tableName, columns, partCols, fileInputFormat, fileOutputFormat, bucketCount,
-        bucketCols, null);
-  }
-
-  /**
-   * Create a table metadata and the directory for the table data
-   * @param tableName table name
-   * @param columns list of fields of the table
-   * @param partCols partition keys of the table
-   * @param fileInputFormat Class of the input format of the table data file
-   * @param fileOutputFormat Class of the output format of the table data file
-   * @param bucketCount number of buckets that each partition (or the table itself) should be
-   *                    divided into
-   * @param bucketCols Bucket columns
-   * @param parameters Parameters for the table
-   * @throws HiveException
-   */
-  public void createTable(String tableName, List<String> columns, List<String> partCols,
-                          Class<? extends InputFormat> fileInputFormat,
-                          Class<?> fileOutputFormat, int bucketCount, List<String> bucketCols,
-                          Map<String, String> parameters) throws HiveException {
-    if (columns == null) {
-      throw new HiveException("columns not specified for table " + tableName);
-    }
-
-    Table tbl = newTable(tableName);
-    tbl.setInputFormatClass(fileInputFormat.getName());
-    tbl.setOutputFormatClass(fileOutputFormat.getName());
-
-    for (String col : columns) {
-      FieldSchema field = new FieldSchema(col, STRING_TYPE_NAME, "default");
-      tbl.getCols().add(field);
-    }
-
-    if (partCols != null) {
-      for (String partCol : partCols) {
-        FieldSchema part = new FieldSchema();
-        part.setName(partCol);
-        part.setType(STRING_TYPE_NAME); // default partition key
-        tbl.getPartCols().add(part);
-      }
-    }
-    tbl.setSerializationLib(LazySimpleSerDe.class.getName());
-    tbl.setNumBuckets(bucketCount);
-    tbl.setBucketCols(bucketCols);
-    if (parameters != null) {
-      tbl.setParamters(parameters);
-    }
-    createTable(tbl);
-  }
-
-  /**
-   * Updates the existing table metadata with the new metadata.
-   *
-   * @param tblName
-   *          name of the existing table
-   * @param newTbl
-   *          new name of the table. could be the old name
-   * @throws InvalidOperationException
-   *           if the changes in metadata is not acceptable
-   * @throws TException
-   */
-  public void alterTable(String tblName, Table newTbl)
-      throws InvalidOperationException, HiveException {
-    alterTable(tblName, newTbl, false);
-  }
-
-  public void alterTable(String tblName, Table newTbl, boolean cascade)
-      throws InvalidOperationException, HiveException {
-    String[] names = Utilities.getDbTableName(tblName);
-    try {
-      // Remove the DDL_TIME so it gets refreshed
-      if (newTbl.getParameters() != null) {
-        newTbl.getParameters().remove(hive_metastoreConstants.DDL_TIME);
-      }
-      newTbl.checkValidity();
-      getMSC().alter_table(names[0], names[1], newTbl.getTTable(), cascade);
-    } catch (MetaException e) {
-      throw new HiveException("Unable to alter table. " + e.getMessage(), e);
-    } catch (TException e) {
-      throw new HiveException("Unable to alter table. " + e.getMessage(), e);
-    }
-  }
-
-  public void alterIndex(String baseTableName, String indexName, Index newIdx)
-      throws InvalidOperationException, HiveException {
-    String[] names = Utilities.getDbTableName(baseTableName);
-    alterIndex(names[0], names[1], indexName, newIdx);
-  }
-
-  /**
-   * Updates the existing index metadata with the new metadata.
-   *
-   * @param idxName
-   *          name of the existing index
-   * @param newIdx
-   *          new name of the index. could be the old name
-   * @throws InvalidOperationException
-   *           if the changes in metadata is not acceptable
-   * @throws TException
-   */
-  public void alterIndex(String dbName, String baseTblName, String idxName, Index newIdx)
-      throws InvalidOperationException, HiveException {
-    try {
-      getMSC().alter_index(dbName, baseTblName, idxName, newIdx);
-    } catch (MetaException e) {
-      throw new HiveException("Unable to alter index. " + e.getMessage(), e);
-    } catch (TException e) {
-      throw new HiveException("Unable to alter index. " + e.getMessage(), e);
-    }
-  }
-
-  /**
-   * Updates the existing partition metadata with the new metadata.
-   *
-   * @param tblName
-   *          name of the existing table
-   * @param newPart
-   *          new partition
-   * @throws InvalidOperationException
-   *           if the changes in metadata is not acceptable
-   * @throws TException
-   */
-  public void alterPartition(String tblName, Partition newPart)
-      throws InvalidOperationException, HiveException {
-    String[] names = Utilities.getDbTableName(tblName);
-    alterPartition(names[0], names[1], newPart);
-  }
-
-  /**
-   * Updates the existing partition metadata with the new metadata.
-   *
-   * @param dbName
-   *          name of the exiting table's database
-   * @param tblName
-   *          name of the existing table
-   * @param newPart
-   *          new partition
-   * @throws InvalidOperationException
-   *           if the changes in metadata is not acceptable
-   * @throws TException
-   */
-  public void alterPartition(String dbName, String tblName, Partition newPart)
-      throws InvalidOperationException, HiveException {
-    try {
-      // Remove the DDL time so that it gets refreshed
-      if (newPart.getParameters() != null) {
-        newPart.getParameters().remove(hive_metastoreConstants.DDL_TIME);
-      }
-      newPart.checkValidity();
-      getMSC().alter_partition(dbName, tblName, newPart.getTPartition());
-
-    } catch (MetaException e) {
-      throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
-    } catch (TException e) {
-      throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
-    }
-  }
-
-  /**
-   * Updates the existing table metadata with the new metadata.
-   *
-   * @param tblName
-   *          name of the existing table
-   * @param newParts
-   *          new partitions
-   * @throws InvalidOperationException
-   *           if the changes in metadata is not acceptable
-   * @throws TException
-   */
-  public void alterPartitions(String tblName, List<Partition> newParts)
-      throws InvalidOperationException, HiveException {
-    String[] names = Utilities.getDbTableName(tblName);
-    List<org.apache.hadoop.hive.metastore.api.Partition> newTParts =
-      new ArrayList<org.apache.hadoop.hive.metastore.api.Partition>();
-    try {
-      // Remove the DDL time so that it gets refreshed
-      for (Partition tmpPart: newParts) {
-        if (tmpPart.getParameters() != null) {
-          tmpPart.getParameters().remove(hive_metastoreConstants.DDL_TIME);
-        }
-        newTParts.add(tmpPart.getTPartition());
-      }
-      getMSC().alter_partitions(names[0], names[1], newTParts);
-    } catch (MetaException e) {
-      throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
-    } catch (TException e) {
-      throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
-    }
-  }
-  /**
-   * Rename a old partition to new partition
-   *
-   * @param tbl
-   *          existing table
-   * @param oldPartSpec
-   *          spec of old partition
-   * @param newPart
-   *          new partition
-   * @throws InvalidOperationException
-   *           if the changes in metadata is not acceptable
-   * @throws TException
-   */
-  public void renamePartition(Table tbl, Map<String, String> oldPartSpec, Partition newPart)
-      throws HiveException {
-    try {
-      Map<String, String> newPartSpec = newPart.getSpec();
-      if (oldPartSpec.keySet().size() != tbl.getPartCols().size()
-          || newPartSpec.keySet().size() != tbl.getPartCols().size()) {
-        throw new HiveException("Unable to rename partition to the same name: number of partition cols don't match. ");
-      }
-      if (!oldPartSpec.keySet().equals(newPartSpec.keySet())){
-        throw new HiveException("Unable to rename partition to the same name: old and new partition cols don't match. ");
-      }
-      List<String> pvals = new ArrayList<String>();
-
-      for (FieldSchema field : tbl.getPartCols()) {
-        String val = oldPartSpec.get(field.getName());
-        if (val == null || val.length() == 0) {
-          throw new HiveException("get partition: Value for key "
-              + field.getName() + " is null or empty");
-        } else if (val != null){
-          pvals.add(val);
-        }
-      }
-      getMSC().renamePartition(tbl.getDbName(), tbl.getTableName(), pvals,
-          newPart.getTPartition());
-
-    } catch (InvalidOperationException e){
-      throw new HiveException("Unable to rename partition. " + e.getMessage(), e);
-    } catch (MetaException e) {
-      throw new HiveException("Unable to rename partition. " + e.getMessage(), e);
-    } catch (TException e) {
-      throw new HiveException("Unable to rename partition. " + e.getMessage(), e);
-    }
-  }
-
-  public void alterDatabase(String dbName, Database db)
-      throws HiveException {
-    try {
-      getMSC().alterDatabase(dbName, db);
-    } catch (MetaException e) {
-      throw new HiveException("Unable to alter database " + dbName + ". " + e.getMessage(), e);
-    } catch (NoSuchObjectException e) {
-      throw new HiveException("Database " + dbName + " does not exists.", e);
-    } catch (TException e) {
-      throw new HiveException("Unable to alter database " + dbName + ". " + e.getMessage(), e);
-    }
-  }
-  /**
-   * Creates the table with the give objects
-   *
-   * @param tbl
-   *          a table object
-   * @throws HiveException
-   */
-  public void createTable(Table tbl) throws HiveException {
-    createTable(tbl, false);
-  }
-
-  /**
-   * Creates the table with the give objects
-   *
-   * @param tbl
-   *          a table object
-   * @param ifNotExists
-   *          if true, ignore AlreadyExistsException
-   * @throws HiveException
-   */
-  public void createTable(Table tbl, boolean ifNotExists) throws HiveException {
-    try {
-      if (tbl.getDbName() == null || "".equals(tbl.getDbName().trim())) {
-        tbl.setDbName(SessionState.get().getCurrentDatabase());
-      }
-      if (tbl.getCols().size() == 0 || tbl.getSd().getColsSize() == 0) {
-        tbl.setFields(MetaStoreUtils.getFieldsFromDeserializer(tbl.getTableName(),
-            tbl.getDeserializer()));
-      }
-      tbl.checkValidity();
-      if (tbl.getParameters() != null) {
-        tbl.getParameters().remove(hive_metastoreConstants.DDL_TIME);
-      }
-      org.apache.hadoop.hive.metastore.api.Table tTbl = tbl.getTTable();
-      PrincipalPrivilegeSet principalPrivs = new PrincipalPrivilegeSet();
-      SessionState ss = SessionState.get();
-      if (ss != null) {
-        CreateTableAutomaticGrant grants = ss.getCreateTableGrants();
-        if (grants != null) {
-          principalPrivs.setUserPrivileges(grants.getUserGrants());
-          principalPrivs.setGroupPrivileges(grants.getGroupGrants());
-          principalPrivs.setRolePrivileges(grants.getRoleGrants());
-          tTbl.setPrivileges(principalPrivs);
-        }
-      }
-      getMSC().createTable(tTbl);
-    } catch (AlreadyExistsException e) {
-      if (!ifNotExists) {
-        throw new HiveException(e);
-      }
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   *
-   * @param tableName
-   *          table name
-   * @param indexName
-   *          index name
-   * @param indexHandlerClass
-   *          index handler class
-   * @param indexedCols
-   *          index columns
-   * @param indexTblName
-   *          index table's name
-   * @param deferredRebuild
-   *          referred build index table's data
-   * @param inputFormat
-   *          input format
-   * @param outputFormat
-   *          output format
-   * @param serde
-   * @param storageHandler
-   *          index table's storage handler
-   * @param location
-   *          location
-   * @param idxProps
-   *          idx
-   * @param serdeProps
-   *          serde properties
-   * @param collItemDelim
-   * @param fieldDelim
-   * @param fieldEscape
-   * @param lineDelim
-   * @param mapKeyDelim
-   * @throws HiveException
-   */
-  public void createIndex(String tableName, String indexName, String indexHandlerClass,
-      List<String> indexedCols, String indexTblName, boolean deferredRebuild,
-      String inputFormat, String outputFormat, String serde,
-      String storageHandler, String location,
-      Map<String, String> idxProps, Map<String, String> tblProps, Map<String, String> serdeProps,
-      String collItemDelim, String fieldDelim, String fieldEscape,
-      String lineDelim, String mapKeyDelim, String indexComment)
-      throws HiveException {
-
-    try {
-      String tdname = Utilities.getDatabaseName(tableName);
-      String idname = Utilities.getDatabaseName(indexTblName);
-      if (!idname.equals(tdname)) {
-        throw new HiveException("Index on different database (" + idname
-          + ") from base table (" + tdname + ") is not supported.");
-      }
-
-      Index old_index = null;
-      try {
-        old_index = getIndex(tableName, indexName);
-      } catch (Exception e) {
-      }
-      if (old_index != null) {
-        throw new HiveException("Index " + indexName + " already exists on table " + tableName);
-      }
-
-      org.apache.hadoop.hive.metastore.api.Table baseTbl = getTable(tableName).getTTable();
-      if (baseTbl.getTableType() == TableType.VIRTUAL_VIEW.toString()) {
-        throw new HiveException("tableName="+ tableName +" is a VIRTUAL VIEW. Index on VIRTUAL VIEW is not supported.");
-      }
-      if (baseTbl.isTemporary()) {
-        throw new HiveException("tableName=" + tableName
-            + " is a TEMPORARY TABLE. Index on TEMPORARY TABLE is not supported.");
-      }
-
-      org.apache.hadoop.hive.metastore.api.Table temp = null;
-      try {
-        temp = getTable(indexTblName).getTTable();
-      } catch (Exception e) {
-      }
-      if (temp != null) {
-        throw new HiveException("Table name " + indexTblName + " already exists. Choose another name.");
-      }
-
-      SerDeInfo serdeInfo = new SerDeInfo();
-      serdeInfo.setName(indexTblName);
-
-      if(serde != null) {
-        serdeInfo.setSerializationLib(serde);
-      } else {
-        if (storageHandler == null) {
-          serdeInfo.setSerializationLib(org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.class.getName());
-        } else {
-          HiveStorageHandler sh = HiveUtils.getStorageHandler(getConf(), storageHandler);
-          String serDeClassName = sh.getSerDeClass().getName();
-          serdeInfo.setSerializationLib(serDeClassName);
-        }
-      }
-
-      serdeInfo.setParameters(new HashMap<String, String>());
-      if (fieldDelim != null) {
-        serdeInfo.getParameters().put(FIELD_DELIM, fieldDelim);
-        serdeInfo.getParameters().put(SERIALIZATION_FORMAT, fieldDelim);
-      }
-      if (fieldEscape != null) {
-        serdeInfo.getParameters().put(ESCAPE_CHAR, fieldEscape);
-      }
-      if (collItemDelim != null) {
-        serdeInfo.getParameters().put(COLLECTION_DELIM, collItemDelim);
-      }
-      if (mapKeyDelim != null) {
-        serdeInfo.getParameters().put(MAPKEY_DELIM, mapKeyDelim);
-      }
-      if (lineDelim != null) {
-        serdeInfo.getParameters().put(LINE_DELIM, lineDelim);
-      }
-
-      if (serdeProps != null) {
-        Iterator<Entry<String, String>> iter = serdeProps.entrySet()
-          .iterator();
-        while (iter.hasNext()) {
-          Entry<String, String> m = iter.next();
-          serdeInfo.getParameters().put(m.getKey(), m.getValue());
-        }
-      }
-
-      List<FieldSchema> indexTblCols = new ArrayList<FieldSchema>();
-      List<Order> sortCols = new ArrayList<Order>();
-      int k = 0;
-      Table metaBaseTbl = new Table(baseTbl);
-      for (int i = 0; i < metaBaseTbl.getCols().size(); i++) {
-        FieldSchema col = metaBaseTbl.getCols().get(i);
-        if (indexedCols.contains(col.getName())) {
-          indexTblCols.add(col);
-          sortCols.add(new Order(col.getName(), 1));
-          k++;
-        }
-      }
-      if (k != indexedCols.size()) {
-        throw new RuntimeException(
-            "Check the index columns, they should appear in the table being indexed.");
-      }
-
-      int time = (int) (System.currentTimeMillis() / 1000);
-      org.apache.hadoop.hive.metastore.api.Table tt = null;
-      HiveIndexHandler indexHandler = HiveUtils.getIndexHandler(this.getConf(), indexHandlerClass);
-
-      String itname = Utilities.getTableName(indexTblName);
-      if (indexHandler.usesIndexTable()) {
-        tt = new org.apache.hadoop.hive.ql.metadata.Table(idname, itname).getTTable();
-        List<FieldSchema> partKeys = baseTbl.getPartitionKeys();
-        tt.setPartitionKeys(partKeys);
-        tt.setTableType(TableType.INDEX_TABLE.toString());
-        if (tblProps != null) {
-          for (Entry<String, String> prop : tblProps.entrySet()) {
-            tt.putToParameters(prop.getKey(), prop.getValue());
-          }
-        }
-        SessionState ss = SessionState.get();
-        CreateTableAutomaticGrant grants;
-        if (ss != null && ((grants = ss.getCreateTableGrants()) != null)) {
-            PrincipalPrivilegeSet principalPrivs = new PrincipalPrivilegeSet();
-            principalPrivs.setUserPrivileges(grants.getUserGrants());
-            principalPrivs.setGroupPrivileges(grants.getGroupGrants());
-            principalPrivs.setRolePrivileges(grants.getRoleGrants());
-            tt.setPrivileges(principalPrivs);
-          }
-      }
-
-      if(!deferredRebuild) {
-        throw new RuntimeException("Please specify deferred rebuild using \" WITH DEFERRED REBUILD \".");
-      }
-
-      StorageDescriptor indexSd = new StorageDescriptor(
-          indexTblCols,
-          location,
-          inputFormat,
-          outputFormat,
-          false/*compressed - not used*/,
-          -1/*numBuckets - default is -1 when the table has no buckets*/,
-          serdeInfo,
-          null/*bucketCols*/,
-          sortCols,
-          null/*parameters*/);
-
-      String ttname = Utilities.getTableName(tableName);
-      Index indexDesc = new Index(indexName, indexHandlerClass, tdname, ttname, time, time, itname,
-          indexSd, new HashMap<String,String>(), deferredRebuild);
-      if (indexComment != null) {
-        indexDesc.getParameters().put("comment", indexComment);
-      }
-
-      if (idxProps != null)
-      {
-        indexDesc.getParameters().putAll(idxProps);
-      }
-
-      indexHandler.analyzeIndexDefinition(baseTbl, indexDesc, tt);
-
-      this.getMSC().createIndex(indexDesc, tt);
-
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public Index getIndex(String baseTableName, String indexName) throws HiveException {
-    String[] names = Utilities.getDbTableName(baseTableName);
-    return this.getIndex(names[0], names[1], indexName);
-  }
-
-  public Index getIndex(String dbName, String baseTableName,
-      String indexName) throws HiveException {
-    try {
-      return this.getMSC().getIndex(dbName, baseTableName, indexName);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public boolean dropIndex(String baseTableName, String index_name,
-      boolean throwException, boolean deleteData) throws HiveException {
-    String[] names = Utilities.getDbTableName(baseTableName);
-    return dropIndex(names[0], names[1], index_name, throwException, deleteData);
-  }
-
-  public boolean dropIndex(String db_name, String tbl_name, String index_name,
-      boolean throwException, boolean deleteData) throws HiveException {
-    try {
-      return getMSC().dropIndex(db_name, tbl_name, index_name, deleteData);
-    } catch (NoSuchObjectException e) {
-      if (throwException) {
-        throw new HiveException("Index " + index_name + " doesn't exist. ", e);
-      }
-      return false;
-    } catch (Exception e) {
-      throw new HiveException(e.getMessage(), e);
-    }
-  }
-
-  /**
-   * Drops table along with the data in it. If the table doesn't exist then it
-   * is a no-op. If ifPurge option is specified it is passed to the
-   * hdfs command that removes table data from warehouse to make it skip trash.
-   *
-   * @param tableName
-   *          table to drop
-   * @param ifPurge
-   *          completely purge the table (skipping trash) while removing data from warehouse
-   * @throws HiveException
-   *           thrown if the drop fails
-   */
-  public void dropTable(String tableName, boolean ifPurge) throws HiveException {
-    String[] names = Utilities.getDbTableName(tableName);
-    dropTable(names[0], names[1], true, true, ifPurge);
-  }
-
-  /**
-   * Drops table along with the data in it. If the table doesn't exist then it
-   * is a no-op
-   *
-   * @param tableName
-   *          table to drop
-   * @throws HiveException
-   *           thrown if the drop fails
-   */
-  public void dropTable(String tableName) throws HiveException {
-    dropTable(tableName, false);
-  }
-
-  /**
-   * Drops table along with the data in it. If the table doesn't exist then it
-   * is a no-op
-   *
-   * @param dbName
-   *          database where the table lives
-   * @param tableName
-   *          table to drop
-   * @throws HiveException
-   *           thrown if the drop fails
-   */
-  public void dropTable(String dbName, String tableName) throws HiveException {
-    dropTable(dbName, tableName, true, true, false);
-  }
-
-  /**
-   * Drops the table.
-   *
-   * @param dbName
-   * @param tableName
-   * @param deleteData
-   *          deletes the underlying data along with metadata
-   * @param ignoreUnknownTab
-   *          an exception is thrown if this is false and the table doesn't exist
-   * @throws HiveException
-   */
-  public void dropTable(String dbName, String tableName, boolean deleteData,
-      boolean ignoreUnknownTab) throws HiveException {
-    dropTable(dbName, tableName, deleteData, ignoreUnknownTab, false);
-  }
-
-  /**
-   * Drops the table.
-   *
-   * @param dbName
-   * @param tableName
-   * @param deleteData
-   *          deletes the underlying data along with metadata
-   * @param ignoreUnknownTab
-   *          an exception is thrown if this is false and the table doesn't exist
-   * @param ifPurge
-   *          completely purge the table skipping trash while removing data from warehouse
-   * @throws HiveException
-   */
-  public void dropTable(String dbName, String tableName, boolean deleteData,
-      boolean ignoreUnknownTab, boolean ifPurge) throws HiveException {
-    try {
-      getMSC().dropTable(dbName, tableName, deleteData, ignoreUnknownTab, ifPurge);
-    } catch (NoSuchObjectException e) {
-      if (!ignoreUnknownTab) {
-        throw new HiveException(e);
-      }
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public HiveConf getConf() {
-    return (conf);
-  }
-
-  /**
-   * Returns metadata for the table named tableName
-   * @param tableName the name of the table
-   * @return the table metadata
-   * @throws HiveException if there's an internal error or if the
-   * table doesn't exist
-   */
-  public Table getTable(final String tableName) throws HiveException {
-    return this.getTable(tableName, true);
-  }
-
-  /**
-   * Returns metadata for the table named tableName
-   * @param tableName the name of the table
-   * @param throwException controls whether an exception is thrown or a returns a null
-   * @return the table metadata
-   * @throws HiveException if there's an internal error or if the
-   * table doesn't exist
-   */
-  public Table getTable(final String tableName, boolean throwException) throws HiveException {
-    String[] names = Utilities.getDbTableName(tableName);
-    return this.getTable(names[0], names[1], throwException);
-  }
-
-  /**
-   * Returns metadata of the table
-   *
-   * @param dbName
-   *          the name of the database
-   * @param tableName
-   *          the name of the table
-   * @return the table
-   * @exception HiveException
-   *              if there's an internal error or if the table doesn't exist
-   */
-  public Table getTable(final String dbName, final String tableName) throws HiveException {
-    if (tableName.contains(".")) {
-      String[] names = Utilities.getDbTableName(tableName);
-      return this.getTable(names[0], names[1], true);
-    } else {
-      return this.getTable(dbName, tableName, true);
-    }
-  }
-
-  /**
-   * Returns metadata of the table
-   *
-   * @param dbName
-   *          the name of the database
-   * @param tableName
-   *          the name of the table
-   * @param throwException
-   *          controls whether an exception is thrown or a returns a null
-   * @return the table or if throwException is false a null value.
-   * @throws HiveException
-   */
-  public Table getTable(final String dbName, final String tableName,
-      boolean throwException) throws HiveException {
-
-    if (tableName == null || tableName.equals("")) {
-      throw new HiveException("empty table creation??");
-    }
-
-    // Get the table from metastore
-    org.apache.hadoop.hive.metastore.api.Table tTable = null;
-    try {
-      tTable = getMSC().getTable(dbName, tableName);
-    } catch (NoSuchObjectException e) {
-      if (throwException) {
-        LOG.error("Table " + tableName + " not found: " + e.getMessage());
-        throw new InvalidTableException(tableName);
-      }
-      return null;
-    } catch (Exception e) {
-      throw new HiveException("Unable to fetch table " + tableName + ". " + e.getMessage(), e);
-    }
-
-    // For non-views, we need to do some extra fixes
-    if (!TableType.VIRTUAL_VIEW.toString().equals(tTable.getTableType())) {
-      // Fix the non-printable chars
-      Map<String, String> parameters = tTable.getSd().getParameters();
-      String sf = parameters.get(SERIALIZATION_FORMAT);
-      if (sf != null) {
-        char[] b = sf.toCharArray();
-        if ((b.length == 1) && (b[0] < 10)) { // ^A, ^B, ^C, ^D, \t
-          parameters.put(SERIALIZATION_FORMAT, Integer.toString(b[0]));
-        }
-      }
-
-      // Use LazySimpleSerDe for MetadataTypedColumnsetSerDe.
-      // NOTE: LazySimpleSerDe does not support tables with a single column of
-      // col
-      // of type "array<string>". This happens when the table is created using
-      // an
-      // earlier version of Hive.
-      if (org.apache.hadoop.hive.serde2.MetadataTypedColumnsetSerDe.class
-          .getName().equals(
-            tTable.getSd().getSerdeInfo().getSerializationLib())
-          && tTable.getSd().getColsSize() > 0
-          && tTable.getSd().getCols().get(0).getType().indexOf('<') == -1) {
-        tTable.getSd().getSerdeInfo().setSerializationLib(
-            org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.class.getName());
-      }
-    }
-
-    return new Table(tTable);
-  }
-
-  /**
-   * Get all table names for the current database.
-   * @return List of table names
-   * @throws HiveException
-   */
-  public List<String> getAllTables() throws HiveException {
-    return getAllTables(SessionState.get().getCurrentDatabase());
-  }
-
-  /**
-   * Get all table names for the specified database.
-   * @param dbName
-   * @return List of table names
-   * @throws HiveException
-   */
-  public List<String> getAllTables(String dbName) throws HiveException {
-    return getTablesByPattern(dbName, ".*");
-  }
-
-  /**
-   * Returns all existing tables from default database which match the given
-   * pattern. The matching occurs as per Java regular expressions
-   *
-   * @param tablePattern
-   *          java re pattern
-   * @return list of table names
-   * @throws HiveException
-   */
-  public List<String> getTablesByPattern(String tablePattern) throws HiveException {
-    return getTablesByPattern(SessionState.get().getCurrentDatabase(),
-        tablePattern);
-  }
-
-  /**
-   * Returns all existing tables from the specified database which match the given
-   * pattern. The matching occurs as per Java regular expressions.
-   * @param dbName
-   * @param tablePattern
-   * @return list of table names
-   * @throws HiveException
-   */
-  public List<String> getTablesByPattern(String dbName, String tablePattern) throws HiveException {
-    try {
-      return getMSC().getTables(dbName, tablePattern);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Returns all existing tables from the given database which match the given
-   * pattern. The matching occurs as per Java regular expressions
-   *
-   * @param database
-   *          the database name
-   * @param tablePattern
-   *          java re pattern
-   * @return list of table names
-   * @throws HiveException
-   */
-  public List<String> getTablesForDb(String database, String tablePattern)
-      throws HiveException {
-    try {
-      return getMSC().getTables(database, tablePattern);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Get all existing database names.
-   *
-   * @return List of database names.
-   * @throws HiveException
-   */
-  public List<String> getAllDatabases() throws HiveException {
-    try {
-      return getMSC().getAllDatabases();
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Get all existing databases that match the given
-   * pattern. The matching occurs as per Java regular expressions
-   *
-   * @param databasePattern
-   *          java re pattern
-   * @return list of database names
-   * @throws HiveException
-   */
-  public List<String> getDatabasesByPattern(String databasePattern) throws HiveException {
-    try {
-      return getMSC().getDatabases(databasePattern);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public boolean grantPrivileges(PrivilegeBag privileges)
-      throws HiveException {
-    try {
-      return getMSC().grant_privileges(privileges);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * @param privileges
-   *          a bag of privileges
-   * @return true on success
-   * @throws HiveException
-   */
-  public boolean revokePrivileges(PrivilegeBag privileges, boolean grantOption)
-      throws HiveException {
-    try {
-      return getMSC().revoke_privileges(privileges, grantOption);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Query metadata to see if a database with the given name already exists.
-   *
-   * @param dbName
-   * @return true if a database with the given name already exists, false if
-   *         does not exist.
-   * @throws HiveException
-   */
-  public boolean databaseExists(String dbName) throws HiveException {
-    return getDatabase(dbName) != null;
-  }
-
-  /**
-   * Get the database by name.
-   * @param dbName the name of the database.
-   * @return a Database object if this database exists, null otherwise.
-   * @throws HiveException
-   */
-  public Database getDatabase(String dbName) throws HiveException {
-    try {
-      return getMSC().getDatabase(dbName);
-    } catch (NoSuchObjectException e) {
-      return null;
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Get the Database object for current database
-   * @return a Database object if this database exists, null otherwise.
-   * @throws HiveException
-   */
-  public Database getDatabaseCurrent() throws HiveException {
-    String currentDb = SessionState.get().getCurrentDatabase();
-    return getDatabase(currentDb);
-  }
-
-  public void loadPartition(Path loadPath, String tableName,
-      Map<String, String> partSpec, boolean replace, boolean holdDDLTime,
-      boolean inheritTableSpecs, boolean isSkewedStoreAsSubdir,
-      boolean isSrcLocal, boolean isAcid) throws HiveException {
-    Table tbl = getTable(tableName);
-    loadPartition(loadPath, tbl, partSpec, replace, holdDDLTime, inheritTableSpecs,
-        isSkewedStoreAsSubdir, isSrcLocal, isAcid);
-  }
-
-  /**
-   * Load a directory into a Hive Table Partition - Alters existing content of
-   * the partition with the contents of loadPath. - If the partition does not
-   * exist - one is created - files in loadPath are moved into Hive. But the
-   * directory itself is not removed.
-   *
-   * @param loadPath
-   *          Directory containing files to load into Table
-   * @param  tbl
-   *          name of table to be loaded.
-   * @param partSpec
-   *          defines which partition needs to be loaded
-   * @param replace
-   *          if true - replace files in the partition, otherwise add files to
-   *          the partition
-   * @param holdDDLTime if true, force [re]create the partition
-   * @param inheritTableSpecs if true, on [re]creating the partition, take the
-   *          location/inputformat/outputformat/serde details from table spec
-   * @param isSrcLocal
-   *          If the source directory is LOCAL
-   * @param isAcid true if this is an ACID operation
-   */
-  public Partition loadPartition(Path loadPath, Table tbl,
-      Map<String, String> partSpec, boolean replace, boolean holdDDLTime,
-      boolean inheritTableSpecs, boolean isSkewedStoreAsSubdir,
-      boolean isSrcLocal, boolean isAcid) throws HiveException {
-    Path tblDataLocationPath =  tbl.getDataLocation();
-    Partition newTPart = null;
-    try {
-      /**
-       * Move files before creating the partition since down stream processes
-       * check for existence of partition in metadata before accessing the data.
-       * If partition is created before data is moved, downstream waiting
-       * processes might move forward with partial data
-       */
-
-      Partition oldPart = getPartition(tbl, partSpec, false);
-      Path oldPartPath = null;
-      if(oldPart != null) {
-        oldPartPath = oldPart.getDataLocation();
-      }
-
-      Path newPartPath = null;
-
-      if (inheritTableSpecs) {
-        Path partPath = new Path(tbl.getDataLocation(),
-            Warehouse.makePartPath(partSpec));
-        newPartPath = new Path(tblDataLocationPath.toUri().getScheme(), tblDataLocationPath.toUri().getAuthority(),
-            partPath.toUri().getPath());
-
-        if(oldPart != null) {
-          /*
-           * If we are moving the partition across filesystem boundaries
-           * inherit from the table properties. Otherwise (same filesystem) use the
-           * original partition location.
-           *
-           * See: HIVE-1707 and HIVE-2117 for background
-           */
-          FileSystem oldPartPathFS = oldPartPath.getFileSystem(getConf());
-          FileSystem loadPathFS = loadPath.getFileSystem(getConf());
-          if (FileUtils.equalsFileSystem(oldPartPathFS,loadPathFS)) {
-            newPartPath = oldPartPath;
-          }
-        }
-      } else {
-        newPartPath = oldPartPath;
-      }
-
-      List<Path> newFiles = null;
-      if (replace) {
-        Hive.replaceFiles(tbl.getPath(), loadPath, newPartPath, oldPartPath, getConf(),
-            isSrcLocal);
-      } else {
-        newFiles = new ArrayList<Path>();
-        FileSystem fs = tbl.getDataLocation().getFileSystem(conf);
-        Hive.copyFiles(conf, loadPath, newPartPath, fs, isSrcLocal, isAcid, newFiles);
-      }
-
-      boolean forceCreate = (!holdDDLTime) ? true : false;
-      newTPart = getPartition(tbl, partSpec, forceCreate, newPartPath.toString(),
-          inheritTableSpecs, newFiles);
-      // recreate the partition if it existed before
-      if (!holdDDLTime) {
-        if (isSkewedStoreAsSubdir) {
-          org.apache.hadoop.hive.metastore.api.Partition newCreatedTpart = newTPart.getTPartition();
-          SkewedInfo skewedInfo = newCreatedTpart.getSd().getSkewedInfo();
-          /* Construct list bucketing location mappings from sub-directory name. */
-          Map<List<String>, String> skewedColValueLocationMaps = constructListBucketingLocationMap(
-              newPartPath, skewedInfo);
-          /* Add list bucketing location mappings. */
-          skewedInfo.setSkewedColValueLocationMaps(skewedColValueLocationMaps);
-          newCreatedTpart.getSd().setSkewedInfo(skewedInfo);
-          alterPartition(tbl.getDbName(), tbl.getTableName(), new Partition(tbl, newCreatedTpart));
-          newTPart = getPartition(tbl, partSpec, true, newPartPath.toString(), inheritTableSpecs,
-              newFiles);
-          return new Partition(tbl, newCreatedTpart);
-        }
-      }
-    } catch (IOException e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    } catch (MetaException e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    } catch (InvalidOperationException e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    return newTPart;
-  }
-
-  /**
- * Walk through sub-directory tree to construct list bucketing location map.
- *
- * @param fSta
- * @param fSys
- * @param skewedColValueLocationMaps
- * @param newPartPath
- * @param skewedInfo
- * @throws IOException
- */
-private void walkDirTree(FileStatus fSta, FileSystem fSys,
-    Map<List<String>, String> skewedColValueLocationMaps, Path newPartPath, SkewedInfo skewedInfo)
-    throws IOException {
-  /* Base Case. It's leaf. */
-  if (!fSta.isDir()) {
-    /* construct one location map if not exists. */
-    constructOneLBLocationMap(fSta, skewedColValueLocationMaps, newPartPath, skewedInfo);
-    return;
-  }
-
-  /* dfs. */
-  FileStatus[] children = fSys.listStatus(fSta.getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-  if (children != null) {
-    for (FileStatus child : children) {
-      walkDirTree(child, fSys, skewedColValueLocationMaps, newPartPath, skewedInfo);
-    }
-  }
-}
-
-/**
- * Construct a list bucketing location map
- * @param fSta
- * @param skewedColValueLocationMaps
- * @param newPartPath
- * @param skewedInfo
- */
-private void constructOneLBLocationMap(FileStatus fSta,
-    Map<List<String>, String> skewedColValueLocationMaps,
-    Path newPartPath, SkewedInfo skewedInfo) {
-  Path lbdPath = fSta.getPath().getParent();
-  List<String> skewedValue = new ArrayList<String>();
-  String lbDirName = FileUtils.unescapePathName(lbdPath.toString());
-  String partDirName = FileUtils.unescapePathName(newPartPath.toString());
-  String lbDirSuffix = lbDirName.replace(partDirName, "");
-  String[] dirNames = lbDirSuffix.split(Path.SEPARATOR);
-  for (String dirName : dirNames) {
-    if ((dirName != null) && (dirName.length() > 0)) {
-      // Construct skewed-value to location map except default directory.
-      // why? query logic knows default-dir structure and don't need to get from map
-        if (!dirName
-            .equalsIgnoreCase(ListBucketingPrunerUtils.HIVE_LIST_BUCKETING_DEFAULT_DIR_NAME)) {
-        String[] kv = dirName.split("=");
-        if (kv.length == 2) {
-          skewedValue.add(kv[1]);
-        }
-      }
-    }
-  }
-  if ((skewedValue.size() > 0) && (skewedValue.size() == skewedInfo.getSkewedColNames().size())
-      && !skewedColValueLocationMaps.containsKey(skewedValue)) {
-    skewedColValueLocationMaps.put(skewedValue, lbdPath.toString());
-  }
-}
-
-  /**
-   * Construct location map from path
-   *
-   * @param newPartPath
-   * @param skewedInfo
-   * @return
-   * @throws IOException
-   * @throws FileNotFoundException
-   */
-  private Map<List<String>, String> constructListBucketingLocationMap(Path newPartPath,
-      SkewedInfo skewedInfo) throws IOException, FileNotFoundException {
-    Map<List<String>, String> skewedColValueLocationMaps = new HashMap<List<String>, String>();
-    FileSystem fSys = newPartPath.getFileSystem(conf);
-    walkDirTree(fSys.getFileStatus(newPartPath), fSys, skewedColValueLocationMaps, newPartPath,
-        skewedInfo);
-    return skewedColValueLocationMaps;
-  }
-
-
-  /**
-   * Given a source directory name of the load path, load all dynamically generated partitions
-   * into the specified table and return a list of strings that represent the dynamic partition
-   * paths.
-   * @param loadPath
-   * @param tableName
-   * @param partSpec
-   * @param replace
-   * @param numDP number of dynamic partitions
-   * @param holdDDLTime
-   * @param listBucketingEnabled
-   * @param isAcid true if this is an ACID operation
-   * @param txnId txnId, can be 0 unless isAcid == true
-   * @return partition map details (PartitionSpec and Partition)
-   * @throws HiveException
-   */
-  public Map<Map<String, String>, Partition> loadDynamicPartitions(Path loadPath,
-      String tableName, Map<String, String> partSpec, boolean replace,
-      int numDP, boolean holdDDLTime, boolean listBucketingEnabled, boolean isAcid, long txnId)
-      throws HiveException {
-
-    Set<Path> validPartitions = new HashSet<Path>();
-    try {
-      Map<Map<String, String>, Partition> partitionsMap = new
-          LinkedHashMap<Map<String, String>, Partition>();
-
-      FileSystem fs = loadPath.getFileSystem(conf);
-      FileStatus[] leafStatus = HiveStatsUtils.getFileStatusRecurse(loadPath, numDP+1, fs);
-      // Check for empty partitions
-      for (FileStatus s : leafStatus) {
-        // Check if the hadoop version supports sub-directories for tables/partitions
-        if (s.isDir() &&
-          !conf.getBoolVar(HiveConf.ConfVars.HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES)) {
-          // No leaves in this directory
-          LOG.info("NOT moving empty directory: " + s.getPath());
-        } else {
-          try {
-            validatePartitionNameCharacters(
-                Warehouse.getPartValuesFromPartName(s.getPath().getParent().toString()));
-          } catch (MetaException e) {
-            throw new HiveException(e);
-          }
-          validPartitions.add(s.getPath().getParent());
-        }
-      }
-
-      if (validPartitions.size() == 0) {
-        LOG.warn("No partition is generated by dynamic partitioning");
-      }
-
-      if (validPartitions.size() > conf.getIntVar(HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS)) {
-        throw new HiveException("Number of dynamic partitions created is " + validPartitions.size()
-            + ", which is more than "
-            + conf.getIntVar(HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS)
-            +". To solve this try to set " + HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.varname
-            + " to at least " + validPartitions.size() + '.');
-      }
-
-      Table tbl = getTable(tableName);
-      // for each dynamically created DP directory, construct a full partition spec
-      // and load the partition based on that
-      Iterator<Path> iter = validPartitions.iterator();
-      while (iter.hasNext()) {
-        // get the dynamically created directory
-        Path partPath = iter.next();
-        assert fs.getFileStatus(partPath).isDir():
-          "partitions " + partPath + " is not a directory !";
-
-        // generate a full partition specification
-        LinkedHashMap<String, String> fullPartSpec = new LinkedHashMap<String, String>(partSpec);
-        Warehouse.makeSpecFromName(fullPartSpec, partPath);
-        Partition newPartition = loadPartition(partPath, tbl, fullPartSpec, replace,
-            holdDDLTime, true, listBucketingEnabled, false, isAcid);
-        partitionsMap.put(fullPartSpec, newPartition);
-        LOG.info("New loading path = " + partPath + " with partSpec " + fullPartSpec);
-      }
-      if (isAcid) {
-        List<String> partNames = new ArrayList<>(partitionsMap.size());
-        for (Partition p : partitionsMap.values()) {
-          partNames.add(p.getName());
-        }
-        metaStoreClient.addDynamicPartitions(txnId, tbl.getDbName(), tbl.getTableName(), partNames);
-      }
-      return partitionsMap;
-    } catch (IOException e) {
-      throw new HiveException(e);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  /**
-   * Load a directory into a Hive Table. - Alters existing content of table with
-   * the contents of loadPath. - If table does not exist - an exception is
-   * thrown - files in loadPath are moved into Hive. But the directory itself is
-   * not removed.
-   *
-   * @param loadPath
-   *          Directory containing files to load into Table
-   * @param tableName
-   *          name of table to be loaded.
-   * @param replace
-   *          if true - replace files in the table, otherwise add files to table
-   * @param holdDDLTime
-   * @param isSrcLocal
-   *          If the source directory is LOCAL
-   * @param isSkewedStoreAsSubdir
-   *          if list bucketing enabled
-   * @param isAcid true if this is an ACID based write
-   */
-  public void loadTable(Path loadPath, String tableName, boolean replace,
-      boolean holdDDLTime, boolean isSrcLocal, boolean isSkewedStoreAsSubdir, boolean isAcid)
-      throws HiveException {
-    List<Path> newFiles = new ArrayList<Path>();
-    Table tbl = getTable(tableName);
-    HiveConf sessionConf = SessionState.getSessionConf();
-    if (replace) {
-      Path tableDest = tbl.getPath();
-      replaceFiles(tableDest, loadPath, tableDest, tableDest, sessionConf, isSrcLocal);
-    } else {
-      FileSystem fs;
-      try {
-        fs = tbl.getDataLocation().getFileSystem(sessionConf);
-        copyFiles(sessionConf, loadPath, tbl.getPath(), fs, isSrcLocal, isAcid, newFiles);
-      } catch (IOException e) {
-        throw new HiveException("addFiles: filesystem error in check phase", e);
-      }
-      tbl.getParameters().put(StatsSetupConst.STATS_GENERATED_VIA_STATS_TASK, "true");
-    }
-
-    try {
-      if (isSkewedStoreAsSubdir) {
-        SkewedInfo skewedInfo = tbl.getSkewedInfo();
-        // Construct list bucketing location mappings from sub-directory name.
-        Map<List<String>, String> skewedColValueLocationMaps = constructListBucketingLocationMap(
-            tbl.getPath(), skewedInfo);
-        // Add list bucketing location mappings.
-        skewedInfo.setSkewedColValueLocationMaps(skewedColValueLocationMaps);
-      }
-    } catch (IOException e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-
-    if (!holdDDLTime) {
-      try {
-        alterTable(tableName, tbl);
-      } catch (InvalidOperationException e) {
-        throw new HiveException(e);
-      }
-    }
-    fireInsertEvent(tbl, null, newFiles);
-  }
-
-  /**
-   * Creates a partition.
-   *
-   * @param tbl
-   *          table for which partition needs to be created
-   * @param partSpec
-   *          partition keys and their values
-   * @return created partition object
-   * @throws HiveException
-   *           if table doesn't exist or partition already exists
-   */
-  public Partition createPartition(Table tbl, Map<String, String> partSpec) throws HiveException {
-    try {
-      return new Partition(tbl, getMSC().add_partition(
-          Partition.createMetaPartitionObject(tbl, partSpec, null)));
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public List<Partition> createPartitions(AddPartitionDesc addPartitionDesc) throws HiveException {
-    Table tbl = getTable(addPartitionDesc.getDbName(), addPartitionDesc.getTableName());
-    int size = addPartitionDesc.getPartitionCount();
-    List<org.apache.hadoop.hive.metastore.api.Partition> in =
-        new ArrayList<org.apache.hadoop.hive.metastore.api.Partition>(size);
-    for (int i = 0; i < size; ++i) {
-      in.add(convertAddSpecToMetaPartition(tbl, addPartitionDesc.getPartition(i)));
-    }
-    List<Partition> out = new ArrayList<Partition>();
-    try {
-      if (!addPartitionDesc.getReplaceMode()){
-        // TODO: normally, the result is not necessary; might make sense to pass false
-        for (org.apache.hadoop.hive.metastore.api.Partition outPart
-            : getMSC().add_partitions(in, addPartitionDesc.isIfNotExists(), true)) {
-          out.add(new Partition(tbl, outPart));
-        }
-      } else {
-        getMSC().alter_partitions(addPartitionDesc.getDbName(), addPartitionDesc.getTableName(), in);
-        List<String> part_names = new ArrayList<String>();
-        for (org.apache.hadoop.hive.metastore.api.Partition p: in){
-          part_names.add(Warehouse.makePartName(tbl.getPartitionKeys(), p.getValues()));
-        }
-        for ( org.apache.hadoop.hive.metastore.api.Partition outPart :
-        getMSC().getPartitionsByNames(addPartitionDesc.getDbName(), addPartitionDesc.getTableName(),part_names)){
-          out.add(new Partition(tbl,outPart));
-        }
-      }
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    return out;
-  }
-
-  private org.apache.hadoop.hive.metastore.api.Partition convertAddSpecToMetaPartition(
-      Table tbl, AddPartitionDesc.OnePartitionDesc addSpec) throws HiveException {
-    Path location = addSpec.getLocation() != null
-        ? new Path(tbl.getPath(), addSpec.getLocation()) : null;
-    if (location !=null && !Utilities.isDefaultNameNode(conf)) {
-      // Ensure that it is a full qualified path (in most cases it will be since tbl.getPath() is full qualified)
-      location = new Path(Utilities.getQualifiedPath(conf, location));
-    }
-    org.apache.hadoop.hive.metastore.api.Partition part =
-        Partition.createMetaPartitionObject(tbl, addSpec.getPartSpec(), location);
-    if (addSpec.getPartParams() != null) {
-      part.setParameters(addSpec.getPartParams());
-    }
-    if (addSpec.getInputFormat() != null) {
-      part.getSd().setInputFormat(addSpec.getInputFormat());
-    }
-    if (addSpec.getOutputFormat() != null) {
-      part.getSd().setOutputFormat(addSpec.getOutputFormat());
-    }
-    if (addSpec.getNumBuckets() != -1) {
-      part.getSd().setNumBuckets(addSpec.getNumBuckets());
-    }
-    if (addSpec.getCols() != null) {
-      part.getSd().setCols(addSpec.getCols());
-    }
-    if (addSpec.getSerializationLib() != null) {
-        part.getSd().getSerdeInfo().setSerializationLib(addSpec.getSerializationLib());
-    }
-    if (addSpec.getSerdeParams() != null) {
-      part.getSd().getSerdeInfo().setParameters(addSpec.getSerdeParams());
-    }
-    if (addSpec.getBucketCols() != null) {
-      part.getSd().setBucketCols(addSpec.getBucketCols());
-    }
-    if (addSpec.getSortCols() != null) {
-      part.getSd().setSortCols(addSpec.getSortCols());
-    }
-    return part;
-  }
-
-  public Partition getPartition(Table tbl, Map<String, String> partSpec,
-      boolean forceCreate) throws HiveException {
-    return getPartition(tbl, partSpec, forceCreate, null, true, null);
-  }
-
-  /**
-   * Returns partition metadata
-   *
-   * @param tbl
-   *          the partition's table
-   * @param partSpec
-   *          partition keys and values
-   * @param forceCreate
-   *          if this is true and partition doesn't exist then a partition is
-   *          created
-   * @param partPath the path where the partition data is located
-   * @param inheritTableSpecs whether to copy over the table specs for if/of/serde
-   * @return result partition object or null if there is no partition
-   * @throws HiveException
-   */
-  public Partition getPartition(Table tbl, Map<String, String> partSpec, boolean forceCreate,
-                                String partPath, boolean inheritTableSpecs)
-      throws HiveException {
-    return getPartition(tbl, partSpec, forceCreate, partPath, inheritTableSpecs, null);
-  }
-
-  /**
-   * Returns partition metadata
-   *
-   * @param tbl
-   *          the partition's table
-   * @param partSpec
-   *          partition keys and values
-   * @param forceCreate
-   *          if this is true and partition doesn't exist then a partition is
-   *          created
-   * @param partPath the path where the partition data is located
-   * @param inheritTableSpecs whether to copy over the table specs for if/of/serde
-   * @param newFiles An optional list of new files that were moved into this partition.  If
-   *                 non-null these will be included in the DML event sent to the metastore.
-   * @return result partition object or null if there is no partition
-   * @throws HiveException
-   */
-  public Partition getPartition(Table tbl, Map<String, String> partSpec,
-      boolean forceCreate, String partPath, boolean inheritTableSpecs, List<Path> newFiles)
-      throws HiveException {
-    tbl.validatePartColumnNames(partSpec, true);
-    List<String> pvals = new ArrayList<String>();
-    for (FieldSchema field : tbl.getPartCols()) {
-      String val = partSpec.get(field.getName());
-      // enable dynamic partitioning
-      if ((val == null && !HiveConf.getBoolVar(conf, HiveConf.ConfVars.DYNAMICPARTITIONING))
-          || (val != null && val.length() == 0)) {
-        throw new HiveException("get partition: Value for key "
-            + field.getName() + " is null or empty");
-      } else if (val != null){
-        pvals.add(val);
-      }
-    }
-    org.apache.hadoop.hive.metastore.api.Partition tpart = null;
-    try {
-      tpart = getMSC().getPartitionWithAuthInfo(tbl.getDbName(),
-          tbl.getTableName(), pvals, getUserName(), getGroupNames());
-    } catch (NoSuchObjectException nsoe) {
-      // this means no partition exists for the given partition
-      // key value pairs - thrift cannot handle null return values, hence
-      // getPartition() throws NoSuchObjectException to indicate null partition
-      tpart = null;
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    try {
-      if (forceCreate) {
-        if (tpart == null) {
-          LOG.debug("creating partition for table " + tbl.getTableName()
-                    + " with partition spec : " + partSpec);
-          try {
-            tpart = getMSC().appendPartition(tbl.getDbName(), tbl.getTableName(), pvals);
-          } catch (AlreadyExistsException aee) {
-            LOG.debug("Caught already exists exception, trying to alter partition instead");
-            tpart = getMSC().getPartitionWithAuthInfo(tbl.getDbName(),
-              tbl.getTableName(), pvals, getUserName(), getGroupNames());
-            alterPartitionSpec(tbl, partSpec, tpart, inheritTableSpecs, partPath);
-          } catch (Exception e) {
-            if (CheckJDOException.isJDODataStoreException(e)) {
-              // Using utility method above, so that JDODataStoreException doesn't
-              // have to be used here. This helps avoid adding jdo dependency for
-              // hcatalog client uses
-              LOG.debug("Caught JDO exception, trying to alter partition instead");
-              tpart = getMSC().getPartitionWithAuthInfo(tbl.getDbName(),
-                tbl.getTableName(), pvals, getUserName(), getGroupNames());
-              if (tpart == null) {
-                // This means the exception was caused by something other than a race condition
-                // in creating the partition, since the partition still doesn't exist.
-                throw e;
-              }
-              alterPartitionSpec(tbl, partSpec, tpart, inheritTableSpecs, partPath);
-            } else {
-              throw e;
-            }
-          }
-        }
-        else {
-          alterPartitionSpec(tbl, partSpec, tpart, inheritTableSpecs, partPath);
-          fireInsertEvent(tbl, partSpec, newFiles);
-        }
-      }
-      if (tpart == null) {
-        return null;
-      }
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    return new Partition(tbl, tpart);
-  }
-
-  private void alterPartitionSpec(Table tbl,
-                                  Map<String, String> partSpec,
-                                  org.apache.hadoop.hive.metastore.api.Partition tpart,
-                                  boolean inheritTableSpecs,
-                                  String partPath) throws HiveException, InvalidOperationException {
-    LOG.debug("altering partition for table " + tbl.getTableName() + " with partition spec : "
-        + partSpec);
-    if (inheritTableSpecs) {
-      tpart.getSd().setOutputFormat(tbl.getTTable().getSd().getOutputFormat());
-      tpart.getSd().setInputFormat(tbl.getTTable().getSd().getInputFormat());
-      tpart.getSd().getSerdeInfo().setSerializationLib(tbl.getSerializationLib());
-      tpart.getSd().getSerdeInfo().setParameters(
-          tbl.getTTable().getSd().getSerdeInfo().getParameters());
-      tpart.getSd().setBucketCols(tbl.getBucketCols());
-      tpart.getSd().setNumBuckets(tbl.getNumBuckets());
-      tpart.getSd().setSortCols(tbl.getSortCols());
-    }
-    if (partPath == null || partPath.trim().equals("")) {
-      throw new HiveException("new partition path should not be null or empty.");
-    }
-    tpart.getSd().setLocation(partPath);
-    tpart.getParameters().put(StatsSetupConst.STATS_GENERATED_VIA_STATS_TASK,"true");
-    String fullName = tbl.getTableName();
-    if (!org.apache.commons.lang.StringUtils.isEmpty(tbl.getDbName())) {
-      fullName = tbl.getDbName() + "." + tbl.getTableName();
-    }
-    alterPartition(fullName, new Partition(tbl, tpart));
-  }
-
-  private void fireInsertEvent(Table tbl, Map<String, String> partitionSpec, List<Path> newFiles)
-      throws HiveException {
-    if (conf.getBoolVar(ConfVars.FIRE_EVENTS_FOR_DML)) {
-      LOG.debug("Firing dml insert event");
-      if (tbl.isTemporary()) {
-        LOG.debug("Not firing dml insert event as " + tbl.getTableName() + " is temporary");
-        return;
-      }
-      FireEventRequestData data = new FireEventRequestData();
-      InsertEventRequestData insertData = new InsertEventRequestData();
-      data.setInsertData(insertData);
-      if (newFiles != null && newFiles.size() > 0) {
-        for (Path p : newFiles) {
-          insertData.addToFilesAdded(p.toString());
-        }
-      } else {
-        insertData.setFilesAdded(new ArrayList<String>());
-      }
-      FireEventRequest rqst = new FireEventRequest(true, data);
-      rqst.setDbName(tbl.getDbName());
-      rqst.setTableName(tbl.getTableName());
-      if (partitionSpec != null && partitionSpec.size() > 0) {
-        List<String> partVals = new ArrayList<String>(partitionSpec.size());
-        for (FieldSchema fs : tbl.getPartitionKeys()) {
-          partVals.add(partitionSpec.get(fs.getName()));
-        }
-        rqst.setPartitionVals(partVals);
-      }
-      try {
-        getMSC().fireListenerEvent(rqst);
-      } catch (TException e) {
-        throw new HiveException(e);
-      }
-    }
-  }
-
-  public boolean dropPartition(String tblName, List<String> part_vals, boolean deleteData)
-      throws HiveException {
-    String[] names = Utilities.getDbTableName(tblName);
-    return dropPartition(names[0], names[1], part_vals, deleteData);
-  }
-
-  public boolean dropPartition(String db_name, String tbl_name,
-      List<String> part_vals, boolean deleteData) throws HiveException {
-    return dropPartition(db_name, tbl_name, part_vals,
-                         PartitionDropOptions.instance().deleteData(deleteData));
-  }
-
-  public boolean dropPartition(String dbName, String tableName, List<String> partVals, PartitionDropOptions options)
-      throws HiveException {
-    try {
-      return getMSC().dropPartition(dbName, tableName, partVals, options);
-    } catch (NoSuchObjectException e) {
-      throw new HiveException("Partition or table doesn't exist.", e);
-    } catch (Exception e) {
-      throw new HiveException(e.getMessage(), e);
-    }
-  }
-
-  public List<Partition> dropPartitions(String tblName, List<DropTableDesc.PartSpec> partSpecs,
-      boolean deleteData, boolean ignoreProtection, boolean ifExists) throws HiveException {
-    String[] names = Utilities.getDbTableName(tblName);
-    return dropPartitions(
-        names[0], names[1], partSpecs, deleteData, ignoreProtection, ifExists);
-  }
-
-  public List<Partition> dropPartitions(String dbName, String tblName,
-      List<DropTableDesc.PartSpec> partSpecs,  boolean deleteData, boolean ignoreProtection,
-      boolean ifExists) throws HiveException {
-    return dropPartitions(dbName, tblName, partSpecs,
-                          PartitionDropOptions.instance()
-                                              .deleteData(deleteData)
-                                              .ignoreProtection(ignoreProtection)
-                                              .ifExists(ifExists));
-  }
-
-  public List<Partition> dropPartitions(String tblName, List<DropTableDesc.PartSpec> partSpecs,
-                                        PartitionDropOptions dropOptions) throws HiveException {
-    String[] names = Utilities.getDbTableName(tblName);
-    return dropPartitions(names[0], names[1], partSpecs, dropOptions);
-  }
-
-  public List<Partition> dropPartitions(String dbName, String tblName,
-      List<DropTableDesc.PartSpec> partSpecs, PartitionDropOptions dropOptions) throws HiveException {
-    try {
-      Table tbl = getTable(dbName, tblName);
-      List<ObjectPair<Integer, byte[]>> partExprs =
-          new ArrayList<ObjectPair<Integer,byte[]>>(partSpecs.size());
-      for (DropTableDesc.PartSpec partSpec : partSpecs) {
-        partExprs.add(new ObjectPair<Integer, byte[]>(partSpec.getPrefixLength(),
-            Utilities.serializeExpressionToKryo(partSpec.getPartSpec())));
-      }
-      List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getMSC().dropPartitions(
-          dbName, tblName, partExprs, dropOptions);
-      return convertFromMetastore(tbl, tParts, null);
-    } catch (NoSuchObjectException e) {
-      throw new HiveException("Partition or table doesn't exist.", e);
-    } catch (Exception e) {
-      throw new HiveException(e.getMessage(), e);
-    }
-  }
-
-  public List<String> getPartitionNames(String tblName, short max) throws HiveException {
-    String[] names = Utilities.getDbTableName(tblName);
-    return getPartitionNames(names[0], names[1], max);
-  }
-
-  public List<String> getPartitionNames(String dbName, String tblName, short max)
-      throws HiveException {
-    List<String> names = null;
-    try {
-      names = getMSC().listPartitionNames(dbName, tblName, max);
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    return names;
-  }
-
-  public List<String> getPartitionNames(String dbName, String tblName,
-      Map<String, String> partSpec, short max) throws HiveException {
-    List<String> names = null;
-    Table t = getTable(dbName, tblName);
-
-    List<String> pvals = MetaStoreUtils.getPvals(t.getPartCols(), partSpec);
-
-    try {
-      names = getMSC().listPartitionNames(dbName, tblName, pvals, max);
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    return names;
-  }
-
-  /**
-   * get all the partitions that the table has
-   *
-   * @param tbl
-   *          object for which partition is needed
-   * @return list of partition objects
-   * @throws HiveException
-   */
-  public List<Partition> getPartitions(Table tbl) throws HiveException {
-    if (tbl.isPartitioned()) {
-      List<org.apache.hadoop.hive.metastore.api.Partition> tParts;
-      try {
-        tParts = getMSC().listPartitionsWithAuthInfo(tbl.getDbName(), tbl.getTableName(),
-            (short) -1, getUserName(), getGroupNames());
-      } catch (Exception e) {
-        LOG.error(StringUtils.stringifyException(e));
-        throw new HiveException(e);
-      }
-      List<Partition> parts = new ArrayList<Partition>(tParts.size());
-      for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
-        parts.add(new Partition(tbl, tpart));
-      }
-      return parts;
-    } else {
-      Partition part = new Partition(tbl);
-      ArrayList<Partition> parts = new ArrayList<Partition>(1);
-      parts.add(part);
-      return parts;
-    }
-  }
-
-  /**
-   * Get all the partitions; unlike {@link #getPartitions(Table)}, does not include auth.
-   * @param tbl table for which partitions are needed
-   * @return list of partition objects
-   */
-  public Set<Partition> getAllPartitionsOf(Table tbl) throws HiveException {
-    if (!tbl.isPartitioned()) {
-      return Sets.newHashSet(new Partition(tbl));
-    }
-
-    List<org.apache.hadoop.hive.metastore.api.Partition> tParts;
-    try {
-      tParts = getMSC().listPartitions(tbl.getDbName(), tbl.getTableName(), (short)-1);
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    Set<Partition> parts = new LinkedHashSet<Partition>(tParts.size());
-    for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
-      parts.add(new Partition(tbl, tpart));
-    }
-    return parts;
-  }
-
-  /**
-   * get all the partitions of the table that matches the given partial
-   * specification. partition columns whose value is can be anything should be
-   * an empty string.
-   *
-   * @param tbl
-   *          object for which partition is needed. Must be partitioned.
-   * @param limit number of partitions to return
-   * @return list of partition objects
-   * @throws HiveException
-   */
-  public List<Partition> getPartitions(Table tbl, Map<String, String> partialPartSpec,
-      short limit)
-  throws HiveException {
-    if (!tbl.isPartitioned()) {
-      throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
-    }
-
-    List<String> partialPvals = MetaStoreUtils.getPvals(tbl.getPartCols(), partialPartSpec);
-
-    List<org.apache.hadoop.hive.metastore.api.Partition> partitions = null;
-    try {
-      partitions = getMSC().listPartitionsWithAuthInfo(tbl.getDbName(), tbl.getTableName(),
-          partialPvals, limit, getUserName(), getGroupNames());
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-
-    List<Partition> qlPartitions = new ArrayList<Partition>();
-    for (org.apache.hadoop.hive.metastore.api.Partition p : partitions) {
-      qlPartitions.add( new Partition(tbl, p));
-    }
-
-    return qlPartitions;
-  }
-
-  /**
-   * get all the partitions of the table that matches the given partial
-   * specification. partition columns whose value is can be anything should be
-   * an empty string.
-   *
-   * @param tbl
-   *          object for which partition is needed. Must be partitioned.
-   * @return list of partition objects
-   * @throws HiveException
-   */
-  public List<Partition> getPartitions(Table tbl, Map<String, String> partialPartSpec)
-  throws HiveException {
-    return getPartitions(tbl, partialPartSpec, (short)-1);
-  }
-
-  /**
-   * get all the partitions of the table that matches the given partial
-   * specification. partition columns whose value is can be anything should be
-   * an empty string.
-   *
-   * @param tbl
-   *          object for which partition is needed. Must be partitioned.
-   * @param partialPartSpec
-   *          partial partition specification (some subpartitions can be empty).
-   * @return list of partition objects
-   * @throws HiveException
-   */
-  public List<Partition> getPartitionsByNames(Table tbl,
-      Map<String, String> partialPartSpec)
-      throws HiveException {
-
-    if (!tbl.isPartitioned()) {
-      throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
-    }
-
-    List<String> names = getPartitionNames(tbl.getDbName(), tbl.getTableName(),
-        partialPartSpec, (short)-1);
-
-    List<Partition> partitions = getPartitionsByNames(tbl, names);
-    return partitions;
-  }
-
-  /**
-   * Get all partitions of the table that matches the list of given partition names.
-   *
-   * @param tbl
-   *          object for which partition is needed. Must be partitioned.
-   * @param partNames
-   *          list of partition names
-   * @return list of partition objects
-   * @throws HiveException
-   */
-  public List<Partition> getPartitionsByNames(Table tbl, List<String> partNames)
-      throws HiveException {
-
-    if (!tbl.isPartitioned()) {
-      throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
-    }
-    List<Partition> partitions = new ArrayList<Partition>(partNames.size());
-
-    int batchSize = HiveConf.getIntVar(conf, HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX);
-    // TODO: might want to increase the default batch size. 1024 is viable; MS gets OOM if too high.
-    int nParts = partNames.size();
-    int nBatches = nParts / batchSize;
-
-    try {
-      for (int i = 0; i < nBatches; ++i) {
-        List<org.apache.hadoop.hive.metastore.api.Partition> tParts =
-          getMSC().getPartitionsByNames(tbl.getDbName(), tbl.getTableName(),
-          partNames.subList(i*batchSize, (i+1)*batchSize));
-        if (tParts != null) {
-          for (org.apache.hadoop.hive.metastore.api.Partition tpart: tParts) {
-            partitions.add(new Partition(tbl, tpart));
-          }
-        }
-      }
-
-      if (nParts > nBatches * batchSize) {
-        List<org.apache.hadoop.hive.metastore.api.Partition> tParts =
-          getMSC().getPartitionsByNames(tbl.getDbName(), tbl.getTableName(),
-          partNames.subList(nBatches*batchSize, nParts));
-        if (tParts != null) {
-          for (org.apache.hadoop.hive.metastore.api.Partition tpart: tParts) {
-            partitions.add(new Partition(tbl, tpart));
-          }
-        }
-      }
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-    return partitions;
-  }
-
-  /**
-   * Get a list of Partitions by filter.
-   * @param tbl The table containing the partitions.
-   * @param filter A string represent partition predicates.
-   * @return a list of partitions satisfying the partition predicates.
-   * @throws HiveException
-   * @throws MetaException
-   * @throws NoSuchObjectException
-   * @throws TException
-   */
-  public List<Partition> getPartitionsByFilter(Table tbl, String filter)
-      throws HiveException, MetaException, NoSuchObjectException, TException {
-
-    if (!tbl.isPartitioned()) {
-      throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
-    }
-
-    List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getMSC().listPartitionsByFilter(
-        tbl.getDbName(), tbl.getTableName(), filter, (short)-1);
-    return convertFromMetastore(tbl, tParts, null);
-  }
-
-  private static List<Partition> convertFromMetastore(Table tbl,
-      List<org.apache.hadoop.hive.metastore.api.Partition> src,
-      List<Partition> dest) throws HiveException {
-    if (src == null) {
-      return dest;
-    }
-    if (dest == null) {
-      dest = new ArrayList<Partition>(src.size());
-    }
-    for (org.apache.hadoop.hive.metastore.api.Partition tPart : src) {
-      dest.add(new Partition(tbl, tPart));
-    }
-    return dest;
-  }
-
-  /**
-   * Get a list of Partitions by expr.
-   * @param tbl The table containing the partitions.
-   * @param expr A serialized expression for partition predicates.
-   * @param conf Hive config.
-   * @param result the resulting list of partitions
-   * @return whether the resulting list contains partitions which may or may not match the expr
-   */
-  public boolean getPartitionsByExpr(Table tbl, ExprNodeGenericFuncDesc expr, HiveConf conf,
-      List<Partition> result) throws HiveException, TException {
-    assert result != null;
-    byte[] exprBytes = Utilities.serializeExpressionToKryo(expr);
-    String defaultPartitionName = HiveConf.getVar(conf, ConfVars.DEFAULTPARTITIONNAME);
-    List<org.apache.hadoop.hive.metastore.api.Partition> msParts =
-        new ArrayList<org.apache.hadoop.hive.metastore.api.Partition>();
-    boolean hasUnknownParts = getMSC().listPartitionsByExpr(tbl.getDbName(),
-        tbl.getTableName(), exprBytes, defaultPartitionName, (short)-1, msParts);
-    convertFromMetastore(tbl, msParts, result);
-    return hasUnknownParts;
-  }
-
-  public void validatePartitionNameCharacters(List<String> partVals) throws HiveException {
-    try {
-      getMSC().validatePartitionNameCharacters(partVals);
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public void createRole(String roleName, String ownerName)
-      throws HiveException {
-    try {
-      getMSC().create_role(new Role(roleName, -1, ownerName));
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public void dropRole(String roleName) throws HiveException {
-    try {
-      getMSC().drop_role(roleName);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Get all existing role names.
-   *
-   * @return List of role names.
-   * @throws HiveException
-   */
-  public List<String> getAllRoleNames() throws HiveException {
-    try {
-      return getMSC().listRoleNames();
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public  List<RolePrincipalGrant> getRoleGrantInfoForPrincipal(String principalName, PrincipalType principalType) throws HiveException {
-    try {
-      GetRoleGrantsForPrincipalRequest req = new GetRoleGrantsForPrincipalRequest(principalName, principalType);
-      GetRoleGrantsForPrincipalResponse resp = getMSC().get_role_grants_for_principal(req);
-      return resp.getPrincipalGrants();
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-
-  public boolean grantRole(String roleName, String userName,
-      PrincipalType principalType, String grantor, PrincipalType grantorType,
-      boolean grantOption) throws HiveException {
-    try {
-      return getMSC().grant_role(roleName, userName, principalType, grantor,
-        grantorType, grantOption);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public boolean revokeRole(String roleName, String userName,
-      PrincipalType principalType, boolean grantOption)  throws HiveException {
-    try {
-      return getMSC().revoke_role(roleName, userName, principalType, grantOption);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  public List<Role> listRoles(String userName,  PrincipalType principalType)
-      throws HiveException {
-    try {
-      return getMSC().list_roles(userName, principalType);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * @param objectType
-   *          hive object type
-   * @param db_name
-   *          database name
-   * @param table_name
-   *          table name
-   * @param part_values
-   *          partition values
-   * @param column_name
-   *          column name
-   * @param user_name
-   *          user name
-   * @param group_names
-   *          group names
-   * @return the privilege set
-   * @throws HiveException
-   */
-  public PrincipalPrivilegeSet get_privilege_set(HiveObjectType objectType,
-      String db_name, String table_name, List<String> part_values,
-      String column_name, String user_name, List<String> group_names)
-      throws HiveException {
-    try {
-      HiveObjectRef hiveObj = new HiveObjectRef(objectType, db_name,
-          table_name, part_values, column_name);
-      return getMSC().get_privilege_set(hiveObj, user_name, group_names);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * @param objectType
-   *          hive object type
-   * @param principalName
-   * @param principalType
-   * @param dbName
-   * @param tableName
-   * @param partValues
-   * @param columnName
-   * @return list of privileges
-   * @throws HiveException
-   */
-  public List<HiveObjectPrivilege> showPrivilegeGrant(
-      HiveObjectType objectType, String principalName,
-      PrincipalType principalType, String dbName, String tableName,
-      List<String> partValues, String columnName) throws HiveException {
-    try {
-      HiveObjectRef hiveObj = new HiveObjectRef(objectType, dbName, tableName,
-          partValues, columnName);
-      return getMSC().list_privileges(principalName, principalType, hiveObj);
-    } catch (Exception e) {
-      throw new HiveException(e);
-    }
-  }
-
-  // for each file or directory in 'srcs', make mapping for every file in src to safe name in dest
-  private static List<List<Path[]>> checkPaths(HiveConf conf, FileSystem fs,
-      FileStatus[] srcs, FileSystem srcFs, Path destf, boolean replace)
-      throws HiveException {
-
-    List<List<Path[]>> result = new ArrayList<List<Path[]>>();
-    try {
-      FileStatus destStatus = !replace ? FileUtils.getFileStatusOrNull(fs, destf) : null;
-      if (destStatus != null && !destStatus.isDir()) {
-        throw new HiveException("checkPaths: destination " + destf
-            + " should be a directory");
-      }
-      for (FileStatus src : srcs) {
-        FileStatus[] items;
-        if (src.isDir()) {
-          items = srcFs.listStatus(src.getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
-          Arrays.sort(items);
-        } else {
-          items = new FileStatus[] {src};
-        }
-
-        List<Path[]> srcToDest = new ArrayList<Path[]>();
-        for (FileStatus item : items) {
-
-          Path itemSource = item.getPath();
-
-          if (Utilities.isTempPath(item)) {
-            // This check is redundant because temp files are removed by
-            // execution layer before
-            // calling loadTable/Partition. But leaving it in just in case.
-            srcFs.delete(itemSource, true);
-            continue;
-          }
-
-          if (!conf.getBoolVar(HiveConf.ConfVars.HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES) &&
-            !HiveConf.getVar(conf, HiveConf.ConfVars.STAGINGDIR).equals(itemSource.getName()) &&
-            item.isDir()) {
-            throw new HiveException("checkPaths: " + src.getPath()
-                + " has nested directory " + itemSource);
-          }
-          // Strip off the file type, if any so we don't make:
-          // 000000_0.gz -> 000000_0.gz_copy_1
-          String name = itemSource.getName();
-          String filetype;
-          int index = name.lastIndexOf('.');
-          if (index >= 0) {
-            filetype = name.substring(index);
-            name = name.substring(0, index);
-          } else {
-            filetype = "";
-          }
-
-          Path itemDest = new Path(destf, itemSource.getName());
-
-          if (!replace) {
-            // It's possible that the file we're copying may have the same
-            // relative name as an existing file in the "destf" directory.
-            // So let's make a quick check to see if we can rename any
-            // potential offenders so as to allow them to move into the
-            // "destf" directory. The scheme is dead simple: simply tack
-            // on "_copy_N" where N starts at 1 and works its way up until
-            // we find a free space.
-
-            // removed source file staging.. it's more confusing when failed.
-            for (int counter = 1; fs.exists(itemDest) || destExists(result, itemDest); counter++) {
-              itemDest = new Path(destf, name + ("_copy_" + counter) + filetype);
-            }
-          }
-          srcToDest.add(new Path[]{itemSource, itemDest});
-        }
-        result.add(srcToDest);
-      }
-    } catch (IOException e) {
-      throw new HiveException("checkPaths: filesystem error in check phase. " + e.getMessage(), e);
-    }
-    return result;
-  }
-
-  private static boolean destExists(List<List<Path[]>> result, Path proposed) {
-    for (List<Path[]> sdpairs : result) {
-      for (Path[] sdpair : sdpairs) {
-        if (sdpair[1].equals(proposed)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private static boolean isSubDir(Path srcf, Path destf, FileSystem fs, boolean isSrcLocal){
-    if (srcf == null) {
-      LOG.debug("The source path is null for isSubDir method.");
-      return false;
-    }
-
-    String fullF1 = getQualifiedPathWithoutSchemeAndAuthority(srcf, fs);
-    String fullF2 = getQualifiedPathWithoutSchemeAndAuthority(destf, fs);
-
-    boolean isInTest = Boolean.valueOf(HiveConf.getBoolVar(fs.getConf(), ConfVars.HIVE_IN_TEST));
-    // In the automation, the data warehouse is the local file system based.
-    LOG.debug("The source path is " + fullF1 + " and the destination path is " + fullF2);
-    if (isInTest) {
-      return fullF1.startsWith(fullF2);
-    }
-
-    // schema is diff, return false
-    String schemaSrcf = srcf.toUri().getScheme();
-    String schemaDestf = destf.toUri().getScheme();
-
-    // if the schemaDestf is null, it means the destination is not in the local file system
-    if (schemaDestf == null && isSrcLocal) {
-      LOG.debug("The source file is in the local while the dest not.");
-      return false;
-    }
-
-    // If both schema information are provided, they should be the same.
-    if (schemaSrcf != null && schemaDestf != null && !schemaSrcf.equals(schemaDestf)) {
-      LOG.debug("The source path's schema is " + schemaSrcf +
-        " and the destination path's schema is " + schemaDestf + ".");
-      return false;
-    }
-
-    LOG.debug("The source path is " + fullF1 + " and the destination path is " + fullF2);
-    return fullF1.startsWith(fullF2);
-  }
-
-  private static String getQualifiedPathWithoutSchemeAndAuthority(Path srcf, FileSystem fs) {
-    Path currentWorkingDir = fs.getWorkingDirectory();
-    Path path = srcf.makeQualified(srcf.toUri(), currentWorkingDir);
-    return ShimLoader.getHadoopShims().getPathWithoutSchemeAndAuthority(path).toString();
-  }
-
-  //it is assumed that parent directory of the destf should already exist when this
-  //method is called. when the replace value is true, this method works a little different
-  //from mv command if the destf is a directory, it replaces the destf instead of moving under
-  //the destf. in this case, the replaced destf still preserves the original destf's permission
-  public static boolean moveFile(HiveConf conf, Path srcf, Path destf,
-      FileSystem fs, boolean replace, boolean isSrcLocal) throws HiveException {
-    boolean success = false;
-
-    //needed for perm inheritance.
-    boolean inheritPerms = HiveConf.getBoolVar(conf,
-        HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
-    HadoopShims shims = ShimLoader.getHadoopShims();
-    HadoopShims.HdfsFileStatus destStatus = null;
-    HadoopShims.HdfsEncryptionShim hdfsEncryptionShim = SessionState.get().getHdfsEncryptionShim();
-
-    // If source path is a subdirectory of the destination path:
-    //   ex: INSERT OVERWRITE DIRECTORY 'target/warehouse/dest4.out' SELECT src.value WHERE src.key >= 300;
-    //   where the staging directory is a subdirectory of the destination directory
-    // (1) Do not delete the dest dir before doing the move operation.
-    // (2) It is assumed that subdir and dir are in same encryption zone.
-    // (3) Move individual files from scr dir to dest dir.
-    boolean destIsSubDir = isSubDir(srcf, destf, fs, isSrcLocal);
-    try {
-      if (inheritPerms || replace) {
-        try{
-          destStatus = shims.getFullFileStatus(conf, fs, destf.getParent());
-          //if destf is an existing directory:
-          //if replace is true, delete followed by rename(mv) is equivalent to replace
-          //if replace is false, rename (mv) actually move the src under dest dir
-          //if destf is an existing file, rename is actually a replace, and do not need
-          // to delete the file first
-          if (replace && !destIsSubDir) {
-            LOG.debug("The path " + destf.toString() + " is deleted");
-            fs.delete(destf, true);
-          }
-        } catch (FileNotFoundException ignore) {
-          //if dest dir does not exist, any re
-          if (inheritPerms) {
-            destStatus = shims.getFullFileStatus(conf, fs, destf.getParent());
-          }
-        }
-      }
-      if (!isSrcLocal) {
-        // For NOT local src file, rename the file
-        if (hdfsEncryptionShim != null && (hdfsEncryptionShim.isPathEncrypted(srcf) || hdfsEncryptionShim.isPathEncrypted(destf))
-            && !hdfsEncryptionShim.arePathsOnSameEncryptionZone(srcf, destf))
-        {
-          LOG.info("Copying source " + srcf + " to " + destf + " because HDFS encryption zones are different.");
-          success = FileUtils.copy(srcf.getFileSystem(conf), srcf, destf.getFileSystem(conf), destf,
-              true,    // delete source
-              replace, // overwrite destination
-              conf);
-        } else {
-          if (destIsSubDir) {
-            FileStatus[] srcs = fs.listStatus(srcf, FileUtils.HIDDEN_FILES_PATH_FILTER);
-            if (srcs.length == 0) {
-              success = true; // Nothing to move.
-            }
-            for (FileStatus status : srcs) {
-              success = FileUtils.copy(srcf.getFileSystem(conf), status.getPath(), destf.getFileSystem(conf), destf,
-                  true,     // delete source
-                  replace,  // overwrite destination
-                  conf);
-
-              if (!success) {
-                throw new HiveException("Unable to move source " + status.getPath() + " to destination " + destf);
-              }
-            }
-          } else {
-            success = fs.rename(srcf, destf);
-          }
-        }
-      } else {
-        // For local src file, copy to hdfs
-        fs.copyFromLocalFile(srcf, destf);
-        success = true;
-      }
-
-      LOG.info((replace ? "Replacing src:" : "Renaming src: ") + srcf.toString()
-          + ", dest: " + destf.toString()  + ", Status:" + success);
-    } catch (IOException ioe) {
-      throw new HiveException("Unable to move source " + srcf + " to destination " + destf, ioe);
-    }
-
-    if (success && inheritPerms) {
-      try {
-        ShimLoader.getHadoopShims().setFullFileStatus(conf, destStatus, fs, destf);
-      } catch (IOException e) {
-        LOG.warn("Error setting permission of file " + destf + ": "+ e.getMessage(), e);
-      }
-    }
-    return success;
-  }
-
-  /**
-   * Copy files.  This handles building the mapping for buckets and such between the source and
-   * destination
-   * @param conf Configuration object
-   * @param srcf source directory, if bucketed should contain bucket files
-   * @param destf directory to move files into
-   * @param fs Filesystem
-   * @param isSrcLocal true if source is on local file system
-   * @param isAcid true if this is an ACID based write
-   * @param newFiles if this is non-null, a list of files that were created as a result of this
-   *                 move will be returned.
-   * @throws HiveException
-   */
-  static protected void copyFiles(HiveConf conf, Path srcf, Path destf,
-      FileSystem fs, boolean isSrcLocal, boolean isAcid, List<Path> newFiles) throws HiveException {
-    boolean inheritPerms = HiveConf.getBoolVar(conf,
-        HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
-    try {
-      // create the destination if it does not exist
-      if (!fs.exists(destf)) {
-        FileUtils.mkdir(fs, destf, inheritPerms, conf);
-      }
-    } catch (IOException e) {
-      throw new HiveException(
-          "copyFiles: error while checking/creating destination directory!!!",
-          e);
-    }
-
-    FileStatus[] srcs;
-    FileSystem srcFs;
-    try {
-      srcFs = srcf.getFileSystem(conf);
-      srcs = srcFs.globStatus(srcf);
-    } catch (IOException e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException("addFiles: filesystem error in check phase. " + e.getMessage(), e);
-    }
-    if (srcs == null) {
-      LOG.info("No sources specified to move: " + srcf);
-      return;
-      // srcs = new FileStatus[0]; Why is this needed?
-    }
-
-    // If we're moving files around for an ACID write then the rules and paths are all different.
-    // You can blame this on Owen.
-    if (isAcid) {
-      moveAcidFiles(srcFs, srcs, destf, newFiles);
-    } else {
-    // check that source and target paths exist
-      List<List<Path[]>> result = checkPaths(conf, fs, srcs, srcFs, destf, false);
-      // move it, move it
-      try {
-        for (List<Path[]> sdpairs : result) {
-          for (Path[] sdpair : sdpairs) {
-            if (!moveFile(conf, sdpair[0], sdpair[1], fs, false, isSrcLocal)) {
-              throw new IOException("Cannot move " + sdpair[0] + " to "
-                  + sdpair[1]);
-            }
-            if (newFiles != null) newFiles.add(sdpair[1]);
-          }
-        }
-      } catch (IOException e) {
-        throw new HiveException("copyFiles: error while moving files!!! " + e.getMessage(), e);
-      }
-    }
-  }
-
-  private static void moveAcidFiles(FileSystem fs, FileStatus[] stats, Path dst,
-                                    List<Path> newFiles) throws HiveException {
-    // The layout for ACID files is table|partname/base|delta/bucket
-    // We will always only be writing delta files.  In the buckets created by FileSinkOperator
-    // it will look like bucket/delta/bucket.  So we need to move that into the above structure.
-    // For the first mover there will be no delta directory, so we can move the whole directory.
-    // For everyone else we will need to just move the buckets under the existing delta
-    // directory.
-
-    Set<Path> createdDeltaDirs = new HashSet<Path>();
-    // Open the original path we've been given and find the list of original buckets
-    for (FileStatus stat : stats) {
-      Path srcPath = stat.getPath();
-
-      LOG.debug("Acid move Looking for original buckets in " + srcPath);
-
-      FileStatus[] origBucketStats = null;
-      try {
-        origBucketStats = fs.listStatus(srcPath, AcidUtils.originalBucketFilter);
-      } catch (IOException e) {
-        String msg = "Unable to look for bucket files in src path " + srcPath.toUri().toString();
-        LOG.error(msg);
-        throw new HiveException(msg, e);
-      }
-      LOG.debug("Acid move found " + origBucketStats.length + " original buckets");
-
-      for (FileStatus origBucketStat : origBucketStats) {
-        Path origBucketPath = origBucketStat.getPath();
-        LOG.debug("Acid move looking for delta files in bucket " + origBucketPath);
-
-        FileStatus[] deltaStats = null;
-        try {
-          deltaStats = fs.listStatus(origBucketPath, AcidUtils.deltaFileFilter);
-        } catch (IOException e) {
-          throw new HiveException("Unable to look for delta files in original bucket " +
-              origBucketPath.toUri().toString(), e);
-        }
-        LOG.debug("Acid move found " + deltaStats.length + " delta files");
-
-        for (FileStatus deltaStat : deltaStats) {
-          Path deltaPath = deltaStat.getPath();
-          // Create the delta directory.  Don't worry if it already exists,
-          // as that likely means another task got to it first.  Then move each of the buckets.
-          // it would be more efficient to try to move the delta with it's buckets but that is
-          // harder to make race condition proof.
-          Path deltaDest = new Path(dst, deltaPath.getName());
-          try {
-            if (!createdDeltaDirs.contains(deltaDest)) {
-              try {
-                fs.mkdirs(deltaDest);
-                createdDeltaDirs.add(deltaDest);
-              } catch (IOException swallowIt) {
-                // Don't worry about this, as it likely just means it's already been created.
-                LOG.info("Unable to create delta directory " + deltaDest +
-                    ", assuming it already exists: " + swallowIt.getMessage());
-              }
-            }
-            FileStatus[] bucketStats = fs.listStatus(deltaPath, AcidUtils.bucketFileFilter);
-            LOG.debug("Acid move found " + bucketStats.length + " bucket files");
-            for (FileStatus bucketStat : bucketStats) {
-              Path bucketSrc = bucketStat.getPath();
-              Path bucketDest = new Path(deltaDest, bucketSrc.getName());
-              LOG.info("Moving bucket " + bucketSrc.toUri().toString() + " to " +
-                  bucketDest.toUri().toString());
-              fs.rename(bucketSrc, bucketDest);
-              if (newFiles != null) newFiles.add(bucketDest);
-            }
-          } catch (IOException e) {
-            throw new HiveException("Error moving acid files " + e.getMessage(), e);
-          }
-        }
-      }
-    }
-  }
-
-
-  /**
-   * Replaces files in the partition with new data set specified by srcf. Works
-   * by renaming directory of srcf to the destination file.
-   * srcf, destf, and tmppath should resident in the same DFS, but the oldPath can be in a
-   * different DFS.
-   *
-   * @param tablePath path of the table.  Used to identify permission inheritance.
-   * @param srcf
-   *          Source directory to be renamed to tmppath. It should be a
-   *          leaf directory where the final data files reside. However it
-   *          could potentially contain subdirectories as well.
-   * @param destf
-   *          The directory where the final data needs to go
-   * @param oldPath
-   *          The directory where the old data location, need to be cleaned up.  Most of time, will be the same
-   *          as destf, unless its across FileSystem boundaries.
-   * @param isSrcLocal
-   *          If the source directory is LOCAL
-   */
-  protected static void replaceFiles(Path tablePath, Path srcf, Path destf, Path oldPath, HiveConf conf,
-          boolean isSrcLocal) throws HiveException {
-    try {
-
-      FileSystem destFs = destf.getFileSystem(conf);
-      boolean inheritPerms = HiveConf.getBoolVar(conf,
-          HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
-
-      // check if srcf contains nested sub-directories
-      FileStatus[] srcs;
-      FileSystem srcFs;
-      try {
-        srcFs = srcf.getFileSystem(conf);
-        srcs = srcFs.globStatus(srcf);
-      } catch (IOException e) {
-        throw new HiveException("Getting globStatus " + srcf.toString(), e);
-      }
-      if (srcs == null) {
-        LOG.info("No sources specified to move: " + srcf);
-        return;
-      }
-      List<List<Path[]>> result = checkPaths(conf, destFs, srcs, srcFs, destf,
-          true);
-
-      if (oldPath != null) {
-        try {
-          FileSystem fs2 = oldPath.getFileSystem(conf);
-          if (fs2.exists(oldPath)) {
-            // Do not delete oldPath if:
-            //  - destf is subdir of oldPath
-            //if ( !(fs2.equals(destf.getFileSystem(conf)) && FileUtils.isSubDir(oldPath, destf, fs2)))
-            if (FileUtils.isSubDir(oldPath, destf, fs2)) {
-              FileUtils.trashFilesUnderDir(fs2, oldPath, conf);
-            }
-            if (inheritPerms) {
-              inheritFromTable(tablePath, destf, conf, destFs);
-            }
-          }
-        } catch (Exception e) {
-          //swallow the exception
-          LOG.warn("Directory " + oldPath.toString() + " cannot be removed: " + e, e);
-        }
-      }
-
-      // rename src directory to destf
-      if (srcs.length == 1 && srcs[0].isDir()) {
-        // rename can fail if the parent doesn't exist
-        Path destfp = destf.getParent();
-        if (!destFs.exists(destfp)) {
-          boolean success = destFs.mkdirs(destfp);
-          if (!success) {
-            LOG.warn("Error creating directory " + destf.toString());
-          }
-          if (inheritPerms && success) {
-            inheritFromTable(tablePath, destfp, conf, destFs);
-          }
-        }
-
-        // Copy/move each file under the source directory to avoid to delete the destination
-        // directory if it is the root of an HDFS encryption zone.
-        for (List<Path[]> sdpairs : result) {
-          for (Path[] sdpair : sdpairs) {
-            Path destParent = sdpair[1].getParent();
-            FileSystem destParentFs = destParent.getFileSystem(conf);
-            if (!destParentFs.isDirectory(destParent)) {
-              boolean success = destFs.mkdirs(destParent);
-              if (!success) {
-                LOG.warn("Error creating directory " + destParent);
-              }
-              if (inheritPerms && success) {
-                inheritFromTable(tablePath, destParent, conf, destFs);
-              }
-            }
-            if (!moveFile(conf, sdpair[0], sdpair[1], destFs, true, isSrcLocal)) {
-              throw new IOException("Unable to move file/directory from " + sdpair[0] +
-                  " to " + sdpair[1]);
-            }
-          }
-        }
-      } else { // srcf is a file or pattern containing wildcards
-        if (!destFs.exists(destf)) {
-          boolean success = destFs.mkdirs(destf);
-          if (!success) {
-            LOG.warn("Error creating directory " + destf.toString());
-          }
-          if (inheritPerms && success) {
-            inheritFromTable(tablePath, destf, conf, destFs);
-          }
-        }
-        // srcs must be a list of files -- ensured by LoadSemanticAnalyzer
-        for (List<Path[]> sdpairs : result) {
-          for (Path[] sdpair : sdpairs) {
-            if (!moveFile(conf, sdpair[0], sdpair[1], destFs, true,
-                isSrcLocal)) {
-              throw new IOException("Error moving: " + sdpair[0] + " into: " + sdpair[1]);
-            }
-          }
-        }
-      }
-    } catch (IOException e) {
-      throw new HiveException(e.getMessage(), e);
-    }
-  }
-
-  /**
-   * This method sets all paths from tablePath to destf (including destf) to have same permission as tablePath.
-   * @param tablePath path of table
-   * @param destf path of table-subdir.
-   * @param conf
-   * @param fs
-   */
-  private static void inheritFromTable(Path tablePath, Path destf, HiveConf conf, FileSystem fs) {
-    if (!FileUtils.isSubDir(destf, tablePath, fs)) {
-      //partition may not be under the parent.
-      return;
-    }
-    HadoopShims shims = ShimLoader.getHadoopShims();
-    //Calculate all the paths from the table dir, to destf
-    //At end of this loop, currPath is table dir, and pathsToSet contain list of all those paths.
-    Path currPath = destf;
-    List<Path> pathsToSet = new LinkedList<Path>();
-    while (!currPath.equals(tablePath)) {
-      pathsToSet.add(currPath);
-      currPath = currPath.getParent();
-    }
-
-    try {
-      HadoopShims.HdfsFileStatus fullFileStatus = shims.getFullFileStatus(conf, fs, currPath);
-      for (Path pathToSet : pathsToSet) {
-        shims.setFullFileStatus(conf, fullFileStatus, fs, pathToSet);
-      }
-    } catch (Exception e) {
-      LOG.warn("Error setting permissions or group of " + destf, e);
-    }
-  }
-
-  public static boolean isHadoop1() {
-    return ShimLoader.getMajorVersion().startsWith("0.20");
-  }
-
-  public void exchangeTablePartitions(Map<String, String> partitionSpecs,
-      String sourceDb, String sourceTable, String destDb,
-      String destinationTableName) throws HiveException {
-    try {
-      getMSC().exchange_partition(partitionSpecs, sourceDb, sourceTable, destDb,
-        destinationTableName);
-    } catch (Exception ex) {
-      LOG.error(StringUtils.stringifyException(ex));
-      throw new HiveException(ex);
-    }
-  }
-
-  /**
-   * Creates a metastore client. Currently it creates only JDBC based client as
-   * File based store support is removed
-   *
-   * @returns a Meta Store Client
-   * @throws HiveMetaException
-   *           if a working client can't be created
-   */
-  private IMetaStoreClient createMetaStoreClient() throws MetaException {
-
-    HiveMetaHookLoader hookLoader = new HiveMetaHookLoader() {
+    private static ThreadLocal<Hive> hiveDB = new ThreadLocal<Hive>() {
         @Override
-        public HiveMetaHook getHook(
-          org.apache.hadoop.hive.metastore.api.Table tbl)
-          throws MetaException {
+        protected synchronized Hive initialValue() {
+            return null;
+        }
 
-          try {
-            if (tbl == null) {
-              return null;
+        @Override
+        public synchronized void remove() {
+            if (this.get() != null) {
+                this.get().close();
             }
-            HiveStorageHandler storageHandler =
-              HiveUtils.getStorageHandler(conf,
-                tbl.getParameters().get(META_TABLE_STORAGE));
-            if (storageHandler == null) {
-              return null;
+            super.remove();
+        }
+    };
+
+    // register all permanent functions. need improvement
+    static {
+        try {
+            reloadFunctions();
+        } catch (Exception e) {
+            LOG.warn("Failed to access metastore. This class should not accessed in runtime.", e);
+        }
+    }
+
+    public static void reloadFunctions() throws HiveException {
+        Hive db = Hive.get();
+        for (String dbName : db.getAllDatabases()) {
+            for (String functionName : db.getFunctions(dbName, "*")) {
+                Function function = db.getFunction(dbName, functionName);
+                try {
+                    FunctionRegistry.registerPermanentFunction(
+                            FunctionUtils.qualifyFunctionName(functionName, dbName), function.getClassName(),
+                            false, FunctionTask.toFunctionResource(function.getResourceUris()));
+                } catch (Exception e) {
+                    LOG.warn("Failed to register persistent function " +
+                            functionName + ":" + function.getClassName() + ". Ignore and continue.");
+                }
             }
-            return storageHandler.getMetaHook();
-          } catch (HiveException ex) {
+        }
+    }
+
+    public static Hive get(Configuration c, Class<?> clazz) throws HiveException {
+        return get(c instanceof HiveConf ? (HiveConf) c : new HiveConf(c, clazz));
+    }
+
+    /**
+     * Gets hive object for the current thread. If one is not initialized then a
+     * new one is created If the new configuration is different in metadata conf
+     * vars then a new one is created.
+     *
+     * @param c new Hive Configuration
+     * @return Hive object for current thread
+     * @throws HiveException
+     */
+    public static Hive get(HiveConf c) throws HiveException {
+        Hive db = hiveDB.get();
+        if (db == null ||
+                (db.metaStoreClient != null && !db.metaStoreClient.isCompatibleWith(c))) {
+            return get(c, true);
+        }
+        db.conf = c;
+        return db;
+    }
+
+    /**
+     * get a connection to metastore. see get(HiveConf) function for comments
+     *
+     * @param c            new conf
+     * @param needsRefresh if true then creates a new one
+     * @return The connection to the metastore
+     * @throws HiveException
+     */
+    public static Hive get(HiveConf c, boolean needsRefresh) throws HiveException {
+        Hive db = hiveDB.get();
+        if (db == null || needsRefresh || !db.isCurrentUserOwner()) {
+            if (db != null) {
+                LOG.debug("Creating new db. db = " + db + ", needsRefresh = " + needsRefresh +
+                        ", db.isCurrentUserOwner = " + db.isCurrentUserOwner());
+            }
+            closeCurrent();
+            c.set("fs.scheme.class", "dfs");
+            Hive newdb = new Hive(c);
+            hiveDB.set(newdb);
+            return newdb;
+        }
+        db.conf = c;
+        return db;
+    }
+
+    public static Hive get() throws HiveException {
+        Hive db = hiveDB.get();
+        if (db != null && !db.isCurrentUserOwner()) {
+            LOG.debug("Creating new db. db.isCurrentUserOwner = " + db.isCurrentUserOwner());
+            db.close();
+            db = null;
+        }
+        if (db == null) {
+            SessionState session = SessionState.get();
+            db = new Hive(session == null ? new HiveConf(Hive.class) : session.getConf());
+            hiveDB.set(db);
+        }
+        return db;
+    }
+
+    public static void set(Hive hive) {
+        hiveDB.set(hive);
+    }
+
+    public static void closeCurrent() {
+        hiveDB.remove();
+    }
+
+    /**
+     * Hive
+     *
+     * @param c
+     */
+    private Hive(HiveConf c) throws HiveException {
+        conf = c;
+    }
+
+
+    private boolean isCurrentUserOwner() throws HiveException {
+        try {
+            return owner == null || owner.equals(UserGroupInformation.getCurrentUser());
+        } catch (IOException e) {
+            throw new HiveException("Error getting current user: " + e.getMessage(), e);
+        }
+    }
+
+
+    /**
+     * closes the connection to metastore for the calling thread
+     */
+    private void close() {
+        LOG.debug("Closing current thread's connection to Hive Metastore.");
+        if (metaStoreClient != null) {
+            metaStoreClient.close();
+            metaStoreClient = null;
+        }
+    }
+
+    /**
+     * Create a database
+     *
+     * @param db
+     * @param ifNotExist if true, will ignore AlreadyExistsException exception
+     * @throws AlreadyExistsException
+     * @throws HiveException
+     */
+    public void createDatabase(Database db, boolean ifNotExist)
+            throws AlreadyExistsException, HiveException {
+        try {
+            getMSC().createDatabase(db);
+        } catch (AlreadyExistsException e) {
+            if (!ifNotExist) {
+                throw e;
+            }
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Create a Database. Raise an error if a database with the same name already exists.
+     *
+     * @param db
+     * @throws AlreadyExistsException
+     * @throws HiveException
+     */
+    public void createDatabase(Database db) throws AlreadyExistsException, HiveException {
+        createDatabase(db, false);
+    }
+
+    /**
+     * Drop a database.
+     *
+     * @param name
+     * @throws NoSuchObjectException
+     * @throws HiveException
+     * @see org.apache.hadoop.hive.metastore.HiveMetaStoreClient#dropDatabase(java.lang.String)
+     */
+    public void dropDatabase(String name) throws HiveException, NoSuchObjectException {
+        dropDatabase(name, true, false, false);
+    }
+
+    /**
+     * Drop a database
+     *
+     * @param name
+     * @param deleteData
+     * @param ignoreUnknownDb if true, will ignore NoSuchObjectException
+     * @throws HiveException
+     * @throws NoSuchObjectException
+     */
+    public void dropDatabase(String name, boolean deleteData, boolean ignoreUnknownDb)
+            throws HiveException, NoSuchObjectException {
+        dropDatabase(name, deleteData, ignoreUnknownDb, false);
+    }
+
+    /**
+     * Drop a database
+     *
+     * @param name
+     * @param deleteData
+     * @param ignoreUnknownDb if true, will ignore NoSuchObjectException
+     * @param cascade         if true, delete all tables on the DB if exists. Otherwise, the query
+     *                        will fail if table still exists.
+     * @throws HiveException
+     * @throws NoSuchObjectException
+     */
+    public void dropDatabase(String name, boolean deleteData, boolean ignoreUnknownDb, boolean cascade)
+            throws HiveException, NoSuchObjectException {
+        try {
+            getMSC().dropDatabase(name, deleteData, ignoreUnknownDb, cascade);
+        } catch (NoSuchObjectException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+
+    /**
+     * Creates a table metadata and the directory for the table data
+     *
+     * @param tableName        name of the table
+     * @param columns          list of fields of the table
+     * @param partCols         partition keys of the table
+     * @param fileInputFormat  Class of the input format of the table data file
+     * @param fileOutputFormat Class of the output format of the table data file
+     * @throws HiveException thrown if the args are invalid or if the metadata or the data
+     *                       directory couldn't be created
+     */
+    public void createTable(String tableName, List<String> columns,
+                            List<String> partCols, Class<? extends InputFormat> fileInputFormat,
+                            Class<?> fileOutputFormat) throws HiveException {
+        this.createTable(tableName, columns, partCols, fileInputFormat,
+                fileOutputFormat, -1, null);
+    }
+
+    /**
+     * Creates a table metadata and the directory for the table data
+     *
+     * @param tableName        name of the table
+     * @param columns          list of fields of the table
+     * @param partCols         partition keys of the table
+     * @param fileInputFormat  Class of the input format of the table data file
+     * @param fileOutputFormat Class of the output format of the table data file
+     * @param bucketCount      number of buckets that each partition (or the table itself) should
+     *                         be divided into
+     * @throws HiveException thrown if the args are invalid or if the metadata or the data
+     *                       directory couldn't be created
+     */
+    public void createTable(String tableName, List<String> columns,
+                            List<String> partCols, Class<? extends InputFormat> fileInputFormat,
+                            Class<?> fileOutputFormat, int bucketCount, List<String> bucketCols)
+            throws HiveException {
+        createTable(tableName, columns, partCols, fileInputFormat, fileOutputFormat, bucketCount,
+                bucketCols, null);
+    }
+
+    /**
+     * Create a table metadata and the directory for the table data
+     *
+     * @param tableName        table name
+     * @param columns          list of fields of the table
+     * @param partCols         partition keys of the table
+     * @param fileInputFormat  Class of the input format of the table data file
+     * @param fileOutputFormat Class of the output format of the table data file
+     * @param bucketCount      number of buckets that each partition (or the table itself) should be
+     *                         divided into
+     * @param bucketCols       Bucket columns
+     * @param parameters       Parameters for the table
+     * @throws HiveException
+     */
+    public void createTable(String tableName, List<String> columns, List<String> partCols,
+                            Class<? extends InputFormat> fileInputFormat,
+                            Class<?> fileOutputFormat, int bucketCount, List<String> bucketCols,
+                            Map<String, String> parameters) throws HiveException {
+        if (columns == null) {
+            throw new HiveException("columns not specified for table " + tableName);
+        }
+
+        Table tbl = newTable(tableName);
+        tbl.setInputFormatClass(fileInputFormat.getName());
+        tbl.setOutputFormatClass(fileOutputFormat.getName());
+
+        for (String col : columns) {
+            FieldSchema field = new FieldSchema(col, STRING_TYPE_NAME, "default");
+            tbl.getCols().add(field);
+        }
+
+        if (partCols != null) {
+            for (String partCol : partCols) {
+                FieldSchema part = new FieldSchema();
+                part.setName(partCol);
+                part.setType(STRING_TYPE_NAME); // default partition key
+                tbl.getPartCols().add(part);
+            }
+        }
+        tbl.setSerializationLib(LazySimpleSerDe.class.getName());
+        tbl.setNumBuckets(bucketCount);
+        tbl.setBucketCols(bucketCols);
+        if (parameters != null) {
+            tbl.setParamters(parameters);
+        }
+        createTable(tbl);
+    }
+
+    /**
+     * Updates the existing table metadata with the new metadata.
+     *
+     * @param tblName name of the existing table
+     * @param newTbl  new name of the table. could be the old name
+     * @throws InvalidOperationException if the changes in metadata is not acceptable
+     * @throws TException
+     */
+    public void alterTable(String tblName, Table newTbl)
+            throws InvalidOperationException, HiveException {
+        alterTable(tblName, newTbl, false);
+    }
+
+    public void alterTable(String tblName, Table newTbl, boolean cascade)
+            throws InvalidOperationException, HiveException {
+        String[] names = Utilities.getDbTableName(tblName);
+        try {
+            // Remove the DDL_TIME so it gets refreshed
+            if (newTbl.getParameters() != null) {
+                newTbl.getParameters().remove(hive_metastoreConstants.DDL_TIME);
+            }
+            newTbl.checkValidity();
+            getMSC().alter_table(names[0], names[1], newTbl.getTTable(), cascade);
+        } catch (MetaException e) {
+            throw new HiveException("Unable to alter table. " + e.getMessage(), e);
+        } catch (TException e) {
+            throw new HiveException("Unable to alter table. " + e.getMessage(), e);
+        }
+    }
+
+    public void alterIndex(String baseTableName, String indexName, Index newIdx)
+            throws InvalidOperationException, HiveException {
+        String[] names = Utilities.getDbTableName(baseTableName);
+        alterIndex(names[0], names[1], indexName, newIdx);
+    }
+
+    /**
+     * Updates the existing index metadata with the new metadata.
+     *
+     * @param idxName name of the existing index
+     * @param newIdx  new name of the index. could be the old name
+     * @throws InvalidOperationException if the changes in metadata is not acceptable
+     * @throws TException
+     */
+    public void alterIndex(String dbName, String baseTblName, String idxName, Index newIdx)
+            throws InvalidOperationException, HiveException {
+        try {
+            getMSC().alter_index(dbName, baseTblName, idxName, newIdx);
+        } catch (MetaException e) {
+            throw new HiveException("Unable to alter index. " + e.getMessage(), e);
+        } catch (TException e) {
+            throw new HiveException("Unable to alter index. " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Updates the existing partition metadata with the new metadata.
+     *
+     * @param tblName name of the existing table
+     * @param newPart new partition
+     * @throws InvalidOperationException if the changes in metadata is not acceptable
+     * @throws TException
+     */
+    public void alterPartition(String tblName, Partition newPart)
+            throws InvalidOperationException, HiveException {
+        String[] names = Utilities.getDbTableName(tblName);
+        alterPartition(names[0], names[1], newPart);
+    }
+
+    /**
+     * Updates the existing partition metadata with the new metadata.
+     *
+     * @param dbName  name of the exiting table's database
+     * @param tblName name of the existing table
+     * @param newPart new partition
+     * @throws InvalidOperationException if the changes in metadata is not acceptable
+     * @throws TException
+     */
+    public void alterPartition(String dbName, String tblName, Partition newPart)
+            throws InvalidOperationException, HiveException {
+        try {
+            // Remove the DDL time so that it gets refreshed
+            if (newPart.getParameters() != null) {
+                newPart.getParameters().remove(hive_metastoreConstants.DDL_TIME);
+            }
+            newPart.checkValidity();
+            getMSC().alter_partition(dbName, tblName, newPart.getTPartition());
+
+        } catch (MetaException e) {
+            throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
+        } catch (TException e) {
+            throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Updates the existing table metadata with the new metadata.
+     *
+     * @param tblName  name of the existing table
+     * @param newParts new partitions
+     * @throws InvalidOperationException if the changes in metadata is not acceptable
+     * @throws TException
+     */
+    public void alterPartitions(String tblName, List<Partition> newParts)
+            throws InvalidOperationException, HiveException {
+        String[] names = Utilities.getDbTableName(tblName);
+        List<org.apache.hadoop.hive.metastore.api.Partition> newTParts =
+                new ArrayList<org.apache.hadoop.hive.metastore.api.Partition>();
+        try {
+            // Remove the DDL time so that it gets refreshed
+            for (Partition tmpPart : newParts) {
+                if (tmpPart.getParameters() != null) {
+                    tmpPart.getParameters().remove(hive_metastoreConstants.DDL_TIME);
+                }
+                newTParts.add(tmpPart.getTPartition());
+            }
+            getMSC().alter_partitions(names[0], names[1], newTParts);
+        } catch (MetaException e) {
+            throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
+        } catch (TException e) {
+            throw new HiveException("Unable to alter partition. " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Rename a old partition to new partition
+     *
+     * @param tbl         existing table
+     * @param oldPartSpec spec of old partition
+     * @param newPart     new partition
+     * @throws InvalidOperationException if the changes in metadata is not acceptable
+     * @throws TException
+     */
+    public void renamePartition(Table tbl, Map<String, String> oldPartSpec, Partition newPart)
+            throws HiveException {
+        try {
+            Map<String, String> newPartSpec = newPart.getSpec();
+            if (oldPartSpec.keySet().size() != tbl.getPartCols().size()
+                    || newPartSpec.keySet().size() != tbl.getPartCols().size()) {
+                throw new HiveException("Unable to rename partition to the same name: number of partition cols don't match. ");
+            }
+            if (!oldPartSpec.keySet().equals(newPartSpec.keySet())) {
+                throw new HiveException("Unable to rename partition to the same name: old and new partition cols don't match. ");
+            }
+            List<String> pvals = new ArrayList<String>();
+
+            for (FieldSchema field : tbl.getPartCols()) {
+                String val = oldPartSpec.get(field.getName());
+                if (val == null || val.length() == 0) {
+                    throw new HiveException("get partition: Value for key "
+                            + field.getName() + " is null or empty");
+                } else if (val != null) {
+                    pvals.add(val);
+                }
+            }
+            getMSC().renamePartition(tbl.getDbName(), tbl.getTableName(), pvals,
+                    newPart.getTPartition());
+
+        } catch (InvalidOperationException e) {
+            throw new HiveException("Unable to rename partition. " + e.getMessage(), e);
+        } catch (MetaException e) {
+            throw new HiveException("Unable to rename partition. " + e.getMessage(), e);
+        } catch (TException e) {
+            throw new HiveException("Unable to rename partition. " + e.getMessage(), e);
+        }
+    }
+
+    public void alterDatabase(String dbName, Database db)
+            throws HiveException {
+        try {
+            getMSC().alterDatabase(dbName, db);
+        } catch (MetaException e) {
+            throw new HiveException("Unable to alter database " + dbName + ". " + e.getMessage(), e);
+        } catch (NoSuchObjectException e) {
+            throw new HiveException("Database " + dbName + " does not exists.", e);
+        } catch (TException e) {
+            throw new HiveException("Unable to alter database " + dbName + ". " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Creates the table with the give objects
+     *
+     * @param tbl a table object
+     * @throws HiveException
+     */
+    public void createTable(Table tbl) throws HiveException {
+        createTable(tbl, false);
+    }
+
+    /**
+     * Creates the table with the give objects
+     *
+     * @param tbl         a table object
+     * @param ifNotExists if true, ignore AlreadyExistsException
+     * @throws HiveException
+     */
+    public void createTable(Table tbl, boolean ifNotExists) throws HiveException {
+        try {
+            if (tbl.getDbName() == null || "".equals(tbl.getDbName().trim())) {
+                tbl.setDbName(SessionState.get().getCurrentDatabase());
+            }
+            if (tbl.getCols().size() == 0 || tbl.getSd().getColsSize() == 0) {
+                tbl.setFields(MetaStoreUtils.getFieldsFromDeserializer(tbl.getTableName(),
+                        tbl.getDeserializer()));
+            }
+            tbl.checkValidity();
+            if (tbl.getParameters() != null) {
+                tbl.getParameters().remove(hive_metastoreConstants.DDL_TIME);
+            }
+            org.apache.hadoop.hive.metastore.api.Table tTbl = tbl.getTTable();
+            PrincipalPrivilegeSet principalPrivs = new PrincipalPrivilegeSet();
+            SessionState ss = SessionState.get();
+            if (ss != null) {
+                CreateTableAutomaticGrant grants = ss.getCreateTableGrants();
+                if (grants != null) {
+                    principalPrivs.setUserPrivileges(grants.getUserGrants());
+                    principalPrivs.setGroupPrivileges(grants.getGroupGrants());
+                    principalPrivs.setRolePrivileges(grants.getRoleGrants());
+                    tTbl.setPrivileges(principalPrivs);
+                }
+            }
+            getMSC().createTable(tTbl);
+        } catch (AlreadyExistsException e) {
+            if (!ifNotExists) {
+                throw new HiveException(e);
+            }
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * @param tableName         table name
+     * @param indexName         index name
+     * @param indexHandlerClass index handler class
+     * @param indexedCols       index columns
+     * @param indexTblName      index table's name
+     * @param deferredRebuild   referred build index table's data
+     * @param inputFormat       input format
+     * @param outputFormat      output format
+     * @param serde
+     * @param storageHandler    index table's storage handler
+     * @param location          location
+     * @param idxProps          idx
+     * @param serdeProps        serde properties
+     * @param collItemDelim
+     * @param fieldDelim
+     * @param fieldEscape
+     * @param lineDelim
+     * @param mapKeyDelim
+     * @throws HiveException
+     */
+    public void createIndex(String tableName, String indexName, String indexHandlerClass,
+                            List<String> indexedCols, String indexTblName, boolean deferredRebuild,
+                            String inputFormat, String outputFormat, String serde,
+                            String storageHandler, String location,
+                            Map<String, String> idxProps, Map<String, String> tblProps, Map<String, String> serdeProps,
+                            String collItemDelim, String fieldDelim, String fieldEscape,
+                            String lineDelim, String mapKeyDelim, String indexComment)
+            throws HiveException {
+
+        try {
+            String tdname = Utilities.getDatabaseName(tableName);
+            String idname = Utilities.getDatabaseName(indexTblName);
+            if (!idname.equals(tdname)) {
+                throw new HiveException("Index on different database (" + idname
+                        + ") from base table (" + tdname + ") is not supported.");
+            }
+
+            Index old_index = null;
+            try {
+                old_index = getIndex(tableName, indexName);
+            } catch (Exception e) {
+            }
+            if (old_index != null) {
+                throw new HiveException("Index " + indexName + " already exists on table " + tableName);
+            }
+
+            org.apache.hadoop.hive.metastore.api.Table baseTbl = getTable(tableName).getTTable();
+            if (baseTbl.getTableType() == TableType.VIRTUAL_VIEW.toString()) {
+                throw new HiveException("tableName=" + tableName + " is a VIRTUAL VIEW. Index on VIRTUAL VIEW is not supported.");
+            }
+            if (baseTbl.isTemporary()) {
+                throw new HiveException("tableName=" + tableName
+                        + " is a TEMPORARY TABLE. Index on TEMPORARY TABLE is not supported.");
+            }
+
+            org.apache.hadoop.hive.metastore.api.Table temp = null;
+            try {
+                temp = getTable(indexTblName).getTTable();
+            } catch (Exception e) {
+            }
+            if (temp != null) {
+                throw new HiveException("Table name " + indexTblName + " already exists. Choose another name.");
+            }
+
+            SerDeInfo serdeInfo = new SerDeInfo();
+            serdeInfo.setName(indexTblName);
+
+            if (serde != null) {
+                serdeInfo.setSerializationLib(serde);
+            } else {
+                if (storageHandler == null) {
+                    serdeInfo.setSerializationLib(org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.class.getName());
+                } else {
+                    HiveStorageHandler sh = HiveUtils.getStorageHandler(getConf(), storageHandler);
+                    String serDeClassName = sh.getSerDeClass().getName();
+                    serdeInfo.setSerializationLib(serDeClassName);
+                }
+            }
+
+            serdeInfo.setParameters(new HashMap<String, String>());
+            if (fieldDelim != null) {
+                serdeInfo.getParameters().put(FIELD_DELIM, fieldDelim);
+                serdeInfo.getParameters().put(SERIALIZATION_FORMAT, fieldDelim);
+            }
+            if (fieldEscape != null) {
+                serdeInfo.getParameters().put(ESCAPE_CHAR, fieldEscape);
+            }
+            if (collItemDelim != null) {
+                serdeInfo.getParameters().put(COLLECTION_DELIM, collItemDelim);
+            }
+            if (mapKeyDelim != null) {
+                serdeInfo.getParameters().put(MAPKEY_DELIM, mapKeyDelim);
+            }
+            if (lineDelim != null) {
+                serdeInfo.getParameters().put(LINE_DELIM, lineDelim);
+            }
+
+            if (serdeProps != null) {
+                Iterator<Entry<String, String>> iter = serdeProps.entrySet()
+                        .iterator();
+                while (iter.hasNext()) {
+                    Entry<String, String> m = iter.next();
+                    serdeInfo.getParameters().put(m.getKey(), m.getValue());
+                }
+            }
+
+            List<FieldSchema> indexTblCols = new ArrayList<FieldSchema>();
+            List<Order> sortCols = new ArrayList<Order>();
+            int k = 0;
+            Table metaBaseTbl = new Table(baseTbl);
+            for (int i = 0; i < metaBaseTbl.getCols().size(); i++) {
+                FieldSchema col = metaBaseTbl.getCols().get(i);
+                if (indexedCols.contains(col.getName())) {
+                    indexTblCols.add(col);
+                    sortCols.add(new Order(col.getName(), 1));
+                    k++;
+                }
+            }
+            if (k != indexedCols.size()) {
+                throw new RuntimeException(
+                        "Check the index columns, they should appear in the table being indexed.");
+            }
+
+            int time = (int) (System.currentTimeMillis() / 1000);
+            org.apache.hadoop.hive.metastore.api.Table tt = null;
+            HiveIndexHandler indexHandler = HiveUtils.getIndexHandler(this.getConf(), indexHandlerClass);
+
+            String itname = Utilities.getTableName(indexTblName);
+            if (indexHandler.usesIndexTable()) {
+                tt = new org.apache.hadoop.hive.ql.metadata.Table(idname, itname).getTTable();
+                List<FieldSchema> partKeys = baseTbl.getPartitionKeys();
+                tt.setPartitionKeys(partKeys);
+                tt.setTableType(TableType.INDEX_TABLE.toString());
+                if (tblProps != null) {
+                    for (Entry<String, String> prop : tblProps.entrySet()) {
+                        tt.putToParameters(prop.getKey(), prop.getValue());
+                    }
+                }
+                SessionState ss = SessionState.get();
+                CreateTableAutomaticGrant grants;
+                if (ss != null && ((grants = ss.getCreateTableGrants()) != null)) {
+                    PrincipalPrivilegeSet principalPrivs = new PrincipalPrivilegeSet();
+                    principalPrivs.setUserPrivileges(grants.getUserGrants());
+                    principalPrivs.setGroupPrivileges(grants.getGroupGrants());
+                    principalPrivs.setRolePrivileges(grants.getRoleGrants());
+                    tt.setPrivileges(principalPrivs);
+                }
+            }
+
+            if (!deferredRebuild) {
+                throw new RuntimeException("Please specify deferred rebuild using \" WITH DEFERRED REBUILD \".");
+            }
+
+            StorageDescriptor indexSd = new StorageDescriptor(
+                    indexTblCols,
+                    location,
+                    inputFormat,
+                    outputFormat,
+                    false/*compressed - not used*/,
+                    -1/*numBuckets - default is -1 when the table has no buckets*/,
+                    serdeInfo,
+                    null/*bucketCols*/,
+                    sortCols,
+                    null/*parameters*/);
+
+            String ttname = Utilities.getTableName(tableName);
+            Index indexDesc = new Index(indexName, indexHandlerClass, tdname, ttname, time, time, itname,
+                    indexSd, new HashMap<String, String>(), deferredRebuild);
+            if (indexComment != null) {
+                indexDesc.getParameters().put("comment", indexComment);
+            }
+
+            if (idxProps != null) {
+                indexDesc.getParameters().putAll(idxProps);
+            }
+
+            indexHandler.analyzeIndexDefinition(baseTbl, indexDesc, tt);
+
+            this.getMSC().createIndex(indexDesc, tt);
+
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public Index getIndex(String baseTableName, String indexName) throws HiveException {
+        String[] names = Utilities.getDbTableName(baseTableName);
+        return this.getIndex(names[0], names[1], indexName);
+    }
+
+    public Index getIndex(String dbName, String baseTableName,
+                          String indexName) throws HiveException {
+        try {
+            return this.getMSC().getIndex(dbName, baseTableName, indexName);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public boolean dropIndex(String baseTableName, String index_name,
+                             boolean throwException, boolean deleteData) throws HiveException {
+        String[] names = Utilities.getDbTableName(baseTableName);
+        return dropIndex(names[0], names[1], index_name, throwException, deleteData);
+    }
+
+    public boolean dropIndex(String db_name, String tbl_name, String index_name,
+                             boolean throwException, boolean deleteData) throws HiveException {
+        try {
+            return getMSC().dropIndex(db_name, tbl_name, index_name, deleteData);
+        } catch (NoSuchObjectException e) {
+            if (throwException) {
+                throw new HiveException("Index " + index_name + " doesn't exist. ", e);
+            }
+            return false;
+        } catch (Exception e) {
+            throw new HiveException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Drops table along with the data in it. If the table doesn't exist then it
+     * is a no-op. If ifPurge option is specified it is passed to the
+     * hdfs command that removes table data from warehouse to make it skip trash.
+     *
+     * @param tableName table to drop
+     * @param ifPurge   completely purge the table (skipping trash) while removing data from warehouse
+     * @throws HiveException thrown if the drop fails
+     */
+    public void dropTable(String tableName, boolean ifPurge) throws HiveException {
+        String[] names = Utilities.getDbTableName(tableName);
+        dropTable(names[0], names[1], true, true, ifPurge);
+    }
+
+    /**
+     * Drops table along with the data in it. If the table doesn't exist then it
+     * is a no-op
+     *
+     * @param tableName table to drop
+     * @throws HiveException thrown if the drop fails
+     */
+    public void dropTable(String tableName) throws HiveException {
+        dropTable(tableName, false);
+    }
+
+    /**
+     * Drops table along with the data in it. If the table doesn't exist then it
+     * is a no-op
+     *
+     * @param dbName    database where the table lives
+     * @param tableName table to drop
+     * @throws HiveException thrown if the drop fails
+     */
+    public void dropTable(String dbName, String tableName) throws HiveException {
+        dropTable(dbName, tableName, true, true, false);
+    }
+
+    /**
+     * Drops the table.
+     *
+     * @param dbName
+     * @param tableName
+     * @param deleteData       deletes the underlying data along with metadata
+     * @param ignoreUnknownTab an exception is thrown if this is false and the table doesn't exist
+     * @throws HiveException
+     */
+    public void dropTable(String dbName, String tableName, boolean deleteData,
+                          boolean ignoreUnknownTab) throws HiveException {
+        dropTable(dbName, tableName, deleteData, ignoreUnknownTab, false);
+    }
+
+    /**
+     * Drops the table.
+     *
+     * @param dbName
+     * @param tableName
+     * @param deleteData       deletes the underlying data along with metadata
+     * @param ignoreUnknownTab an exception is thrown if this is false and the table doesn't exist
+     * @param ifPurge          completely purge the table skipping trash while removing data from warehouse
+     * @throws HiveException
+     */
+    public void dropTable(String dbName, String tableName, boolean deleteData,
+                          boolean ignoreUnknownTab, boolean ifPurge) throws HiveException {
+        try {
+            getMSC().dropTable(dbName, tableName, deleteData, ignoreUnknownTab, ifPurge);
+        } catch (NoSuchObjectException e) {
+            if (!ignoreUnknownTab) {
+                throw new HiveException(e);
+            }
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public HiveConf getConf() {
+        return (conf);
+    }
+
+    /**
+     * Returns metadata for the table named tableName
+     *
+     * @param tableName the name of the table
+     * @return the table metadata
+     * @throws HiveException if there's an internal error or if the
+     *                       table doesn't exist
+     */
+    public Table getTable(final String tableName) throws HiveException {
+        return this.getTable(tableName, true);
+    }
+
+    /**
+     * Returns metadata for the table named tableName
+     *
+     * @param tableName      the name of the table
+     * @param throwException controls whether an exception is thrown or a returns a null
+     * @return the table metadata
+     * @throws HiveException if there's an internal error or if the
+     *                       table doesn't exist
+     */
+    public Table getTable(final String tableName, boolean throwException) throws HiveException {
+        String[] names = Utilities.getDbTableName(tableName);
+        return this.getTable(names[0], names[1], throwException);
+    }
+
+    /**
+     * Returns metadata of the table
+     *
+     * @param dbName    the name of the database
+     * @param tableName the name of the table
+     * @return the table
+     * @throws HiveException if there's an internal error or if the table doesn't exist
+     */
+    public Table getTable(final String dbName, final String tableName) throws HiveException {
+        if (tableName.contains(".")) {
+            String[] names = Utilities.getDbTableName(tableName);
+            return this.getTable(names[0], names[1], true);
+        } else {
+            return this.getTable(dbName, tableName, true);
+        }
+    }
+
+    /**
+     * Returns metadata of the table
+     *
+     * @param dbName         the name of the database
+     * @param tableName      the name of the table
+     * @param throwException controls whether an exception is thrown or a returns a null
+     * @return the table or if throwException is false a null value.
+     * @throws HiveException
+     */
+    public Table getTable(final String dbName, final String tableName,
+                          boolean throwException) throws HiveException {
+
+        if (tableName == null || tableName.equals("")) {
+            throw new HiveException("empty table creation??");
+        }
+
+        // Get the table from metastore
+        org.apache.hadoop.hive.metastore.api.Table tTable = null;
+        try {
+            tTable = getMSC().getTable(dbName, tableName);
+        } catch (NoSuchObjectException e) {
+            if (throwException) {
+                LOG.error("Table " + tableName + " not found: " + e.getMessage());
+                throw new InvalidTableException(tableName);
+            }
+            return null;
+        } catch (Exception e) {
+            throw new HiveException("Unable to fetch table " + tableName + ". " + e.getMessage(), e);
+        }
+
+        // For non-views, we need to do some extra fixes
+        if (!TableType.VIRTUAL_VIEW.toString().equals(tTable.getTableType())) {
+            // Fix the non-printable chars
+            Map<String, String> parameters = tTable.getSd().getParameters();
+            String sf = parameters.get(SERIALIZATION_FORMAT);
+            if (sf != null) {
+                char[] b = sf.toCharArray();
+                if ((b.length == 1) && (b[0] < 10)) { // ^A, ^B, ^C, ^D, \t
+                    parameters.put(SERIALIZATION_FORMAT, Integer.toString(b[0]));
+                }
+            }
+
+            // Use LazySimpleSerDe for MetadataTypedColumnsetSerDe.
+            // NOTE: LazySimpleSerDe does not support tables with a single column of
+            // col
+            // of type "array<string>". This happens when the table is created using
+            // an
+            // earlier version of Hive.
+            if (org.apache.hadoop.hive.serde2.MetadataTypedColumnsetSerDe.class
+                    .getName().equals(
+                            tTable.getSd().getSerdeInfo().getSerializationLib())
+                    && tTable.getSd().getColsSize() > 0
+                    && tTable.getSd().getCols().get(0).getType().indexOf('<') == -1) {
+                tTable.getSd().getSerdeInfo().setSerializationLib(
+                        org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe.class.getName());
+            }
+        }
+
+        return new Table(tTable);
+    }
+
+    /**
+     * Get all table names for the current database.
+     *
+     * @return List of table names
+     * @throws HiveException
+     */
+    public List<String> getAllTables() throws HiveException {
+        return getAllTables(SessionState.get().getCurrentDatabase());
+    }
+
+    /**
+     * Get all table names for the specified database.
+     *
+     * @param dbName
+     * @return List of table names
+     * @throws HiveException
+     */
+    public List<String> getAllTables(String dbName) throws HiveException {
+        return getTablesByPattern(dbName, ".*");
+    }
+
+    /**
+     * Returns all existing tables from default database which match the given
+     * pattern. The matching occurs as per Java regular expressions
+     *
+     * @param tablePattern java re pattern
+     * @return list of table names
+     * @throws HiveException
+     */
+    public List<String> getTablesByPattern(String tablePattern) throws HiveException {
+        return getTablesByPattern(SessionState.get().getCurrentDatabase(),
+                tablePattern);
+    }
+
+    /**
+     * Returns all existing tables from the specified database which match the given
+     * pattern. The matching occurs as per Java regular expressions.
+     *
+     * @param dbName
+     * @param tablePattern
+     * @return list of table names
+     * @throws HiveException
+     */
+    public List<String> getTablesByPattern(String dbName, String tablePattern) throws HiveException {
+        try {
+            return getMSC().getTables(dbName, tablePattern);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Returns all existing tables from the given database which match the given
+     * pattern. The matching occurs as per Java regular expressions
+     *
+     * @param database     the database name
+     * @param tablePattern java re pattern
+     * @return list of table names
+     * @throws HiveException
+     */
+    public List<String> getTablesForDb(String database, String tablePattern)
+            throws HiveException {
+        try {
+            return getMSC().getTables(database, tablePattern);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Get all existing database names.
+     *
+     * @return List of database names.
+     * @throws HiveException
+     */
+    public List<String> getAllDatabases() throws HiveException {
+        try {
+            return getMSC().getAllDatabases();
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Get all existing databases that match the given
+     * pattern. The matching occurs as per Java regular expressions
+     *
+     * @param databasePattern java re pattern
+     * @return list of database names
+     * @throws HiveException
+     */
+    public List<String> getDatabasesByPattern(String databasePattern) throws HiveException {
+        try {
+            return getMSC().getDatabases(databasePattern);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public boolean grantPrivileges(PrivilegeBag privileges)
+            throws HiveException {
+        try {
+            return getMSC().grant_privileges(privileges);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * @param privileges a bag of privileges
+     * @return true on success
+     * @throws HiveException
+     */
+    public boolean revokePrivileges(PrivilegeBag privileges, boolean grantOption)
+            throws HiveException {
+        try {
+            return getMSC().revoke_privileges(privileges, grantOption);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Query metadata to see if a database with the given name already exists.
+     *
+     * @param dbName
+     * @return true if a database with the given name already exists, false if
+     * does not exist.
+     * @throws HiveException
+     */
+    public boolean databaseExists(String dbName) throws HiveException {
+        return getDatabase(dbName) != null;
+    }
+
+    /**
+     * Get the database by name.
+     *
+     * @param dbName the name of the database.
+     * @return a Database object if this database exists, null otherwise.
+     * @throws HiveException
+     */
+    public Database getDatabase(String dbName) throws HiveException {
+        try {
+            return getMSC().getDatabase(dbName);
+        } catch (NoSuchObjectException e) {
+            return null;
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Get the Database object for current database
+     *
+     * @return a Database object if this database exists, null otherwise.
+     * @throws HiveException
+     */
+    public Database getDatabaseCurrent() throws HiveException {
+        String currentDb = SessionState.get().getCurrentDatabase();
+        return getDatabase(currentDb);
+    }
+
+    public void loadPartition(Path loadPath, String tableName,
+                              Map<String, String> partSpec, boolean replace, boolean holdDDLTime,
+                              boolean inheritTableSpecs, boolean isSkewedStoreAsSubdir,
+                              boolean isSrcLocal, boolean isAcid) throws HiveException {
+        Table tbl = getTable(tableName);
+        loadPartition(loadPath, tbl, partSpec, replace, holdDDLTime, inheritTableSpecs,
+                isSkewedStoreAsSubdir, isSrcLocal, isAcid);
+    }
+
+    /**
+     * Load a directory into a Hive Table Partition - Alters existing content of
+     * the partition with the contents of loadPath. - If the partition does not
+     * exist - one is created - files in loadPath are moved into Hive. But the
+     * directory itself is not removed.
+     *
+     * @param loadPath          Directory containing files to load into Table
+     * @param tbl               name of table to be loaded.
+     * @param partSpec          defines which partition needs to be loaded
+     * @param replace           if true - replace files in the partition, otherwise add files to
+     *                          the partition
+     * @param holdDDLTime       if true, force [re]create the partition
+     * @param inheritTableSpecs if true, on [re]creating the partition, take the
+     *                          location/inputformat/outputformat/serde details from table spec
+     * @param isSrcLocal        If the source directory is LOCAL
+     * @param isAcid            true if this is an ACID operation
+     */
+    public Partition loadPartition(Path loadPath, Table tbl,
+                                   Map<String, String> partSpec, boolean replace, boolean holdDDLTime,
+                                   boolean inheritTableSpecs, boolean isSkewedStoreAsSubdir,
+                                   boolean isSrcLocal, boolean isAcid) throws HiveException {
+        Path tblDataLocationPath = tbl.getDataLocation();
+        Partition newTPart = null;
+        try {
+            /**
+             * Move files before creating the partition since down stream processes
+             * check for existence of partition in metadata before accessing the data.
+             * If partition is created before data is moved, downstream waiting
+             * processes might move forward with partial data
+             */
+
+            Partition oldPart = getPartition(tbl, partSpec, false);
+            Path oldPartPath = null;
+            if (oldPart != null) {
+                oldPartPath = oldPart.getDataLocation();
+            }
+
+            Path newPartPath = null;
+
+            if (inheritTableSpecs) {
+                Path partPath = new Path(tbl.getDataLocation(),
+                        Warehouse.makePartPath(partSpec));
+                newPartPath = new Path(tblDataLocationPath.toUri().getScheme(), tblDataLocationPath.toUri().getAuthority(),
+                        partPath.toUri().getPath());
+
+                if (oldPart != null) {
+                    /*
+                     * If we are moving the partition across filesystem boundaries
+                     * inherit from the table properties. Otherwise (same filesystem) use the
+                     * original partition location.
+                     *
+                     * See: HIVE-1707 and HIVE-2117 for background
+                     */
+                    FileSystem oldPartPathFS = oldPartPath.getFileSystem(getConf());
+                    FileSystem loadPathFS = loadPath.getFileSystem(getConf());
+                    if (FileUtils.equalsFileSystem(oldPartPathFS, loadPathFS)) {
+                        newPartPath = oldPartPath;
+                    }
+                }
+            } else {
+                newPartPath = oldPartPath;
+            }
+
+            List<Path> newFiles = null;
+            if (replace) {
+                Hive.replaceFiles(tbl.getPath(), loadPath, newPartPath, oldPartPath, getConf(),
+                        isSrcLocal);
+            } else {
+                newFiles = new ArrayList<Path>();
+                FileSystem fs = tbl.getDataLocation().getFileSystem(conf);
+                Hive.copyFiles(conf, loadPath, newPartPath, fs, isSrcLocal, isAcid, newFiles);
+            }
+
+            boolean forceCreate = (!holdDDLTime) ? true : false;
+            newTPart = getPartition(tbl, partSpec, forceCreate, newPartPath.toString(),
+                    inheritTableSpecs, newFiles);
+            // recreate the partition if it existed before
+            if (!holdDDLTime) {
+                if (isSkewedStoreAsSubdir) {
+                    org.apache.hadoop.hive.metastore.api.Partition newCreatedTpart = newTPart.getTPartition();
+                    SkewedInfo skewedInfo = newCreatedTpart.getSd().getSkewedInfo();
+                    /* Construct list bucketing location mappings from sub-directory name. */
+                    Map<List<String>, String> skewedColValueLocationMaps = constructListBucketingLocationMap(
+                            newPartPath, skewedInfo);
+                    /* Add list bucketing location mappings. */
+                    skewedInfo.setSkewedColValueLocationMaps(skewedColValueLocationMaps);
+                    newCreatedTpart.getSd().setSkewedInfo(skewedInfo);
+                    alterPartition(tbl.getDbName(), tbl.getTableName(), new Partition(tbl, newCreatedTpart));
+                    newTPart = getPartition(tbl, partSpec, true, newPartPath.toString(), inheritTableSpecs,
+                            newFiles);
+                    return new Partition(tbl, newCreatedTpart);
+                }
+            }
+        } catch (IOException e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        } catch (MetaException e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        } catch (InvalidOperationException e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        return newTPart;
+    }
+
+    /**
+     * Walk through sub-directory tree to construct list bucketing location map.
+     *
+     * @param fSta
+     * @param fSys
+     * @param skewedColValueLocationMaps
+     * @param newPartPath
+     * @param skewedInfo
+     * @throws IOException
+     */
+    private void walkDirTree(FileStatus fSta, FileSystem fSys,
+                             Map<List<String>, String> skewedColValueLocationMaps, Path newPartPath, SkewedInfo skewedInfo)
+            throws IOException {
+        /* Base Case. It's leaf. */
+        if (!fSta.isDir()) {
+            /* construct one location map if not exists. */
+            constructOneLBLocationMap(fSta, skewedColValueLocationMaps, newPartPath, skewedInfo);
+            return;
+        }
+
+        /* dfs. */
+        FileStatus[] children = fSys.listStatus(fSta.getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
+        if (children != null) {
+            for (FileStatus child : children) {
+                walkDirTree(child, fSys, skewedColValueLocationMaps, newPartPath, skewedInfo);
+            }
+        }
+    }
+
+    /**
+     * Construct a list bucketing location map
+     *
+     * @param fSta
+     * @param skewedColValueLocationMaps
+     * @param newPartPath
+     * @param skewedInfo
+     */
+    private void constructOneLBLocationMap(FileStatus fSta,
+                                           Map<List<String>, String> skewedColValueLocationMaps,
+                                           Path newPartPath, SkewedInfo skewedInfo) {
+        Path lbdPath = fSta.getPath().getParent();
+        List<String> skewedValue = new ArrayList<String>();
+        String lbDirName = FileUtils.unescapePathName(lbdPath.toString());
+        String partDirName = FileUtils.unescapePathName(newPartPath.toString());
+        String lbDirSuffix = lbDirName.replace(partDirName, "");
+        String[] dirNames = lbDirSuffix.split(Path.SEPARATOR);
+        for (String dirName : dirNames) {
+            if ((dirName != null) && (dirName.length() > 0)) {
+                // Construct skewed-value to location map except default directory.
+                // why? query logic knows default-dir structure and don't need to get from map
+                if (!dirName
+                        .equalsIgnoreCase(ListBucketingPrunerUtils.HIVE_LIST_BUCKETING_DEFAULT_DIR_NAME)) {
+                    String[] kv = dirName.split("=");
+                    if (kv.length == 2) {
+                        skewedValue.add(kv[1]);
+                    }
+                }
+            }
+        }
+        if ((skewedValue.size() > 0) && (skewedValue.size() == skewedInfo.getSkewedColNames().size())
+                && !skewedColValueLocationMaps.containsKey(skewedValue)) {
+            skewedColValueLocationMaps.put(skewedValue, lbdPath.toString());
+        }
+    }
+
+    /**
+     * Construct location map from path
+     *
+     * @param newPartPath
+     * @param skewedInfo
+     * @return
+     * @throws IOException
+     * @throws FileNotFoundException
+     */
+    private Map<List<String>, String> constructListBucketingLocationMap(Path newPartPath,
+                                                                        SkewedInfo skewedInfo) throws IOException, FileNotFoundException {
+        Map<List<String>, String> skewedColValueLocationMaps = new HashMap<List<String>, String>();
+        FileSystem fSys = newPartPath.getFileSystem(conf);
+        walkDirTree(fSys.getFileStatus(newPartPath), fSys, skewedColValueLocationMaps, newPartPath,
+                skewedInfo);
+        return skewedColValueLocationMaps;
+    }
+
+
+    /**
+     * Given a source directory name of the load path, load all dynamically generated partitions
+     * into the specified table and return a list of strings that represent the dynamic partition
+     * paths.
+     *
+     * @param loadPath
+     * @param tableName
+     * @param partSpec
+     * @param replace
+     * @param numDP                number of dynamic partitions
+     * @param holdDDLTime
+     * @param listBucketingEnabled
+     * @param isAcid               true if this is an ACID operation
+     * @param txnId                txnId, can be 0 unless isAcid == true
+     * @return partition map details (PartitionSpec and Partition)
+     * @throws HiveException
+     */
+    public Map<Map<String, String>, Partition> loadDynamicPartitions(Path loadPath,
+                                                                     String tableName, Map<String, String> partSpec, boolean replace,
+                                                                     int numDP, boolean holdDDLTime, boolean listBucketingEnabled, boolean isAcid, long txnId)
+            throws HiveException {
+
+        Set<Path> validPartitions = new HashSet<Path>();
+        try {
+            Map<Map<String, String>, Partition> partitionsMap = new
+                    LinkedHashMap<Map<String, String>, Partition>();
+
+            FileSystem fs = loadPath.getFileSystem(conf);
+            FileStatus[] leafStatus = HiveStatsUtils.getFileStatusRecurse(loadPath, numDP + 1, fs);
+            // Check for empty partitions
+            for (FileStatus s : leafStatus) {
+                // Check if the hadoop version supports sub-directories for tables/partitions
+                if (s.isDir() &&
+                        !conf.getBoolVar(HiveConf.ConfVars.HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES)) {
+                    // No leaves in this directory
+                    LOG.info("NOT moving empty directory: " + s.getPath());
+                } else {
+                    try {
+                        validatePartitionNameCharacters(
+                                Warehouse.getPartValuesFromPartName(s.getPath().getParent().toString()));
+                    } catch (MetaException e) {
+                        throw new HiveException(e);
+                    }
+                    validPartitions.add(s.getPath().getParent());
+                }
+            }
+
+            if (validPartitions.size() == 0) {
+                LOG.warn("No partition is generated by dynamic partitioning");
+            }
+
+            if (validPartitions.size() > conf.getIntVar(HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS)) {
+                throw new HiveException("Number of dynamic partitions created is " + validPartitions.size()
+                        + ", which is more than "
+                        + conf.getIntVar(HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS)
+                        + ". To solve this try to set " + HiveConf.ConfVars.DYNAMICPARTITIONMAXPARTS.varname
+                        + " to at least " + validPartitions.size() + '.');
+            }
+
+            Table tbl = getTable(tableName);
+            // for each dynamically created DP directory, construct a full partition spec
+            // and load the partition based on that
+            Iterator<Path> iter = validPartitions.iterator();
+            while (iter.hasNext()) {
+                // get the dynamically created directory
+                Path partPath = iter.next();
+                assert fs.getFileStatus(partPath).isDir() :
+                        "partitions " + partPath + " is not a directory !";
+
+                // generate a full partition specification
+                LinkedHashMap<String, String> fullPartSpec = new LinkedHashMap<String, String>(partSpec);
+                Warehouse.makeSpecFromName(fullPartSpec, partPath);
+                Partition newPartition = loadPartition(partPath, tbl, fullPartSpec, replace,
+                        holdDDLTime, true, listBucketingEnabled, false, isAcid);
+                partitionsMap.put(fullPartSpec, newPartition);
+                LOG.info("New loading path = " + partPath + " with partSpec " + fullPartSpec);
+            }
+            if (isAcid) {
+                List<String> partNames = new ArrayList<>(partitionsMap.size());
+                for (Partition p : partitionsMap.values()) {
+                    partNames.add(p.getName());
+                }
+                metaStoreClient.addDynamicPartitions(txnId, tbl.getDbName(), tbl.getTableName(), partNames);
+            }
+            return partitionsMap;
+        } catch (IOException e) {
+            throw new HiveException(e);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    /**
+     * Load a directory into a Hive Table. - Alters existing content of table with
+     * the contents of loadPath. - If table does not exist - an exception is
+     * thrown - files in loadPath are moved into Hive. But the directory itself is
+     * not removed.
+     *
+     * @param loadPath              Directory containing files to load into Table
+     * @param tableName             name of table to be loaded.
+     * @param replace               if true - replace files in the table, otherwise add files to table
+     * @param holdDDLTime
+     * @param isSrcLocal            If the source directory is LOCAL
+     * @param isSkewedStoreAsSubdir if list bucketing enabled
+     * @param isAcid                true if this is an ACID based write
+     */
+    public void loadTable(Path loadPath, String tableName, boolean replace,
+                          boolean holdDDLTime, boolean isSrcLocal, boolean isSkewedStoreAsSubdir, boolean isAcid)
+            throws HiveException {
+        List<Path> newFiles = new ArrayList<Path>();
+        Table tbl = getTable(tableName);
+        HiveConf sessionConf = SessionState.getSessionConf();
+        if (replace) {
+            Path tableDest = tbl.getPath();
+            replaceFiles(tableDest, loadPath, tableDest, tableDest, sessionConf, isSrcLocal);
+        } else {
+            FileSystem fs;
+            try {
+                fs = tbl.getDataLocation().getFileSystem(sessionConf);
+                copyFiles(sessionConf, loadPath, tbl.getPath(), fs, isSrcLocal, isAcid, newFiles);
+            } catch (IOException e) {
+                throw new HiveException("addFiles: filesystem error in check phase", e);
+            }
+            tbl.getParameters().put(StatsSetupConst.STATS_GENERATED_VIA_STATS_TASK, "true");
+        }
+
+        try {
+            if (isSkewedStoreAsSubdir) {
+                SkewedInfo skewedInfo = tbl.getSkewedInfo();
+                // Construct list bucketing location mappings from sub-directory name.
+                Map<List<String>, String> skewedColValueLocationMaps = constructListBucketingLocationMap(
+                        tbl.getPath(), skewedInfo);
+                // Add list bucketing location mappings.
+                skewedInfo.setSkewedColValueLocationMaps(skewedColValueLocationMaps);
+            }
+        } catch (IOException e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+
+        if (!holdDDLTime) {
+            try {
+                alterTable(tableName, tbl);
+            } catch (InvalidOperationException e) {
+                throw new HiveException(e);
+            }
+        }
+        fireInsertEvent(tbl, null, newFiles);
+    }
+
+    /**
+     * Creates a partition.
+     *
+     * @param tbl      table for which partition needs to be created
+     * @param partSpec partition keys and their values
+     * @return created partition object
+     * @throws HiveException if table doesn't exist or partition already exists
+     */
+    public Partition createPartition(Table tbl, Map<String, String> partSpec) throws HiveException {
+        try {
+            return new Partition(tbl, getMSC().add_partition(
+                    Partition.createMetaPartitionObject(tbl, partSpec, null)));
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public List<Partition> createPartitions(AddPartitionDesc addPartitionDesc) throws HiveException {
+        Table tbl = getTable(addPartitionDesc.getDbName(), addPartitionDesc.getTableName());
+        int size = addPartitionDesc.getPartitionCount();
+        List<org.apache.hadoop.hive.metastore.api.Partition> in =
+                new ArrayList<org.apache.hadoop.hive.metastore.api.Partition>(size);
+        for (int i = 0; i < size; ++i) {
+            in.add(convertAddSpecToMetaPartition(tbl, addPartitionDesc.getPartition(i)));
+        }
+        List<Partition> out = new ArrayList<Partition>();
+        try {
+            if (!addPartitionDesc.getReplaceMode()) {
+                // TODO: normally, the result is not necessary; might make sense to pass false
+                for (org.apache.hadoop.hive.metastore.api.Partition outPart
+                        : getMSC().add_partitions(in, addPartitionDesc.isIfNotExists(), true)) {
+                    out.add(new Partition(tbl, outPart));
+                }
+            } else {
+                getMSC().alter_partitions(addPartitionDesc.getDbName(), addPartitionDesc.getTableName(), in);
+                List<String> part_names = new ArrayList<String>();
+                for (org.apache.hadoop.hive.metastore.api.Partition p : in) {
+                    part_names.add(Warehouse.makePartName(tbl.getPartitionKeys(), p.getValues()));
+                }
+                for (org.apache.hadoop.hive.metastore.api.Partition outPart :
+                        getMSC().getPartitionsByNames(addPartitionDesc.getDbName(), addPartitionDesc.getTableName(), part_names)) {
+                    out.add(new Partition(tbl, outPart));
+                }
+            }
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        return out;
+    }
+
+    private org.apache.hadoop.hive.metastore.api.Partition convertAddSpecToMetaPartition(
+            Table tbl, AddPartitionDesc.OnePartitionDesc addSpec) throws HiveException {
+        Path location = addSpec.getLocation() != null
+                ? new Path(tbl.getPath(), addSpec.getLocation()) : null;
+        if (location != null && !Utilities.isDefaultNameNode(conf)) {
+            // Ensure that it is a full qualified path (in most cases it will be since tbl.getPath() is full qualified)
+            location = new Path(Utilities.getQualifiedPath(conf, location));
+        }
+        org.apache.hadoop.hive.metastore.api.Partition part =
+                Partition.createMetaPartitionObject(tbl, addSpec.getPartSpec(), location);
+        if (addSpec.getPartParams() != null) {
+            part.setParameters(addSpec.getPartParams());
+        }
+        if (addSpec.getInputFormat() != null) {
+            part.getSd().setInputFormat(addSpec.getInputFormat());
+        }
+        if (addSpec.getOutputFormat() != null) {
+            part.getSd().setOutputFormat(addSpec.getOutputFormat());
+        }
+        if (addSpec.getNumBuckets() != -1) {
+            part.getSd().setNumBuckets(addSpec.getNumBuckets());
+        }
+        if (addSpec.getCols() != null) {
+            part.getSd().setCols(addSpec.getCols());
+        }
+        if (addSpec.getSerializationLib() != null) {
+            part.getSd().getSerdeInfo().setSerializationLib(addSpec.getSerializationLib());
+        }
+        if (addSpec.getSerdeParams() != null) {
+            part.getSd().getSerdeInfo().setParameters(addSpec.getSerdeParams());
+        }
+        if (addSpec.getBucketCols() != null) {
+            part.getSd().setBucketCols(addSpec.getBucketCols());
+        }
+        if (addSpec.getSortCols() != null) {
+            part.getSd().setSortCols(addSpec.getSortCols());
+        }
+        return part;
+    }
+
+    public Partition getPartition(Table tbl, Map<String, String> partSpec,
+                                  boolean forceCreate) throws HiveException {
+        return getPartition(tbl, partSpec, forceCreate, null, true, null);
+    }
+
+    /**
+     * Returns partition metadata
+     *
+     * @param tbl               the partition's table
+     * @param partSpec          partition keys and values
+     * @param forceCreate       if this is true and partition doesn't exist then a partition is
+     *                          created
+     * @param partPath          the path where the partition data is located
+     * @param inheritTableSpecs whether to copy over the table specs for if/of/serde
+     * @return result partition object or null if there is no partition
+     * @throws HiveException
+     */
+    public Partition getPartition(Table tbl, Map<String, String> partSpec, boolean forceCreate,
+                                  String partPath, boolean inheritTableSpecs)
+            throws HiveException {
+        return getPartition(tbl, partSpec, forceCreate, partPath, inheritTableSpecs, null);
+    }
+
+    /**
+     * Returns partition metadata
+     *
+     * @param tbl               the partition's table
+     * @param partSpec          partition keys and values
+     * @param forceCreate       if this is true and partition doesn't exist then a partition is
+     *                          created
+     * @param partPath          the path where the partition data is located
+     * @param inheritTableSpecs whether to copy over the table specs for if/of/serde
+     * @param newFiles          An optional list of new files that were moved into this partition.  If
+     *                          non-null these will be included in the DML event sent to the metastore.
+     * @return result partition object or null if there is no partition
+     * @throws HiveException
+     */
+    public Partition getPartition(Table tbl, Map<String, String> partSpec,
+                                  boolean forceCreate, String partPath, boolean inheritTableSpecs, List<Path> newFiles)
+            throws HiveException {
+        tbl.validatePartColumnNames(partSpec, true);
+        List<String> pvals = new ArrayList<String>();
+        for (FieldSchema field : tbl.getPartCols()) {
+            String val = partSpec.get(field.getName());
+            // enable dynamic partitioning
+            if ((val == null && !HiveConf.getBoolVar(conf, HiveConf.ConfVars.DYNAMICPARTITIONING))
+                    || (val != null && val.length() == 0)) {
+                throw new HiveException("get partition: Value for key "
+                        + field.getName() + " is null or empty");
+            } else if (val != null) {
+                pvals.add(val);
+            }
+        }
+        org.apache.hadoop.hive.metastore.api.Partition tpart = null;
+        try {
+            tpart = getMSC().getPartitionWithAuthInfo(tbl.getDbName(),
+                    tbl.getTableName(), pvals, getUserName(), getGroupNames());
+        } catch (NoSuchObjectException nsoe) {
+            // this means no partition exists for the given partition
+            // key value pairs - thrift cannot handle null return values, hence
+            // getPartition() throws NoSuchObjectException to indicate null partition
+            tpart = null;
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        try {
+            if (forceCreate) {
+                if (tpart == null) {
+                    LOG.debug("creating partition for table " + tbl.getTableName()
+                            + " with partition spec : " + partSpec);
+                    try {
+                        tpart = getMSC().appendPartition(tbl.getDbName(), tbl.getTableName(), pvals);
+                    } catch (AlreadyExistsException aee) {
+                        LOG.debug("Caught already exists exception, trying to alter partition instead");
+                        tpart = getMSC().getPartitionWithAuthInfo(tbl.getDbName(),
+                                tbl.getTableName(), pvals, getUserName(), getGroupNames());
+                        alterPartitionSpec(tbl, partSpec, tpart, inheritTableSpecs, partPath);
+                    } catch (Exception e) {
+                        if (CheckJDOException.isJDODataStoreException(e)) {
+                            // Using utility method above, so that JDODataStoreException doesn't
+                            // have to be used here. This helps avoid adding jdo dependency for
+                            // hcatalog client uses
+                            LOG.debug("Caught JDO exception, trying to alter partition instead");
+                            tpart = getMSC().getPartitionWithAuthInfo(tbl.getDbName(),
+                                    tbl.getTableName(), pvals, getUserName(), getGroupNames());
+                            if (tpart == null) {
+                                // This means the exception was caused by something other than a race condition
+                                // in creating the partition, since the partition still doesn't exist.
+                                throw e;
+                            }
+                            alterPartitionSpec(tbl, partSpec, tpart, inheritTableSpecs, partPath);
+                        } else {
+                            throw e;
+                        }
+                    }
+                } else {
+                    alterPartitionSpec(tbl, partSpec, tpart, inheritTableSpecs, partPath);
+                    fireInsertEvent(tbl, partSpec, newFiles);
+                }
+            }
+            if (tpart == null) {
+                return null;
+            }
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        return new Partition(tbl, tpart);
+    }
+
+    private void alterPartitionSpec(Table tbl,
+                                    Map<String, String> partSpec,
+                                    org.apache.hadoop.hive.metastore.api.Partition tpart,
+                                    boolean inheritTableSpecs,
+                                    String partPath) throws HiveException, InvalidOperationException {
+        LOG.debug("altering partition for table " + tbl.getTableName() + " with partition spec : "
+                + partSpec);
+        if (inheritTableSpecs) {
+            tpart.getSd().setOutputFormat(tbl.getTTable().getSd().getOutputFormat());
+            tpart.getSd().setInputFormat(tbl.getTTable().getSd().getInputFormat());
+            tpart.getSd().getSerdeInfo().setSerializationLib(tbl.getSerializationLib());
+            tpart.getSd().getSerdeInfo().setParameters(
+                    tbl.getTTable().getSd().getSerdeInfo().getParameters());
+            tpart.getSd().setBucketCols(tbl.getBucketCols());
+            tpart.getSd().setNumBuckets(tbl.getNumBuckets());
+            tpart.getSd().setSortCols(tbl.getSortCols());
+        }
+        if (partPath == null || partPath.trim().equals("")) {
+            throw new HiveException("new partition path should not be null or empty.");
+        }
+        tpart.getSd().setLocation(partPath);
+        tpart.getParameters().put(StatsSetupConst.STATS_GENERATED_VIA_STATS_TASK, "true");
+        String fullName = tbl.getTableName();
+        if (!org.apache.commons.lang.StringUtils.isEmpty(tbl.getDbName())) {
+            fullName = tbl.getDbName() + "." + tbl.getTableName();
+        }
+        alterPartition(fullName, new Partition(tbl, tpart));
+    }
+
+    private void fireInsertEvent(Table tbl, Map<String, String> partitionSpec, List<Path> newFiles)
+            throws HiveException {
+        if (conf.getBoolVar(ConfVars.FIRE_EVENTS_FOR_DML)) {
+            LOG.debug("Firing dml insert event");
+            if (tbl.isTemporary()) {
+                LOG.debug("Not firing dml insert event as " + tbl.getTableName() + " is temporary");
+                return;
+            }
+            FireEventRequestData data = new FireEventRequestData();
+            InsertEventRequestData insertData = new InsertEventRequestData();
+            data.setInsertData(insertData);
+            if (newFiles != null && newFiles.size() > 0) {
+                for (Path p : newFiles) {
+                    insertData.addToFilesAdded(p.toString());
+                }
+            } else {
+                insertData.setFilesAdded(new ArrayList<String>());
+            }
+            FireEventRequest rqst = new FireEventRequest(true, data);
+            rqst.setDbName(tbl.getDbName());
+            rqst.setTableName(tbl.getTableName());
+            if (partitionSpec != null && partitionSpec.size() > 0) {
+                List<String> partVals = new ArrayList<String>(partitionSpec.size());
+                for (FieldSchema fs : tbl.getPartitionKeys()) {
+                    partVals.add(partitionSpec.get(fs.getName()));
+                }
+                rqst.setPartitionVals(partVals);
+            }
+            try {
+                getMSC().fireListenerEvent(rqst);
+            } catch (TException e) {
+                throw new HiveException(e);
+            }
+        }
+    }
+
+    public boolean dropPartition(String tblName, List<String> part_vals, boolean deleteData)
+            throws HiveException {
+        String[] names = Utilities.getDbTableName(tblName);
+        return dropPartition(names[0], names[1], part_vals, deleteData);
+    }
+
+    public boolean dropPartition(String db_name, String tbl_name,
+                                 List<String> part_vals, boolean deleteData) throws HiveException {
+        return dropPartition(db_name, tbl_name, part_vals,
+                PartitionDropOptions.instance().deleteData(deleteData));
+    }
+
+    public boolean dropPartition(String dbName, String tableName, List<String> partVals, PartitionDropOptions options)
+            throws HiveException {
+        try {
+            return getMSC().dropPartition(dbName, tableName, partVals, options);
+        } catch (NoSuchObjectException e) {
+            throw new HiveException("Partition or table doesn't exist.", e);
+        } catch (Exception e) {
+            throw new HiveException(e.getMessage(), e);
+        }
+    }
+
+    public List<Partition> dropPartitions(String tblName, List<DropTableDesc.PartSpec> partSpecs,
+                                          boolean deleteData, boolean ignoreProtection, boolean ifExists) throws HiveException {
+        String[] names = Utilities.getDbTableName(tblName);
+        return dropPartitions(
+                names[0], names[1], partSpecs, deleteData, ignoreProtection, ifExists);
+    }
+
+    public List<Partition> dropPartitions(String dbName, String tblName,
+                                          List<DropTableDesc.PartSpec> partSpecs, boolean deleteData, boolean ignoreProtection,
+                                          boolean ifExists) throws HiveException {
+        return dropPartitions(dbName, tblName, partSpecs,
+                PartitionDropOptions.instance()
+                        .deleteData(deleteData)
+                        .ignoreProtection(ignoreProtection)
+                        .ifExists(ifExists));
+    }
+
+    public List<Partition> dropPartitions(String tblName, List<DropTableDesc.PartSpec> partSpecs,
+                                          PartitionDropOptions dropOptions) throws HiveException {
+        String[] names = Utilities.getDbTableName(tblName);
+        return dropPartitions(names[0], names[1], partSpecs, dropOptions);
+    }
+
+    public List<Partition> dropPartitions(String dbName, String tblName,
+                                          List<DropTableDesc.PartSpec> partSpecs, PartitionDropOptions dropOptions) throws HiveException {
+        try {
+            Table tbl = getTable(dbName, tblName);
+            List<ObjectPair<Integer, byte[]>> partExprs =
+                    new ArrayList<ObjectPair<Integer, byte[]>>(partSpecs.size());
+            for (DropTableDesc.PartSpec partSpec : partSpecs) {
+                partExprs.add(new ObjectPair<Integer, byte[]>(partSpec.getPrefixLength(),
+                        Utilities.serializeExpressionToKryo(partSpec.getPartSpec())));
+            }
+            List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getMSC().dropPartitions(
+                    dbName, tblName, partExprs, dropOptions);
+            return convertFromMetastore(tbl, tParts, null);
+        } catch (NoSuchObjectException e) {
+            throw new HiveException("Partition or table doesn't exist.", e);
+        } catch (Exception e) {
+            throw new HiveException(e.getMessage(), e);
+        }
+    }
+
+    public List<String> getPartitionNames(String tblName, short max) throws HiveException {
+        String[] names = Utilities.getDbTableName(tblName);
+        return getPartitionNames(names[0], names[1], max);
+    }
+
+    public List<String> getPartitionNames(String dbName, String tblName, short max)
+            throws HiveException {
+        List<String> names = null;
+        try {
+            names = getMSC().listPartitionNames(dbName, tblName, max);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        return names;
+    }
+
+    public List<String> getPartitionNames(String dbName, String tblName,
+                                          Map<String, String> partSpec, short max) throws HiveException {
+        List<String> names = null;
+        Table t = getTable(dbName, tblName);
+
+        List<String> pvals = MetaStoreUtils.getPvals(t.getPartCols(), partSpec);
+
+        try {
+            names = getMSC().listPartitionNames(dbName, tblName, pvals, max);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        return names;
+    }
+
+    /**
+     * get all the partitions that the table has
+     *
+     * @param tbl object for which partition is needed
+     * @return list of partition objects
+     * @throws HiveException
+     */
+    public List<Partition> getPartitions(Table tbl) throws HiveException {
+        if (tbl.isPartitioned()) {
+            List<org.apache.hadoop.hive.metastore.api.Partition> tParts;
+            try {
+                tParts = getMSC().listPartitionsWithAuthInfo(tbl.getDbName(), tbl.getTableName(),
+                        (short) -1, getUserName(), getGroupNames());
+            } catch (Exception e) {
+                LOG.error(StringUtils.stringifyException(e));
+                throw new HiveException(e);
+            }
+            List<Partition> parts = new ArrayList<Partition>(tParts.size());
+            for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
+                parts.add(new Partition(tbl, tpart));
+            }
+            return parts;
+        } else {
+            Partition part = new Partition(tbl);
+            ArrayList<Partition> parts = new ArrayList<Partition>(1);
+            parts.add(part);
+            return parts;
+        }
+    }
+
+    /**
+     * Get all the partitions; unlike {@link #getPartitions(Table)}, does not include auth.
+     *
+     * @param tbl table for which partitions are needed
+     * @return list of partition objects
+     */
+    public Set<Partition> getAllPartitionsOf(Table tbl) throws HiveException {
+        if (!tbl.isPartitioned()) {
+            return Sets.newHashSet(new Partition(tbl));
+        }
+
+        List<org.apache.hadoop.hive.metastore.api.Partition> tParts;
+        try {
+            tParts = getMSC().listPartitions(tbl.getDbName(), tbl.getTableName(), (short) -1);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        Set<Partition> parts = new LinkedHashSet<Partition>(tParts.size());
+        for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
+            parts.add(new Partition(tbl, tpart));
+        }
+        return parts;
+    }
+
+    /**
+     * get all the partitions of the table that matches the given partial
+     * specification. partition columns whose value is can be anything should be
+     * an empty string.
+     *
+     * @param tbl   object for which partition is needed. Must be partitioned.
+     * @param limit number of partitions to return
+     * @return list of partition objects
+     * @throws HiveException
+     */
+    public List<Partition> getPartitions(Table tbl, Map<String, String> partialPartSpec,
+                                         short limit)
+            throws HiveException {
+        if (!tbl.isPartitioned()) {
+            throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
+        }
+
+        List<String> partialPvals = MetaStoreUtils.getPvals(tbl.getPartCols(), partialPartSpec);
+
+        List<org.apache.hadoop.hive.metastore.api.Partition> partitions = null;
+        try {
+            partitions = getMSC().listPartitionsWithAuthInfo(tbl.getDbName(), tbl.getTableName(),
+                    partialPvals, limit, getUserName(), getGroupNames());
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+
+        List<Partition> qlPartitions = new ArrayList<Partition>();
+        for (org.apache.hadoop.hive.metastore.api.Partition p : partitions) {
+            qlPartitions.add(new Partition(tbl, p));
+        }
+
+        return qlPartitions;
+    }
+
+    /**
+     * get all the partitions of the table that matches the given partial
+     * specification. partition columns whose value is can be anything should be
+     * an empty string.
+     *
+     * @param tbl object for which partition is needed. Must be partitioned.
+     * @return list of partition objects
+     * @throws HiveException
+     */
+    public List<Partition> getPartitions(Table tbl, Map<String, String> partialPartSpec)
+            throws HiveException {
+        return getPartitions(tbl, partialPartSpec, (short) -1);
+    }
+
+    /**
+     * get all the partitions of the table that matches the given partial
+     * specification. partition columns whose value is can be anything should be
+     * an empty string.
+     *
+     * @param tbl             object for which partition is needed. Must be partitioned.
+     * @param partialPartSpec partial partition specification (some subpartitions can be empty).
+     * @return list of partition objects
+     * @throws HiveException
+     */
+    public List<Partition> getPartitionsByNames(Table tbl,
+                                                Map<String, String> partialPartSpec)
+            throws HiveException {
+
+        if (!tbl.isPartitioned()) {
+            throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
+        }
+
+        List<String> names = getPartitionNames(tbl.getDbName(), tbl.getTableName(),
+                partialPartSpec, (short) -1);
+
+        List<Partition> partitions = getPartitionsByNames(tbl, names);
+        return partitions;
+    }
+
+    /**
+     * Get all partitions of the table that matches the list of given partition names.
+     *
+     * @param tbl       object for which partition is needed. Must be partitioned.
+     * @param partNames list of partition names
+     * @return list of partition objects
+     * @throws HiveException
+     */
+    public List<Partition> getPartitionsByNames(Table tbl, List<String> partNames)
+            throws HiveException {
+
+        if (!tbl.isPartitioned()) {
+            throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
+        }
+        List<Partition> partitions = new ArrayList<Partition>(partNames.size());
+
+        int batchSize = HiveConf.getIntVar(conf, HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX);
+        // TODO: might want to increase the default batch size. 1024 is viable; MS gets OOM if too high.
+        int nParts = partNames.size();
+        int nBatches = nParts / batchSize;
+
+        try {
+            for (int i = 0; i < nBatches; ++i) {
+                List<org.apache.hadoop.hive.metastore.api.Partition> tParts =
+                        getMSC().getPartitionsByNames(tbl.getDbName(), tbl.getTableName(),
+                                partNames.subList(i * batchSize, (i + 1) * batchSize));
+                if (tParts != null) {
+                    for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
+                        partitions.add(new Partition(tbl, tpart));
+                    }
+                }
+            }
+
+            if (nParts > nBatches * batchSize) {
+                List<org.apache.hadoop.hive.metastore.api.Partition> tParts =
+                        getMSC().getPartitionsByNames(tbl.getDbName(), tbl.getTableName(),
+                                partNames.subList(nBatches * batchSize, nParts));
+                if (tParts != null) {
+                    for (org.apache.hadoop.hive.metastore.api.Partition tpart : tParts) {
+                        partitions.add(new Partition(tbl, tpart));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+        return partitions;
+    }
+
+    /**
+     * Get a list of Partitions by filter.
+     *
+     * @param tbl    The table containing the partitions.
+     * @param filter A string represent partition predicates.
+     * @return a list of partitions satisfying the partition predicates.
+     * @throws HiveException
+     * @throws MetaException
+     * @throws NoSuchObjectException
+     * @throws TException
+     */
+    public List<Partition> getPartitionsByFilter(Table tbl, String filter)
+            throws HiveException, MetaException, NoSuchObjectException, TException {
+
+        if (!tbl.isPartitioned()) {
+            throw new HiveException(ErrorMsg.TABLE_NOT_PARTITIONED, tbl.getTableName());
+        }
+
+        List<org.apache.hadoop.hive.metastore.api.Partition> tParts = getMSC().listPartitionsByFilter(
+                tbl.getDbName(), tbl.getTableName(), filter, (short) -1);
+        return convertFromMetastore(tbl, tParts, null);
+    }
+
+    private static List<Partition> convertFromMetastore(Table tbl,
+                                                        List<org.apache.hadoop.hive.metastore.api.Partition> src,
+                                                        List<Partition> dest) throws HiveException {
+        if (src == null) {
+            return dest;
+        }
+        if (dest == null) {
+            dest = new ArrayList<Partition>(src.size());
+        }
+        for (org.apache.hadoop.hive.metastore.api.Partition tPart : src) {
+            dest.add(new Partition(tbl, tPart));
+        }
+        return dest;
+    }
+
+    /**
+     * Get a list of Partitions by expr.
+     *
+     * @param tbl    The table containing the partitions.
+     * @param expr   A serialized expression for partition predicates.
+     * @param conf   Hive config.
+     * @param result the resulting list of partitions
+     * @return whether the resulting list contains partitions which may or may not match the expr
+     */
+    public boolean getPartitionsByExpr(Table tbl, ExprNodeGenericFuncDesc expr, HiveConf conf,
+                                       List<Partition> result) throws HiveException, TException {
+        assert result != null;
+        byte[] exprBytes = Utilities.serializeExpressionToKryo(expr);
+        String defaultPartitionName = HiveConf.getVar(conf, ConfVars.DEFAULTPARTITIONNAME);
+        List<org.apache.hadoop.hive.metastore.api.Partition> msParts =
+                new ArrayList<org.apache.hadoop.hive.metastore.api.Partition>();
+        boolean hasUnknownParts = getMSC().listPartitionsByExpr(tbl.getDbName(),
+                tbl.getTableName(), exprBytes, defaultPartitionName, (short) -1, msParts);
+        convertFromMetastore(tbl, msParts, result);
+        return hasUnknownParts;
+    }
+
+    public void validatePartitionNameCharacters(List<String> partVals) throws HiveException {
+        try {
+            getMSC().validatePartitionNameCharacters(partVals);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public void createRole(String roleName, String ownerName)
+            throws HiveException {
+        try {
+            getMSC().create_role(new Role(roleName, -1, ownerName));
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public void dropRole(String roleName) throws HiveException {
+        try {
+            getMSC().drop_role(roleName);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Get all existing role names.
+     *
+     * @return List of role names.
+     * @throws HiveException
+     */
+    public List<String> getAllRoleNames() throws HiveException {
+        try {
+            return getMSC().listRoleNames();
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public List<RolePrincipalGrant> getRoleGrantInfoForPrincipal(String principalName, PrincipalType principalType) throws HiveException {
+        try {
+            GetRoleGrantsForPrincipalRequest req = new GetRoleGrantsForPrincipalRequest(principalName, principalType);
+            GetRoleGrantsForPrincipalResponse resp = getMSC().get_role_grants_for_principal(req);
+            return resp.getPrincipalGrants();
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+
+    public boolean grantRole(String roleName, String userName,
+                             PrincipalType principalType, String grantor, PrincipalType grantorType,
+                             boolean grantOption) throws HiveException {
+        try {
+            return getMSC().grant_role(roleName, userName, principalType, grantor,
+                    grantorType, grantOption);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public boolean revokeRole(String roleName, String userName,
+                              PrincipalType principalType, boolean grantOption) throws HiveException {
+        try {
+            return getMSC().revoke_role(roleName, userName, principalType, grantOption);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    public List<Role> listRoles(String userName, PrincipalType principalType)
+            throws HiveException {
+        try {
+            return getMSC().list_roles(userName, principalType);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * @param objectType  hive object type
+     * @param db_name     database name
+     * @param table_name  table name
+     * @param part_values partition values
+     * @param column_name column name
+     * @param user_name   user name
+     * @param group_names group names
+     * @return the privilege set
+     * @throws HiveException
+     */
+    public PrincipalPrivilegeSet get_privilege_set(HiveObjectType objectType,
+                                                   String db_name, String table_name, List<String> part_values,
+                                                   String column_name, String user_name, List<String> group_names)
+            throws HiveException {
+        try {
+            HiveObjectRef hiveObj = new HiveObjectRef(objectType, db_name,
+                    table_name, part_values, column_name);
+            return getMSC().get_privilege_set(hiveObj, user_name, group_names);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * @param objectType    hive object type
+     * @param principalName
+     * @param principalType
+     * @param dbName
+     * @param tableName
+     * @param partValues
+     * @param columnName
+     * @return list of privileges
+     * @throws HiveException
+     */
+    public List<HiveObjectPrivilege> showPrivilegeGrant(
+            HiveObjectType objectType, String principalName,
+            PrincipalType principalType, String dbName, String tableName,
+            List<String> partValues, String columnName) throws HiveException {
+        try {
+            HiveObjectRef hiveObj = new HiveObjectRef(objectType, dbName, tableName,
+                    partValues, columnName);
+            return getMSC().list_privileges(principalName, principalType, hiveObj);
+        } catch (Exception e) {
+            throw new HiveException(e);
+        }
+    }
+
+    // for each file or directory in 'srcs', make mapping for every file in src to safe name in dest
+    private static List<List<Path[]>> checkPaths(HiveConf conf, FileSystem fs,
+                                                 FileStatus[] srcs, FileSystem srcFs, Path destf, boolean replace)
+            throws HiveException {
+
+        List<List<Path[]>> result = new ArrayList<List<Path[]>>();
+        try {
+            FileStatus destStatus = !replace ? FileUtils.getFileStatusOrNull(fs, destf) : null;
+            if (destStatus != null && !destStatus.isDir()) {
+                throw new HiveException("checkPaths: destination " + destf
+                        + " should be a directory");
+            }
+            for (FileStatus src : srcs) {
+                FileStatus[] items;
+                if (src.isDir()) {
+                    items = srcFs.listStatus(src.getPath(), FileUtils.HIDDEN_FILES_PATH_FILTER);
+                    Arrays.sort(items);
+                } else {
+                    items = new FileStatus[]{src};
+                }
+
+                List<Path[]> srcToDest = new ArrayList<Path[]>();
+                for (FileStatus item : items) {
+
+                    Path itemSource = item.getPath();
+
+                    if (Utilities.isTempPath(item)) {
+                        // This check is redundant because temp files are removed by
+                        // execution layer before
+                        // calling loadTable/Partition. But leaving it in just in case.
+                        srcFs.delete(itemSource, true);
+                        continue;
+                    }
+
+                    if (!conf.getBoolVar(HiveConf.ConfVars.HIVE_HADOOP_SUPPORTS_SUBDIRECTORIES) &&
+                            !HiveConf.getVar(conf, HiveConf.ConfVars.STAGINGDIR).equals(itemSource.getName()) &&
+                            item.isDir()) {
+                        throw new HiveException("checkPaths: " + src.getPath()
+                                + " has nested directory " + itemSource);
+                    }
+                    // Strip off the file type, if any so we don't make:
+                    // 000000_0.gz -> 000000_0.gz_copy_1
+                    String name = itemSource.getName();
+                    String filetype;
+                    int index = name.lastIndexOf('.');
+                    if (index >= 0) {
+                        filetype = name.substring(index);
+                        name = name.substring(0, index);
+                    } else {
+                        filetype = "";
+                    }
+
+                    Path itemDest = new Path(destf, itemSource.getName());
+
+                    if (!replace) {
+                        // It's possible that the file we're copying may have the same
+                        // relative name as an existing file in the "destf" directory.
+                        // So let's make a quick check to see if we can rename any
+                        // potential offenders so as to allow them to move into the
+                        // "destf" directory. The scheme is dead simple: simply tack
+                        // on "_copy_N" where N starts at 1 and works its way up until
+                        // we find a free space.
+
+                        // removed source file staging.. it's more confusing when failed.
+                        for (int counter = 1; fs.exists(itemDest) || destExists(result, itemDest); counter++) {
+                            itemDest = new Path(destf, name + ("_copy_" + counter) + filetype);
+                        }
+                    }
+                    srcToDest.add(new Path[]{itemSource, itemDest});
+                }
+                result.add(srcToDest);
+            }
+        } catch (IOException e) {
+            throw new HiveException("checkPaths: filesystem error in check phase. " + e.getMessage(), e);
+        }
+        return result;
+    }
+
+    private static boolean destExists(List<List<Path[]>> result, Path proposed) {
+        for (List<Path[]> sdpairs : result) {
+            for (Path[] sdpair : sdpairs) {
+                if (sdpair[1].equals(proposed)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isSubDir(Path srcf, Path destf, FileSystem fs, boolean isSrcLocal) {
+        if (srcf == null) {
+            LOG.debug("The source path is null for isSubDir method.");
+            return false;
+        }
+
+        String fullF1 = getQualifiedPathWithoutSchemeAndAuthority(srcf, fs);
+        String fullF2 = getQualifiedPathWithoutSchemeAndAuthority(destf, fs);
+
+        boolean isInTest = Boolean.valueOf(HiveConf.getBoolVar(fs.getConf(), ConfVars.HIVE_IN_TEST));
+        // In the automation, the data warehouse is the local file system based.
+        LOG.debug("The source path is " + fullF1 + " and the destination path is " + fullF2);
+        if (isInTest) {
+            return fullF1.startsWith(fullF2);
+        }
+
+        // schema is diff, return false
+        String schemaSrcf = srcf.toUri().getScheme();
+        String schemaDestf = destf.toUri().getScheme();
+
+        // if the schemaDestf is null, it means the destination is not in the local file system
+        if (schemaDestf == null && isSrcLocal) {
+            LOG.debug("The source file is in the local while the dest not.");
+            return false;
+        }
+
+        // If both schema information are provided, they should be the same.
+        if (schemaSrcf != null && schemaDestf != null && !schemaSrcf.equals(schemaDestf)) {
+            LOG.debug("The source path's schema is " + schemaSrcf +
+                    " and the destination path's schema is " + schemaDestf + ".");
+            return false;
+        }
+
+        LOG.debug("The source path is " + fullF1 + " and the destination path is " + fullF2);
+        return fullF1.startsWith(fullF2);
+    }
+
+    private static String getQualifiedPathWithoutSchemeAndAuthority(Path srcf, FileSystem fs) {
+        Path currentWorkingDir = fs.getWorkingDirectory();
+        Path path = srcf.makeQualified(srcf.toUri(), currentWorkingDir);
+        return ShimLoader.getHadoopShims().getPathWithoutSchemeAndAuthority(path).toString();
+    }
+
+    //it is assumed that parent directory of the destf should already exist when this
+    //method is called. when the replace value is true, this method works a little different
+    //from mv command if the destf is a directory, it replaces the destf instead of moving under
+    //the destf. in this case, the replaced destf still preserves the original destf's permission
+    public static boolean moveFile(HiveConf conf, Path srcf, Path destf,
+                                   FileSystem fs, boolean replace, boolean isSrcLocal) throws HiveException {
+        boolean success = false;
+
+        //needed for perm inheritance.
+        boolean inheritPerms = HiveConf.getBoolVar(conf,
+                HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
+        HadoopShims shims = ShimLoader.getHadoopShims();
+        HadoopShims.HdfsFileStatus destStatus = null;
+        HadoopShims.HdfsEncryptionShim hdfsEncryptionShim = SessionState.get().getHdfsEncryptionShim();
+
+        // If source path is a subdirectory of the destination path:
+        //   ex: INSERT OVERWRITE DIRECTORY 'target/warehouse/dest4.out' SELECT src.value WHERE src.key >= 300;
+        //   where the staging directory is a subdirectory of the destination directory
+        // (1) Do not delete the dest dir before doing the move operation.
+        // (2) It is assumed that subdir and dir are in same encryption zone.
+        // (3) Move individual files from scr dir to dest dir.
+        boolean destIsSubDir = isSubDir(srcf, destf, fs, isSrcLocal);
+        try {
+            if (inheritPerms || replace) {
+                try {
+                    destStatus = shims.getFullFileStatus(conf, fs, destf.getParent());
+                    //if destf is an existing directory:
+                    //if replace is true, delete followed by rename(mv) is equivalent to replace
+                    //if replace is false, rename (mv) actually move the src under dest dir
+                    //if destf is an existing file, rename is actually a replace, and do not need
+                    // to delete the file first
+                    if (replace && !destIsSubDir) {
+                        LOG.debug("The path " + destf.toString() + " is deleted");
+                        fs.delete(destf, true);
+                    }
+                } catch (FileNotFoundException ignore) {
+                    //if dest dir does not exist, any re
+                    if (inheritPerms) {
+                        destStatus = shims.getFullFileStatus(conf, fs, destf.getParent());
+                    }
+                }
+            }
+            if (!isSrcLocal) {
+                // For NOT local src file, rename the file
+                if (hdfsEncryptionShim != null && (hdfsEncryptionShim.isPathEncrypted(srcf) || hdfsEncryptionShim.isPathEncrypted(destf))
+                        && !hdfsEncryptionShim.arePathsOnSameEncryptionZone(srcf, destf)) {
+                    LOG.info("Copying source " + srcf + " to " + destf + " because HDFS encryption zones are different.");
+                    success = FileUtils.copy(srcf.getFileSystem(conf), srcf, destf.getFileSystem(conf), destf,
+                            true,    // delete source
+                            replace, // overwrite destination
+                            conf);
+                } else {
+                    if (destIsSubDir) {
+                        FileStatus[] srcs = fs.listStatus(srcf, FileUtils.HIDDEN_FILES_PATH_FILTER);
+                        if (srcs.length == 0) {
+                            success = true; // Nothing to move.
+                        }
+                        for (FileStatus status : srcs) {
+                            success = FileUtils.copy(srcf.getFileSystem(conf), status.getPath(), destf.getFileSystem(conf), destf,
+                                    true,     // delete source
+                                    replace,  // overwrite destination
+                                    conf);
+
+                            if (!success) {
+                                throw new HiveException("Unable to move source " + status.getPath() + " to destination " + destf);
+                            }
+                        }
+                    } else {
+                        success = fs.rename(srcf, destf);
+                    }
+                }
+            } else {
+                // For local src file, copy to hdfs
+                fs.copyFromLocalFile(srcf, destf);
+                success = true;
+            }
+
+            LOG.info((replace ? "Replacing src:" : "Renaming src: ") + srcf.toString()
+                    + ", dest: " + destf.toString() + ", Status:" + success);
+        } catch (IOException ioe) {
+            throw new HiveException("Unable to move source " + srcf + " to destination " + destf, ioe);
+        }
+
+        if (success && inheritPerms) {
+            try {
+                ShimLoader.getHadoopShims().setFullFileStatus(conf, destStatus, fs, destf);
+            } catch (IOException e) {
+                LOG.warn("Error setting permission of file " + destf + ": " + e.getMessage(), e);
+            }
+        }
+        return success;
+    }
+
+    /**
+     * Copy files.  This handles building the mapping for buckets and such between the source and
+     * destination
+     *
+     * @param conf       Configuration object
+     * @param srcf       source directory, if bucketed should contain bucket files
+     * @param destf      directory to move files into
+     * @param fs         Filesystem
+     * @param isSrcLocal true if source is on local file system
+     * @param isAcid     true if this is an ACID based write
+     * @param newFiles   if this is non-null, a list of files that were created as a result of this
+     *                   move will be returned.
+     * @throws HiveException
+     */
+    static protected void copyFiles(final HiveConf conf, Path srcf, Path destf,
+                                    final FileSystem fs, final boolean isSrcLocal, boolean isAcid, List<Path> newFiles) throws HiveException {
+        boolean inheritPerms = HiveConf.getBoolVar(conf,
+                HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
+        try {
+            // create the destination if it does not exist
+            if (!fs.exists(destf)) {
+                FileUtils.mkdir(fs, destf, inheritPerms, conf);
+            }
+        } catch (IOException e) {
+            throw new HiveException(
+                    "copyFiles: error while checking/creating destination directory!!!",
+                    e);
+        }
+
+        FileStatus[] srcs;
+        FileSystem srcFs;
+        try {
+            srcFs = srcf.getFileSystem(conf);
+            srcs = srcFs.globStatus(srcf);
+        } catch (IOException e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException("addFiles: filesystem error in check phase. " + e.getMessage(), e);
+        }
+        if (srcs == null) {
+            LOG.info("No sources specified to move: " + srcf);
+            return;
+            // srcs = new FileStatus[0]; Why is this needed?
+        }
+
+        // If we're moving files around for an ACID write then the rules and paths are all different.
+        // You can blame this on Owen.
+        if (isAcid) {
+            moveAcidFiles(srcFs, srcs, destf, newFiles);
+        } else {
+            // check that source and target paths exist
+            List<List<Path[]>> result = checkPaths(conf, fs, srcs, srcFs, destf, false);
+
+            //fordeal Patch by zhiyue@2020-03-14
+            boolean threadResult = true;
+            final List<Future<Boolean>> futures = new LinkedList<>();
+            final ExecutorService pool = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVE_MOVE_FILES_THREAD_COUNT) > 0 ?
+                    Executors.newFixedThreadPool(HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVE_MOVE_FILES_THREAD_COUNT),
+                            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Delete-Thread-%d").build()) : null;
+            final SessionState parentSession = SessionState.get();
+            // move it, move it
+            try {
+                for (List<Path[]> sdpairs : result) {
+                    for (final Path[] sdpair : sdpairs) {
+                        if (null == pool) {
+                            boolean moveResult = moveFile(conf, sdpair[0], sdpair[1], fs, false, isSrcLocal);
+                            if (!moveResult) {
+                                throw new IOException("Cannot move " + sdpair[0] + " to "
+                                        + sdpair[1]);
+                            }
+                            threadResult &= moveResult;
+                        } else {
+                            futures.add(pool.submit(new Callable<Boolean>() {
+                                @Override
+                                public Boolean call() throws Exception {
+                                    SessionState.setCurrentSessionState(parentSession);
+                                    return moveFile(conf, sdpair[0], sdpair[1], fs, false, isSrcLocal);
+                                }
+                            }));
+                        }
+
+                        if (newFiles != null) newFiles.add(sdpair[1]);
+                    }
+                }
+            } catch (IOException e) {
+                throw new HiveException("copyFiles: error while moving files!!! " + e.getMessage(), e);
+            }
+
+            if (null != pool) {
+                pool.shutdown();
+                for (Future<Boolean> future : futures) {
+                    try {
+                        threadResult &= future.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        LOG.error("@zhiyue: Failed to move: ", e);
+                        pool.shutdownNow();
+                        throw new HiveException(e);
+                    }
+                }
+            }
+
+            if (!threadResult) {
+                LOG.error("@zhiyue Faild thread move file");
+            }
+        }
+    }
+
+
+    private static void moveAcidFiles(FileSystem fs, FileStatus[] stats, Path dst,
+                                      List<Path> newFiles) throws HiveException {
+        // The layout for ACID files is table|partname/base|delta/bucket
+        // We will always only be writing delta files.  In the buckets created by FileSinkOperator
+        // it will look like bucket/delta/bucket.  So we need to move that into the above structure.
+        // For the first mover there will be no delta directory, so we can move the whole directory.
+        // For everyone else we will need to just move the buckets under the existing delta
+        // directory.
+
+        Set<Path> createdDeltaDirs = new HashSet<Path>();
+        // Open the original path we've been given and find the list of original buckets
+        for (FileStatus stat : stats) {
+            Path srcPath = stat.getPath();
+
+            LOG.debug("Acid move Looking for original buckets in " + srcPath);
+
+            FileStatus[] origBucketStats = null;
+            try {
+                origBucketStats = fs.listStatus(srcPath, AcidUtils.originalBucketFilter);
+            } catch (IOException e) {
+                String msg = "Unable to look for bucket files in src path " + srcPath.toUri().toString();
+                LOG.error(msg);
+                throw new HiveException(msg, e);
+            }
+            LOG.debug("Acid move found " + origBucketStats.length + " original buckets");
+
+            for (FileStatus origBucketStat : origBucketStats) {
+                Path origBucketPath = origBucketStat.getPath();
+                LOG.debug("Acid move looking for delta files in bucket " + origBucketPath);
+
+                FileStatus[] deltaStats = null;
+                try {
+                    deltaStats = fs.listStatus(origBucketPath, AcidUtils.deltaFileFilter);
+                } catch (IOException e) {
+                    throw new HiveException("Unable to look for delta files in original bucket " +
+                            origBucketPath.toUri().toString(), e);
+                }
+                LOG.debug("Acid move found " + deltaStats.length + " delta files");
+
+                for (FileStatus deltaStat : deltaStats) {
+                    Path deltaPath = deltaStat.getPath();
+                    // Create the delta directory.  Don't worry if it already exists,
+                    // as that likely means another task got to it first.  Then move each of the buckets.
+                    // it would be more efficient to try to move the delta with it's buckets but that is
+                    // harder to make race condition proof.
+                    Path deltaDest = new Path(dst, deltaPath.getName());
+                    try {
+                        if (!createdDeltaDirs.contains(deltaDest)) {
+                            try {
+                                fs.mkdirs(deltaDest);
+                                createdDeltaDirs.add(deltaDest);
+                            } catch (IOException swallowIt) {
+                                // Don't worry about this, as it likely just means it's already been created.
+                                LOG.info("Unable to create delta directory " + deltaDest +
+                                        ", assuming it already exists: " + swallowIt.getMessage());
+                            }
+                        }
+                        FileStatus[] bucketStats = fs.listStatus(deltaPath, AcidUtils.bucketFileFilter);
+                        LOG.debug("Acid move found " + bucketStats.length + " bucket files");
+                        for (FileStatus bucketStat : bucketStats) {
+                            Path bucketSrc = bucketStat.getPath();
+                            Path bucketDest = new Path(deltaDest, bucketSrc.getName());
+                            LOG.info("Moving bucket " + bucketSrc.toUri().toString() + " to " +
+                                    bucketDest.toUri().toString());
+                            fs.rename(bucketSrc, bucketDest);
+                            if (newFiles != null) newFiles.add(bucketDest);
+                        }
+                    } catch (IOException e) {
+                        throw new HiveException("Error moving acid files " + e.getMessage(), e);
+                    }
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Replaces files in the partition with new data set specified by srcf. Works
+     * by renaming directory of srcf to the destination file.
+     * srcf, destf, and tmppath should resident in the same DFS, but the oldPath can be in a
+     * different DFS.
+     *
+     * @param tablePath  path of the table.  Used to identify permission inheritance.
+     * @param srcf       Source directory to be renamed to tmppath. It should be a
+     *                   leaf directory where the final data files reside. However it
+     *                   could potentially contain subdirectories as well.
+     * @param destf      The directory where the final data needs to go
+     * @param oldPath    The directory where the old data location, need to be cleaned up.  Most of time, will be the same
+     *                   as destf, unless its across FileSystem boundaries.
+     * @param isSrcLocal If the source directory is LOCAL
+     */
+    protected static void replaceFiles(Path tablePath, Path srcf, Path destf, Path oldPath, final HiveConf conf,
+                                       final boolean isSrcLocal) throws HiveException {
+        try {
+
+            final FileSystem destFs = destf.getFileSystem(conf);
+            boolean inheritPerms = HiveConf.getBoolVar(conf,
+                    HiveConf.ConfVars.HIVE_WAREHOUSE_SUBDIR_INHERIT_PERMS);
+
+            // check if srcf contains nested sub-directories
+            FileStatus[] srcs;
+            FileSystem srcFs;
+            try {
+                srcFs = srcf.getFileSystem(conf);
+                srcs = srcFs.globStatus(srcf);
+            } catch (IOException e) {
+                throw new HiveException("Getting globStatus " + srcf.toString(), e);
+            }
+            if (srcs == null) {
+                LOG.info("No sources specified to move: " + srcf);
+                return;
+            }
+            List<List<Path[]>> result = checkPaths(conf, destFs, srcs, srcFs, destf,
+                    true);
+
+            boolean threadResult = true;
+            final List<Future<Boolean>> futures = new LinkedList<>();
+            final ExecutorService pool = HiveConf.getIntVar(conf, ConfVars.HIVE_MOVE_FILES_THREAD_COUNT) > 0 ?
+                    Executors.newFixedThreadPool(HiveConf.getIntVar(conf, ConfVars.HIVE_MOVE_FILES_THREAD_COUNT),
+                            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("Replace-Thread-%d").build()) : null;
+            final SessionState parentSession = SessionState.get();
+
+            if (oldPath != null) {
+                try {
+                    FileSystem fs2 = oldPath.getFileSystem(conf);
+                    if (fs2.exists(oldPath)) {
+                        // Do not delete oldPath if:
+                        //  - destf is subdir of oldPath
+                        //if ( !(fs2.equals(destf.getFileSystem(conf)) && FileUtils.isSubDir(oldPath, destf, fs2)))
+                        if (FileUtils.isSubDir(oldPath, destf, fs2)) {
+                            FileUtils.trashFilesUnderDir(fs2, oldPath, conf);
+                        }
+                        if (inheritPerms) {
+                            inheritFromTable(tablePath, destf, conf, destFs);
+                        }
+                    }
+                } catch (Exception e) {
+                    //swallow the exception
+                    LOG.warn("Directory " + oldPath.toString() + " cannot be removed: " + e, e);
+                }
+            }
+
+            // rename src directory to destf
+            if (srcs.length == 1 && srcs[0].isDir()) {
+                // rename can fail if the parent doesn't exist
+                Path destfp = destf.getParent();
+                if (!destFs.exists(destfp)) {
+                    boolean success = destFs.mkdirs(destfp);
+                    if (!success) {
+                        LOG.warn("Error creating directory " + destf.toString());
+                    }
+                    if (inheritPerms && success) {
+                        inheritFromTable(tablePath, destfp, conf, destFs);
+                    }
+                }
+
+                // Copy/move each file under the source directory to avoid to delete the destination
+                // directory if it is the root of an HDFS encryption zone.
+                for (List<Path[]> sdpairs : result) {
+                    for (final Path[] sdpair : sdpairs) {
+                        Path destParent = sdpair[1].getParent();
+                        FileSystem destParentFs = destParent.getFileSystem(conf);
+                        if (!destParentFs.isDirectory(destParent)) {
+                            boolean success = destFs.mkdirs(destParent);
+                            if (!success) {
+                                LOG.warn("Error creating directory " + destParent);
+                            }
+                            if (inheritPerms && success) {
+                                inheritFromTable(tablePath, destParent, conf, destFs);
+                            }
+                        }
+                        if (null == pool) {
+                            boolean moveResult = moveFile(conf, sdpair[0], sdpair[1], destFs, true, isSrcLocal);
+                            threadResult &= moveResult;
+                            if (!moveResult) {
+                                throw new IOException("Cannot move " + sdpair[0] + " to "
+                                        + sdpair[1]);
+                            }
+                        } else {
+                            futures.add(pool.submit(new Callable<Boolean>() {
+                                @Override
+                                public Boolean call() throws Exception {
+                                    SessionState.setCurrentSessionState(parentSession);
+                                    return moveFile(conf, sdpair[0], sdpair[1], destFs, true, isSrcLocal);
+                                }
+                            }));
+                        }
+                    }
+                }
+            } else { // srcf is a file or pattern containing wildcards
+                if (!destFs.exists(destf)) {
+                    boolean success = destFs.mkdirs(destf);
+                    if (!success) {
+                        LOG.warn("Error creating directory " + destf.toString());
+                    }
+                    if (inheritPerms && success) {
+                        inheritFromTable(tablePath, destf, conf, destFs);
+                    }
+                }
+                // srcs must be a list of files -- ensured by LoadSemanticAnalyzer
+                for (List<Path[]> sdpairs : result) {
+                    for (final Path[] sdpair : sdpairs) {
+                        if (null == pool) {
+                            boolean moveResult = moveFile(conf, sdpair[0], sdpair[1], destFs, true, isSrcLocal);
+                            threadResult &= moveResult;
+                            if (!moveResult) {
+                                throw new IOException("Cannot move " + sdpair[0] + " to "
+                                        + sdpair[1]);
+                            }
+                        } else {
+                            futures.add(pool.submit(new Callable<Boolean>() {
+                                @Override
+                                public Boolean call() throws Exception {
+                                    SessionState.setCurrentSessionState(parentSession);
+                                    return moveFile(conf, sdpair[0], sdpair[1], destFs, true, isSrcLocal);
+                                }
+                            }));
+                        }
+                    }
+                }
+            }
+
+            if (null != pool) {
+                pool.shutdown();
+                for (Future<Boolean> future : futures) {
+                    try {
+                        threadResult &= future.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        LOG.error("@zhiyue: Failed to move: ", e);
+                        pool.shutdownNow();
+                        throw new HiveException(e);
+                    }
+                }
+            }
+
+            if (!threadResult) {
+                LOG.error("replace result data error");
+                throw new IOException("Error replace file!!!");
+            }
+        } catch (IOException e) {
+            throw new HiveException(e.getMessage(), e);
+        }
+    }
+
+
+    /**
+     * This method sets all paths from tablePath to destf (including destf) to have same permission as tablePath.
+     *
+     * @param tablePath path of table
+     * @param destf     path of table-subdir.
+     * @param conf
+     * @param fs
+     */
+    private static void inheritFromTable(Path tablePath, Path destf, HiveConf conf, FileSystem fs) {
+        if (!FileUtils.isSubDir(destf, tablePath, fs)) {
+            //partition may not be under the parent.
+            return;
+        }
+        HadoopShims shims = ShimLoader.getHadoopShims();
+        //Calculate all the paths from the table dir, to destf
+        //At end of this loop, currPath is table dir, and pathsToSet contain list of all those paths.
+        Path currPath = destf;
+        List<Path> pathsToSet = new LinkedList<Path>();
+        while (!currPath.equals(tablePath)) {
+            pathsToSet.add(currPath);
+            currPath = currPath.getParent();
+        }
+
+        try {
+            HadoopShims.HdfsFileStatus fullFileStatus = shims.getFullFileStatus(conf, fs, currPath);
+            for (Path pathToSet : pathsToSet) {
+                shims.setFullFileStatus(conf, fullFileStatus, fs, pathToSet);
+            }
+        } catch (Exception e) {
+            LOG.warn("Error setting permissions or group of " + destf, e);
+        }
+    }
+
+    public static boolean isHadoop1() {
+        return ShimLoader.getMajorVersion().startsWith("0.20");
+    }
+
+    public void exchangeTablePartitions(Map<String, String> partitionSpecs,
+                                        String sourceDb, String sourceTable, String destDb,
+                                        String destinationTableName) throws HiveException {
+        try {
+            getMSC().exchange_partition(partitionSpecs, sourceDb, sourceTable, destDb,
+                    destinationTableName);
+        } catch (Exception ex) {
             LOG.error(StringUtils.stringifyException(ex));
-            throw new MetaException(
-              "Failed to load storage handler:  " + ex.getMessage());
-          }
+            throw new HiveException(ex);
         }
-      };
-    return RetryingMetaStoreClient.getProxy(conf, hookLoader, metaCallTimeMap,
-        SessionHiveMetaStoreClient.class.getName());
-  }
-
-  /**
-   * @return the metastore client for the current thread
-   * @throws MetaException
-   */
-  @LimitedPrivate(value = {"Hive"})
-  @Unstable
-  public IMetaStoreClient getMSC() throws MetaException {
-    if (metaStoreClient == null) {
-      try {
-        owner = UserGroupInformation.getCurrentUser();
-      } catch(IOException e) {
-        String msg = "Error getting current user: " + e.getMessage();
-        LOG.error(msg, e);
-        throw new MetaException(msg + "\n" + StringUtils.stringifyException(e));
-      }
-      metaStoreClient = createMetaStoreClient();
-    }
-    return metaStoreClient;
-  }
-
-  private String getUserName() {
-    return SessionState.getUserFromAuthenticator();
-  }
-
-  private List<String> getGroupNames() {
-    SessionState ss = SessionState.get();
-    if (ss != null && ss.getAuthenticator() != null) {
-      return ss.getAuthenticator().getGroupNames();
-    }
-    return null;
-  }
-
-  public static List<FieldSchema> getFieldsFromDeserializer(String name,
-      Deserializer serde) throws HiveException {
-    try {
-      return MetaStoreUtils.getFieldsFromDeserializer(name, serde);
-    } catch (SerDeException e) {
-      throw new HiveException("Error in getting fields from serde. "
-          + e.getMessage(), e);
-    } catch (MetaException e) {
-      throw new HiveException("Error in getting fields from serde."
-          + e.getMessage(), e);
-    }
-  }
-
-  public List<Index> getIndexes(String dbName, String tblName, short max) throws HiveException {
-    List<Index> indexes = null;
-    try {
-      indexes = getMSC().listIndexes(dbName, tblName, max);
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-    return indexes;
-  }
-
-  public boolean updateTableColumnStatistics(ColumnStatistics statsObj) throws HiveException {
-    try {
-      return getMSC().updateTableColumnStatistics(statsObj);
-    } catch (Exception e) {
-      LOG.debug(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public boolean updatePartitionColumnStatistics(ColumnStatistics statsObj) throws HiveException {
-    try {
-      return getMSC().updatePartitionColumnStatistics(statsObj);
-    } catch (Exception e) {
-      LOG.debug(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public boolean setPartitionColumnStatistics(SetPartitionsStatsRequest request) throws HiveException {
-    try {
-      return getMSC().setPartitionColumnStatistics(request);
-    } catch (Exception e) {
-      LOG.debug(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public List<ColumnStatisticsObj> getTableColumnStatistics(
-      String dbName, String tableName, List<String> colNames) throws HiveException {
-    try {
-      return getMSC().getTableColumnStatistics(dbName, tableName, colNames);
-    } catch (Exception e) {
-      LOG.debug(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String dbName,
-      String tableName, List<String> partNames, List<String> colNames) throws HiveException {
-      try {
-      return getMSC().getPartitionColumnStatistics(dbName, tableName, partNames, colNames);
-    } catch (Exception e) {
-      LOG.debug(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public AggrStats getAggrColStatsFor(String dbName, String tblName,
-    List<String> colNames, List<String> partName) {
-    try {
-      return getMSC().getAggrColStatsFor(dbName, tblName, colNames, partName);
-    } catch (Exception e) {
-      LOG.debug(StringUtils.stringifyException(e));
-      return null;
-    }
-  }
-
-  public boolean deleteTableColumnStatistics(String dbName, String tableName, String colName)
-    throws HiveException {
-    try {
-      return getMSC().deleteTableColumnStatistics(dbName, tableName, colName);
-    } catch(Exception e) {
-      LOG.debug(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public boolean deletePartitionColumnStatistics(String dbName, String tableName, String partName,
-    String colName) throws HiveException {
-      try {
-        return getMSC().deletePartitionColumnStatistics(dbName, tableName, partName, colName);
-      } catch(Exception e) {
-        LOG.debug(StringUtils.stringifyException(e));
-        throw new HiveException(e);
-      }
     }
 
-  public Table newTable(String tableName) throws HiveException {
-    String[] names = Utilities.getDbTableName(tableName);
-    return new Table(names[0], names[1]);
-  }
+    /**
+     * Creates a metastore client. Currently it creates only JDBC based client as
+     * File based store support is removed
+     *
+     * @throws HiveMetaException if a working client can't be created
+     * @returns a Meta Store Client
+     */
+    private IMetaStoreClient createMetaStoreClient() throws MetaException {
 
-  public String getDelegationToken(String owner, String renewer)
-    throws HiveException{
-    try {
-      return getMSC().getDelegationToken(owner, renewer);
-    } catch(Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
+        HiveMetaHookLoader hookLoader = new HiveMetaHookLoader() {
+            @Override
+            public HiveMetaHook getHook(
+                    org.apache.hadoop.hive.metastore.api.Table tbl)
+                    throws MetaException {
 
-  public void cancelDelegationToken(String tokenStrForm)
-    throws HiveException {
-    try {
-      getMSC().cancelDelegationToken(tokenStrForm);
-    }  catch(Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  /**
-   * Enqueue a compaction request.
-   * @param dbname name of the database, if null default will be used.
-   * @param tableName name of the table, cannot be null
-   * @param partName name of the partition, if null table will be compacted (valid only for
-   *                 non-partitioned tables).
-   * @param compactType major or minor
-   * @throws HiveException
-   */
-  public void compact(String dbname, String tableName, String partName,  String compactType)
-      throws HiveException {
-    try {
-      CompactionType cr = null;
-      if ("major".equals(compactType)) cr = CompactionType.MAJOR;
-      else if ("minor".equals(compactType)) cr = CompactionType.MINOR;
-      else throw new RuntimeException("Unknown compaction type " + compactType);
-      getMSC().compact(dbname, tableName, partName, cr);
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public ShowCompactResponse showCompactions() throws HiveException {
-    try {
-      return getMSC().showCompactions();
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public GetOpenTxnsInfoResponse showTransactions() throws HiveException {
-    try {
-      return getMSC().showTxns();
-    } catch (Exception e) {
-      LOG.error(StringUtils.stringifyException(e));
-      throw new HiveException(e);
-    }
-  }
-
-  public void createFunction(Function func) throws HiveException {
-    try {
-      getMSC().createFunction(func);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  public void alterFunction(String dbName, String funcName, Function newFunction)
-      throws HiveException {
-    try {
-      getMSC().alterFunction(dbName, funcName, newFunction);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  public void dropFunction(String dbName, String funcName)
-      throws HiveException {
-    try {
-      getMSC().dropFunction(dbName, funcName);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  public Function getFunction(String dbName, String funcName) throws HiveException {
-    try {
-      return getMSC().getFunction(dbName, funcName);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  public List<String> getFunctions(String dbName, String pattern) throws HiveException {
-    try {
-      return getMSC().getFunctions(dbName, pattern);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  public void setMetaConf(String propName, String propValue) throws HiveException {
-    try {
-      getMSC().setMetaConf(propName, propValue);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  public String getMetaConf(String propName) throws HiveException {
-    try {
-      return getMSC().getMetaConf(propName);
-    } catch (TException te) {
-      throw new HiveException(te);
-    }
-  }
-
-  public void clearMetaCallTiming() {
-    metaCallTimeMap.clear();
-  }
-
-  public void dumpAndClearMetaCallTiming(String phase) {
-    boolean phaseInfoLogged = false;
-    if (LOG.isDebugEnabled()) {
-      phaseInfoLogged = logDumpPhase(phase);
-      LOG.debug("Total time spent in each metastore function (ms): " + metaCallTimeMap);
+                try {
+                    if (tbl == null) {
+                        return null;
+                    }
+                    HiveStorageHandler storageHandler =
+                            HiveUtils.getStorageHandler(conf,
+                                    tbl.getParameters().get(META_TABLE_STORAGE));
+                    if (storageHandler == null) {
+                        return null;
+                    }
+                    return storageHandler.getMetaHook();
+                } catch (HiveException ex) {
+                    LOG.error(StringUtils.stringifyException(ex));
+                    throw new MetaException(
+                            "Failed to load storage handler:  " + ex.getMessage());
+                }
+            }
+        };
+        return RetryingMetaStoreClient.getProxy(conf, hookLoader, metaCallTimeMap,
+                SessionHiveMetaStoreClient.class.getName());
     }
 
-    if (LOG.isInfoEnabled()) {
-      // print information about calls that took longer time at INFO level
-      for (Entry<String, Long> callTime : metaCallTimeMap.entrySet()) {
-        // dump information if call took more than 1 sec (1000ms)
-        if (callTime.getValue() > 1000) {
-          if (!phaseInfoLogged) {
+    /**
+     * @return the metastore client for the current thread
+     * @throws MetaException
+     */
+    @LimitedPrivate(value = {"Hive"})
+    @Unstable
+    public IMetaStoreClient getMSC() throws MetaException {
+        if (metaStoreClient == null) {
+            try {
+                owner = UserGroupInformation.getCurrentUser();
+            } catch (IOException e) {
+                String msg = "Error getting current user: " + e.getMessage();
+                LOG.error(msg, e);
+                throw new MetaException(msg + "\n" + StringUtils.stringifyException(e));
+            }
+            metaStoreClient = createMetaStoreClient();
+        }
+        return metaStoreClient;
+    }
+
+    private String getUserName() {
+        return SessionState.getUserFromAuthenticator();
+    }
+
+    private List<String> getGroupNames() {
+        SessionState ss = SessionState.get();
+        if (ss != null && ss.getAuthenticator() != null) {
+            return ss.getAuthenticator().getGroupNames();
+        }
+        return null;
+    }
+
+    public static List<FieldSchema> getFieldsFromDeserializer(String name,
+                                                              Deserializer serde) throws HiveException {
+        try {
+            return MetaStoreUtils.getFieldsFromDeserializer(name, serde);
+        } catch (SerDeException e) {
+            throw new HiveException("Error in getting fields from serde. "
+                    + e.getMessage(), e);
+        } catch (MetaException e) {
+            throw new HiveException("Error in getting fields from serde."
+                    + e.getMessage(), e);
+        }
+    }
+
+    public List<Index> getIndexes(String dbName, String tblName, short max) throws HiveException {
+        List<Index> indexes = null;
+        try {
+            indexes = getMSC().listIndexes(dbName, tblName, max);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+        return indexes;
+    }
+
+    public boolean updateTableColumnStatistics(ColumnStatistics statsObj) throws HiveException {
+        try {
+            return getMSC().updateTableColumnStatistics(statsObj);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public boolean updatePartitionColumnStatistics(ColumnStatistics statsObj) throws HiveException {
+        try {
+            return getMSC().updatePartitionColumnStatistics(statsObj);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public boolean setPartitionColumnStatistics(SetPartitionsStatsRequest request) throws HiveException {
+        try {
+            return getMSC().setPartitionColumnStatistics(request);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public List<ColumnStatisticsObj> getTableColumnStatistics(
+            String dbName, String tableName, List<String> colNames) throws HiveException {
+        try {
+            return getMSC().getTableColumnStatistics(dbName, tableName, colNames);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String dbName,
+                                                                               String tableName, List<String> partNames, List<String> colNames) throws HiveException {
+        try {
+            return getMSC().getPartitionColumnStatistics(dbName, tableName, partNames, colNames);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public AggrStats getAggrColStatsFor(String dbName, String tblName,
+                                        List<String> colNames, List<String> partName) {
+        try {
+            return getMSC().getAggrColStatsFor(dbName, tblName, colNames, partName);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            return null;
+        }
+    }
+
+    public boolean deleteTableColumnStatistics(String dbName, String tableName, String colName)
+            throws HiveException {
+        try {
+            return getMSC().deleteTableColumnStatistics(dbName, tableName, colName);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public boolean deletePartitionColumnStatistics(String dbName, String tableName, String partName,
+                                                   String colName) throws HiveException {
+        try {
+            return getMSC().deletePartitionColumnStatistics(dbName, tableName, partName, colName);
+        } catch (Exception e) {
+            LOG.debug(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public Table newTable(String tableName) throws HiveException {
+        String[] names = Utilities.getDbTableName(tableName);
+        return new Table(names[0], names[1]);
+    }
+
+    public String getDelegationToken(String owner, String renewer)
+            throws HiveException {
+        try {
+            return getMSC().getDelegationToken(owner, renewer);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public void cancelDelegationToken(String tokenStrForm)
+            throws HiveException {
+        try {
+            getMSC().cancelDelegationToken(tokenStrForm);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    /**
+     * Enqueue a compaction request.
+     *
+     * @param dbname      name of the database, if null default will be used.
+     * @param tableName   name of the table, cannot be null
+     * @param partName    name of the partition, if null table will be compacted (valid only for
+     *                    non-partitioned tables).
+     * @param compactType major or minor
+     * @throws HiveException
+     */
+    public void compact(String dbname, String tableName, String partName, String compactType)
+            throws HiveException {
+        try {
+            CompactionType cr = null;
+            if ("major".equals(compactType)) cr = CompactionType.MAJOR;
+            else if ("minor".equals(compactType)) cr = CompactionType.MINOR;
+            else throw new RuntimeException("Unknown compaction type " + compactType);
+            getMSC().compact(dbname, tableName, partName, cr);
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public ShowCompactResponse showCompactions() throws HiveException {
+        try {
+            return getMSC().showCompactions();
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public GetOpenTxnsInfoResponse showTransactions() throws HiveException {
+        try {
+            return getMSC().showTxns();
+        } catch (Exception e) {
+            LOG.error(StringUtils.stringifyException(e));
+            throw new HiveException(e);
+        }
+    }
+
+    public void createFunction(Function func) throws HiveException {
+        try {
+            getMSC().createFunction(func);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    public void alterFunction(String dbName, String funcName, Function newFunction)
+            throws HiveException {
+        try {
+            getMSC().alterFunction(dbName, funcName, newFunction);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    public void dropFunction(String dbName, String funcName)
+            throws HiveException {
+        try {
+            getMSC().dropFunction(dbName, funcName);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    public Function getFunction(String dbName, String funcName) throws HiveException {
+        try {
+            return getMSC().getFunction(dbName, funcName);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    public List<String> getFunctions(String dbName, String pattern) throws HiveException {
+        try {
+            return getMSC().getFunctions(dbName, pattern);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    public void setMetaConf(String propName, String propValue) throws HiveException {
+        try {
+            getMSC().setMetaConf(propName, propValue);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    public String getMetaConf(String propName) throws HiveException {
+        try {
+            return getMSC().getMetaConf(propName);
+        } catch (TException te) {
+            throw new HiveException(te);
+        }
+    }
+
+    public void clearMetaCallTiming() {
+        metaCallTimeMap.clear();
+    }
+
+    public void dumpAndClearMetaCallTiming(String phase) {
+        boolean phaseInfoLogged = false;
+        if (LOG.isDebugEnabled()) {
             phaseInfoLogged = logDumpPhase(phase);
-          }
-          LOG.info("Total time spent in this metastore function was greater than 1000ms : "
-              + callTime);
+            LOG.debug("Total time spent in each metastore function (ms): " + metaCallTimeMap);
         }
-      }
-    }
-    metaCallTimeMap.clear();
-  }
 
-  private boolean logDumpPhase(String phase) {
-    LOG.info("Dumping metastore api call timing information for : " + phase + " phase");
-    return true;
-  }
+        if (LOG.isInfoEnabled()) {
+            // print information about calls that took longer time at INFO level
+            for (Entry<String, Long> callTime : metaCallTimeMap.entrySet()) {
+                // dump information if call took more than 1 sec (1000ms)
+                if (callTime.getValue() > 1000) {
+                    if (!phaseInfoLogged) {
+                        phaseInfoLogged = logDumpPhase(phase);
+                    }
+                    LOG.info("Total time spent in this metastore function was greater than 1000ms : "
+                            + callTime);
+                }
+            }
+        }
+        metaCallTimeMap.clear();
+    }
+
+    private boolean logDumpPhase(String phase) {
+        LOG.info("Dumping metastore api call timing information for : " + phase + " phase");
+        return true;
+    }
 
 };


### PR DESCRIPTION
when SparkSQL use Hive metastore,  writing result data will use hive-1.2.1-spark2 api
Hive-1.2.1-spark2 loadPartition functition is one thread to replace or rename tmp path file
after hive2.0, change threadpool to copy or rename
